### PR TITLE
Remove password synchronization between source/destination

### DIFF
--- a/backend_services_deployment.md
+++ b/backend_services_deployment.md
@@ -22,13 +22,7 @@ podified OpenStack control plane services.
 
 ## Variables
 
-Define the shell variables used in the steps below. The values are
-just illustrative, use values which are correct for your environment:
-
-```
-# MariaDB root password on the original deployment.
-DB_ROOT_PASSWORD=SomePassword
-```
+(There are no shell variables necessary currently.)
 
 ## Pre-checks
 
@@ -39,12 +33,6 @@ DB_ROOT_PASSWORD=SomePassword
   ```
   # in install_yamls
   make input
-  ```
-
-* Set passwords to match the original deployment:
-
-  ```
-  oc set data secret/osp-secret "DbRootPassword=$DB_ROOT_PASSWORD"
   ```
 
 * Deploy OpenStackControlPlane. **Make sure to only enable MariaDB and

--- a/openstack_control_plane_deployment.md
+++ b/openstack_control_plane_deployment.md
@@ -7,30 +7,24 @@
 
 ## Variables
 
-Define the shell variables used in the steps below. The values are
-just illustrative, use values which are correct for your environment:
+* Set the desired admin password for the podified deployment. This can
+  be the original deployment's admin password or something else.
 
-```
-ADMIN_PASSWORD=SomePassword
-KEYSTONE_DATABASE_PASSWORD=SomePassword
-```
+  ```
+  ADMIN_PASSWORD=SomePassword
+  ```
 
 ## Pre-checks
 
 ## Procedure - OpenStack control plane services deployment
 
-* Set Keystone password and database user creation password to match
-  the original deployment:
+* If the `$ADMIN_PASSWORD` is different than the already set password
+  in `osp-secret`, amend the `AdminPassword` key in the `osp-secret`
+  correspondingly:
 
   ```
   oc set data secret/osp-secret "AdminPassword=$ADMIN_PASSWORD"
-  oc set data secret/osp-secret "DatabasePassword=$KEYSTONE_DATABASE_PASSWORD"
-  oc set data secret/osp-secret "KeystoneDatabasePassword=$KEYSTONE_DATABASE_PASSWORD"
   ```
-
-  > Note: The `DatabasePassword` is currently common, affects creation
-  > of all database users. This should be fixed in podified control
-  > plane after the MariaDB Operator is replaced with Galera Operator.
 
 * Patch OpenStackControlPlane to deploy Keystone:
 
@@ -49,11 +43,6 @@ KEYSTONE_DATABASE_PASSWORD=SomePassword
 ## Post-checks
 
 * Test that `openstack user list` works.
-
-  > Note: This used to work, but after recent changes to endpoint
-  > management mechanism in the Keystone operator, the operator
-  > actually removes all existing endpoints. This needs to be
-  > addressed further.
 
   ```
   cat > clouds-adopted.yaml <<EOF


### PR DESCRIPTION
Doing the adoption as a "big bang" rather than gradual, we no longer need to ensure that the passwords in source match the passwords in destination, so let's not do that. The reasons are:

* Making the procedure shorter by removing unnecessary steps.

* Working better with the current podified control plane PoC created by "install_yamls", which forces use a single password for all service DBs, and is thus incompatible with the source environment in that regard.

* Allowing some services to perhaps gain stronger passwords during the migration procedure.