### PR TITLE
Restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,6 @@ Data Plane Adoption procedure
 Work-in-progress documentation.
 
 
-## Ceph adoption
-
-If the environment includes Ceph and some of its services are
-collocated on the Controller hosts ("internal Ceph"), then Ceph
-services need to be moved out of Controller hosts as the last
-step of the OpenStack adoption.
-Follow this documentation:
-
-* [Ceph cluster migration (RBD)](ceph.md)
-
-
 ## OpenStack adoption
 
 This is a procedure for adopting an OpenStack cloud.
@@ -25,10 +14,22 @@ Perform the actions from the sub-documents in the following order:
 
 * [Copy MariaDB data](mariadb_copy.md)
 
-* [Deploy OpenStack control plane services](openstack_control_plane_deployment.md)
+* [Keystone adoption](keystone_adoption.md)
 
-* [Glance Adoption](glance_adoption.md)
+* [Glance adoption](glance_adoption.md)
+
+* [Adoption of other services](other_services_adoption.md)
 
 If you face issues during adoption, check the
 [Troubleshooting](troubleshooting.md) document for common problems and
 solutions.
+
+
+## Post-OpenStack Ceph adoption
+
+If the environment includes Ceph and some of its services are
+collocated on the Controller hosts ("internal Ceph"), then Ceph
+services need to be moved out of Controller hosts as the last step of
+the OpenStack adoption. Follow this documentation:
+
+* [Ceph cluster migration (RBD)](ceph.md)

--- a/backend_services_deployment.md
+++ b/backend_services_deployment.md
@@ -12,8 +12,6 @@ podified OpenStack control plane services.
 * The `openstack-operator` deployed, but `OpenStackControlPlane`
   **not** deployed.
 
