### PR TITLE
Initial deployment of control plane services

### DIFF
--- a/openstack_control_plane_deployment.md
+++ b/openstack_control_plane_deployment.md
@@ -40,9 +40,7 @@
   '
   ```
 
-## Post-checks
-
-* Test that `openstack user list` works.
+* Create a clouds.yaml file to talk to adopted Keystone:
 
   ```
   cat > clouds-adopted.yaml <<EOF
@@ -60,9 +58,114 @@
       region_name: regionOne
       volume_api_version: '3'
   EOF
+  ```
 
+* Clean up old endpoints that still point to old control plane
+  (everything except Keystone endpoints):
+
+  ```
   export OS_CLIENT_CONFIG_FILE=clouds-adopted.yaml
   export OS_CLOUD=adopted
 
-  openstack user list
+  openstack endpoint list | grep ' cinderv3 ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' glance ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' neutron ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' nova ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' placement ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' swift ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  ```
+
+* Deploy the rest of control plane services:
+
+  ```
+  oc patch openstackcontrolplane openstack --type=merge --patch '
+  spec:
+    # cinder:
+    #   enabled: true
+    #   template:
+    #     cinderAPI:
+    #       replicas: 1
+    #       containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+    #     cinderScheduler:
+    #       replicas: 1
+    #       containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+    #     cinderBackup:
+    #       replicas: 1
+    #       containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+    #     cinderVolumes:
+    #       volume1:
+    #         containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+    #         replicas: 1
+
+    glance:
+      enabled: true
+      template:
+        databaseInstance: openstack
+        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        storageClass: ""
+        storageRequest: 10G
+        glanceAPIInternal:
+          containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        glanceAPIExternal:
+          containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+
+    placement:
+      enabled: true
+      template:
+        containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+        databaseInstance: openstack
+        secret: osp-secret
+
+    ovn:
+      enabled: true
+      template:
+        ovnDBCluster:
+          ovndbcluster-nb:
+            replicas: 1
+            containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+            dbType: NB
+            storageRequest: 10G
+          ovndbcluster-sb:
+            replicas: 1
+            containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
+            dbType: SB
+            storageRequest: 10G
+        ovnNorthd:
+          replicas: 1
+          containerImage: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
+
+    ovs:
+      enabled: true
+      template:
+        ovsContainerImage: "quay.io/skaplons/ovs:latest"
+        ovnContainerImage: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+
+    neutron:
+      enabled: true
+      template:
+        databaseInstance: openstack
+        containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+        secret: osp-secret
+
+    # nova:
+    #   enabled: true
+    #   template:
+    #     secret: osp-secret
+  '
+  ```
+
+
+## Post-checks
+
+* See that endpoints are defined:
+
+  ```
+  export OS_CLIENT_CONFIG_FILE=clouds-adopted.yaml
+  export OS_CLOUD=adopted
+
+  openstack endpoint list
   ```


### PR DESCRIPTION
When enabling all services, some of the containers were erroring out, so those services are commented out for now. Here's how pod list looked with all services enabled:

```
$ oc get pod
NAME                                                              READY   STATUS             RESTARTS         AGE
a36e1b3d106136052b82eb521749965f8e9b0b0c48ab56ddf9ff68acfaf258d   0/1     Completed          0                6d22h
cinder-966758f6d-mc4zk                                            1/1     Running            0                45m
cinder-backup-0                                                   2/2     Running            0                45m
cinder-operator-controller-manager-5476b67b7f-mzf4g               2/2     Running            0                6d22h
cinder-scheduler-0                                                2/2     Running            0                45m
cinder-volume-volume1-0                                           0/2     CrashLoopBackOff   26 (2m14s ago)   45m
controller-manager-cf8c8bb6c-2txjd                                1/1     Running            0                6d22h
glance-external-api-b95fb68f8-hc4nr                               1/1     Running            0                79m
glance-internal-api-75859f6bc-2h74z                               1/1     Running            0                79m
glance-operator-controller-manager-5978fdfbdc-hfjvv               2/2     Running            0                6d22h
keystone-5b9c75dbf5-mcnp2                                         1/1     Running            0                94m
keystone-operator-controller-manager-669d5b6fbd-fgr5z             2/2     Running            0                6d22h
mariadb-openstack                                                 1/1     Running            0                105m
mariadb-operator-controller-manager-86f5cdbb6d-48npl              2/2     Running            0                6d22h
neutron-7c548b7bcb-hcgqp                                          1/1     Running            0                40m
neutron-operator-controller-manager-786cf54786-kq7vn              2/2     Running            0                6d22h
nova-api-0                                                        2/2     Running            0                41m
nova-cell0-conductor-0                                            0/1     CrashLoopBackOff   12 (4m3s ago)    41m
nova-operator-controller-manager-7b75ddf84d-vktfv                 2/2     Running            0                6d22h
nova-scheduler-0                                                  0/1     CrashLoopBackOff   12 (117s ago)    41m
openstack-operator-controller-manager-9b644ff7c-csvvt             2/2     Running            0                6d22h
openstack-operator-index-f8xws                                    1/1     Running            0                6d22h
ovn-northd-b95f869d7-t8bmm                                        1/1     Running            0                42m
ovn-operator-controller-manager-545456d787-gjzsw                  2/2     Running            0                6d22h
ovs-hwmqh                                                         3/3     Running            0                42m
ovs-operator-controller-manager-5cf97fb7d4-kt76q                  2/2     Running            0                6d22h
ovsdbserver-nb-0                                                  1/1     Running            0                43m
ovsdbserver-sb-0                                                  1/1     Running            0                43m
placement-74c78d99fc-k9gw5                                        1/1     Running            0                54m
placement-operator-controller-manager-7458f5f8d-qhd6g             2/2     Running            0                6d22h
rabbitmq-server-0                                                 1/1     Running            0                105m
```

One issue with current state is that even if old potentially conflicting Keystone endpoints are cleaned up before deploying the additional services, the correct endpoints aren't created:

```
$ openstack endpoint list
+----------------------------------+-----------+--------------+--------------+---------+-----------+---------------------------------------------------------------------+
| ID                               | Region    | Service Name | Service Type | Enabled | Interface | URL                                                                 |
+----------------------------------+-----------+--------------+--------------+---------+-----------+---------------------------------------------------------------------+
| 33d5eaa703e642ec9f298fdb565403f4 | regionOne | keystone     | identity     | True    | public    | http://keystone-public-openstack.apps-crc.testing                   |
| 61fbdf9c199946b3a762ec3491caf2dc | regionOne | keystone     | identity     | True    | admin     | http://keystone-admin-openstack.apps-crc.testing                    |
| 79c4c0edf3444a05ad9935c5c316c56e | regionOne | cinderv2     | volumev2     | True    | internal  | http://cinder-internal-openstack.apps-crc.testing/v2/%(project_id)s |
| 7dda18ad52ad474db38a9281bba02708 | regionOne | cinderv2     | volumev2     | True    | public    | http://cinder-public-openstack.apps-crc.testing/v2/%(project_id)s   |
| a6398f3ae38b498fa897bf3e2d4945ab | regionOne | cinderv2     | volumev2     | True    | admin     | http://cinder-admin-openstack.apps-crc.testing/v2/%(project_id)s    |
| e506309742e74e17876065440fc6b62b | regionOne | keystone     | identity     | True    | internal  | http://keystone-internal-openstack.apps-crc.testing                 |
+----------------------------------+-----------+--------------+--------------+---------+-----------+---------------------------------------------------------------------+

$ oc get keystoneendpoint
NAME              STATUS    MESSAGE
cinderv2          True      Setup complete
cinderv3          Unknown   Setup started
glance-external   Unknown   Setup started
glance-internal   Unknown   Setup started
neutron           Unknown   Setup started
nova              Unknown   Setup started
placement         Unknown   Setup started
```