-* The MariaDB PVC is bound.
-
   For developer/CI environments, the openstack operator can be deployed
   by running `make openstack` inside
   [install_yamls](https://github.com/openstack-k8s-operators/install_yamls)
@@ -21,6 +19,12 @@ podified OpenStack control plane services.
 
   For production environments, the deployment method will likely be
   different.
+
+* There are free PVs available to be claimed (for MariaDB and RabbitMQ).
+
+  For developer/CI environments driven by install_yamls, make sure
+  you've run `make crc_storage`.
+
 
 ## Variables
 
@@ -78,15 +82,8 @@ podified OpenStack control plane services.
 
 ## Post-checks
 
-* Check if MariaDB PVC is bound:
+* Check that MariaDB is running.
 
   ```
-  oc get pvc mariadb-openstack -o jsonpath='{.status.phase}{"\n"}'
-  ```
-
-  if not, run:
-
-  ```
-  # in install_yamls
-  make crc_storage
+  oc get pod mariadb-openstack -o jsonpath='{.status.phase}{"\n"}'
   ```

--- a/backend_services_deployment.md
+++ b/backend_services_deployment.md
@@ -28,7 +28,29 @@ podified OpenStack control plane services.
 
 ## Variables
 
-(There are no shell variables necessary currently.)
+* Set the desired admin password for the podified deployment. This can
+  be the original deployment's admin password or something else.
+
+  ```
+  ADMIN_PASSWORD=SomePassword
+  ```
+
+* Set service password variables to match the original deployment.
+  Database passwords can differ in podified environment, but
+  synchronizing the service account passwords is a required step.
+
+  E.g. in developer environments with TripleO Standalone, the
+  passwords can be extracted like this:
+
+  ```
+  CINDER_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' CinderPassword:' | awk -F ': ' '{ print $2; }')
+  GLANCE_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' GlancePassword:' | awk -F ': ' '{ print $2; }')
+  IRONIC_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' IronicPassword:' | awk -F ': ' '{ print $2; }')
+  NEUTRON_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' NeutronPassword:' | awk -F ': ' '{ print $2; }')
+  NOVA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' NovaPassword:' | awk -F ': ' '{ print $2; }')
+  OCTAVIA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' OctaviaPassword:' | awk -F ': ' '{ print $2; }')
+  PLACEMENT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' PlacementPassword:' | awk -F ': ' '{ print $2; }')
+  ```
 
 ## Pre-checks
 
@@ -36,9 +58,33 @@ podified OpenStack control plane services.
 
 * Create OSP secret.
 
+  The procedure for this will vary, but in developer/CI environments
+  we use install_yamls:
+
   ```
   # in install_yamls
   make input
+  ```
+
+* If the `$ADMIN_PASSWORD` is different than the already set password
+  in `osp-secret`, amend the `AdminPassword` key in the `osp-secret`
+  correspondingly:
+
+  ```
+  oc set data secret/osp-secret "AdminPassword=$ADMIN_PASSWORD"
+  ```
+
+* Set service account passwords in `osp-secret` to match the service
+  account passwords from original deployment:
+
+  ```
+  oc set data secret/osp-secret "CinderPassword=$CINDER_PASSWORD"
+  oc set data secret/osp-secret "GlancePassword=$GLANCE_PASSWORD"
+  oc set data secret/osp-secret "IronicPassword=$IRONIC_PASSWORD"
+  oc set data secret/osp-secret "NeutronPassword=$NEUTRON_PASSWORD"
+  oc set data secret/osp-secret "NovaPassword=$NOVA_PASSWORD"
+  oc set data secret/osp-secret "OctaviaPassword=$OCTAVIA_PASSWORD"
+  oc set data secret/osp-secret "PlacementPassword=$PLACEMENT_PASSWORD"
   ```
 
 * Deploy OpenStackControlPlane. **Make sure to only enable MariaDB and

--- a/backend_services_deployment.md
+++ b/backend_services_deployment.md
@@ -9,7 +9,10 @@ podified OpenStack control plane services.
 
 ## Prerequisites
 
-* The `openstack-operator` deployed, but `OpenStackControlPlane`
+* The cloud which we want to adopt is up and running. It's on
+  OpenStack Wallaby release.
+
+* The `openstack-operator` is deployed, but `OpenStackControlPlane` is
   **not** deployed.
 
   For developer/CI environments, the openstack operator can be deployed

--- a/glance_adoption.md
+++ b/glance_adoption.md
@@ -84,16 +84,6 @@ stringData:
 
 This secret will be used in the `extraVolumes` parameters to propagate the files
 to the `GlanceAPI` pods (both internal and external).
-Edit the `osp-secret` and change the `GlancePassword` to make sure the service
-will be able to interact with keystone, which points to the credentials of the
-source Cloud.
-
-```
-$ cat tripleo-standalone-passwords.yaml  | awk '/Glance/ { print $2 }'
-Ok1gAcO2IsHBsUUW6bAyC5gcA
-```
-
-The `base64` value of this secret should be used to patch the `osp-secret`.
 
 Patch OpenStackControlPlane to deploy Glance:
 

--- a/glance_adoption.md
+++ b/glance_adoption.md
@@ -21,13 +21,13 @@ In order to keep things simple, this scenario assumes that both `MariaDB` and
 documentation:
 
 1. [Create an OpenStackControlPlane](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/backend_services_deployment.md)
-2. [Adopt MariaDB](https://github.com/fmount/data-plane-adoption/blob/main/mariadb_copy.md)
-3. [Adopt Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/openstack_control_plane_deployment.md)
+2. [Adopt MariaDB](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/mariadb_copy.md)
+3. [Adopt Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md)
 
 
 ## Enable glance:
 
-As already done for [Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/openstack_control_plane_deployment.md), the Glance Adoption follows the same pattern.
+As already done for [Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md), the Glance Adoption follows the same pattern.
 
 Patch OpenStackControlPlane to deploy Glance:
 

--- a/glance_adoption.md
+++ b/glance_adoption.md
@@ -1,4 +1,4 @@
-# Glance Adoption
+# Glance adoption
 
 Adopting Glance means that an existing `OpenStackControlPlane` CR, where Glance
 is supposed to be disabled, should be patched to start the service with the
@@ -16,16 +16,14 @@ This guide also assumes that:
 3. (optional) an internal/external `Ceph` cluster is reacheable by both `crc` and
 `TripleO`
 
-In order to keep things simple, this scenario assumes that both `MariaDB` and
-`Keystone` are already adopted; the procedure is described by the following
-documentation:
 
-1. [Create an OpenStackControlPlane](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/backend_services_deployment.md)
-2. [Adopt MariaDB](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/mariadb_copy.md)
-3. [Adopt Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md)
+## Prerequisites
+
+* Previous Adoption steps completed. Notably, MariaDB and Keystone
+  should be already adopted.
 
 
-## Enable glance:
+## Procedure - Glance adoption
 
 As already done for [Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md), the Glance Adoption follows the same pattern.
 
@@ -129,7 +127,9 @@ spec:
 '
 ```
 
-## Test the glance service from the OpenStack cli
+## Post-checks
+
+### Test the glance service from the OpenStack cli
 
 Inspect the resulting glance pods:
 
@@ -163,7 +163,7 @@ cli and check the service is active and the endpoints are properly updated.
 | 709859219bc24ab9ac548eab74ad4dd5 | regionOne | glance       | image        | True    | admin     | http://glance-admin-openstack.apps-crc.testing      |
 ```
 
-## Image upload
+### Image upload
 
 We can test that an image can be created on from the adopted service.
 

--- a/keystone_adoption.md
+++ b/keystone_adoption.md
@@ -1,0 +1,75 @@
+# Keystone adoption
+
+## Prerequisites
+
+* Previous Adoption steps completed. Notably, the service databases
+  must already be imported into the podified MariaDB.
+
+## Variables
+
+(There are no shell variables necessary currently.)
+
+## Pre-checks
+
+## Procedure - Keystone adoption
+
+* Patch OpenStackControlPlane to deploy Keystone:
+
+  ```
+  oc patch openstackcontrolplane openstack --type=merge --patch '
+  spec:
+    keystone:
+      enabled: true
+      template:
+        secret: osp-secret
+        containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+        databaseInstance: openstack
+  '
+  ```
+
+* Create a clouds.yaml file to talk to adopted Keystone:
+
+  ```
+  cat > clouds-adopted.yaml <<EOF
+  clouds:
+    adopted:
+      auth:
+        auth_url: http://keystone-public-openstack.apps-crc.testing
+        password: $ADMIN_PASSWORD
+        project_domain_name: Default
+        project_name: admin
+        user_domain_name: Default
+        username: admin
+      cacert: ''
+      identity_api_version: '3'
+      region_name: regionOne
+      volume_api_version: '3'
+  EOF
+  ```
+
+* Clean up old endpoints that still point to old control plane
+  (everything except Keystone endpoints):
+
+  ```
+  export OS_CLIENT_CONFIG_FILE=clouds-adopted.yaml
+  export OS_CLOUD=adopted
+
+  openstack endpoint list | grep ' cinderv3 ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' glance ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' neutron ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' nova ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' placement ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  openstack endpoint list | grep ' swift ' | awk '{ print $2; }' | xargs openstack endpoint delete
+  ```
+
+## Post-checks
+
+* See that Keystone endpoints are defined and pointing to the podified
+  FQDNs:
+
+  ```
+  export OS_CLIENT_CONFIG_FILE=clouds-adopted.yaml
+  export OS_CLOUD=adopted
+
+  openstack endpoint list | grep keystone
+  ```

--- a/openstack_control_plane_deployment.md
+++ b/openstack_control_plane_deployment.md
@@ -7,24 +7,11 @@
 
 ## Variables
 
-* Set the desired admin password for the podified deployment. This can
-  be the original deployment's admin password or something else.
-
-  ```
-  ADMIN_PASSWORD=SomePassword
-  ```
+(There are no shell variables necessary currently.)
 
 ## Pre-checks
 
 ## Procedure - OpenStack control plane services deployment
-
-* If the `$ADMIN_PASSWORD` is different than the already set password
-  in `osp-secret`, amend the `AdminPassword` key in the `osp-secret`
-  correspondingly:
-
-  ```
-  oc set data secret/osp-secret "AdminPassword=$ADMIN_PASSWORD"
-  ```
 
 * Patch OpenStackControlPlane to deploy Keystone:
 


### PR DESCRIPTION
The main thing in this PR is splitting out Keystone adoption in a separate document. As is apparent from the Glance adoption doc, there may be enough configuration info for each service that we should get back to the document-per-service model. Even if eventually we may be able to patch the OpenStackControlPlane CR for all services at once, the documentation structure will be much clearer if we address each service in its own doc, rather than having one mega-document.

Additionally this PR tweaks MariaDB prerequisite info, puts setting of all service passwords into a common place right after we create the `osp-secret` at the very beginning of the procedure, and tweaks the Glance doc mainly in headings to be more consistent with the rest of the documentation.