### PR TITLE
Bootstrap the Adoption test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /local
 /tests/inventory.yaml
+/tests/secrets.yaml
+/tests/vars.yaml
 
 # rendered docs
 /site

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /local
-# docs
-site/
+/tests/inventory.yaml
+
+# rendered docs
+/site

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+TEST_INVENTORY ?= tests/inventory.yaml
+
+test-minimal:
+	ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook -v -i $(TEST_INVENTORY) tests/playbooks/test_minimal.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 TEST_INVENTORY ?= tests/inventory.yaml
+TEST_VARS ?= tests/vars.yaml
+TEST_SECRETS ?= tests/secrets.yaml
 
 test-minimal:
-	ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook -v -i $(TEST_INVENTORY) tests/playbooks/test_minimal.yaml
+	ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_minimal.yaml

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-Data Plane Adoption procedure
-=============================
+# Data Plane Adoption
 
-Work-in-progress [documentation](https://openstack-k8s-operators.github.io/data-plane-adoption).
+## Procedure documentation
+
+Navigate to the
+[documentation site](https://openstack-k8s-operators.github.io/data-plane-adoption).
 
 
-Docs Testing
-------------
+### Rendering documentation locally
 
-Cross-platform:
+Install docs build requirements into virtualenv:
 
 ```
+python3 -m venv local/docs-venv
+source local/docs-venv/bin/activate
 pip install -r docs/doc_requirements.txt
 ```
 
-Then:
+Serve docs site on localhost:
 
 ```
 mkdocs serve
@@ -23,7 +26,7 @@ Click the link it outputs. As you save changes to files modified in your editor,
 the browser will automatically show the new content.
 
 
-# Tests
+## Procedure test suite
 
 This repository also includes a test suite for Adoption. Currently
 only one test target is defined:
@@ -35,17 +38,19 @@ only one test target is defined:
 
 We can add more scenarios as we go (e.g. one that includes Ceph).
 
-## Executing the tests
+
+### Running the tests
 
 The interface between the execution infrastructure and the test suite
-is an Ansible inventory file. Inventory samples are provided. To
-execute the tests, follow this procedure.
+is an Ansible inventory and variables files. Inventory and variable
+samples are provided. To run the tests, follow this procedure:
 
 * Create `tests/inventory.yaml` file by copying and editing one of the
   included samples (e.g. `tests/inventory.sample-crc-vagrant.yaml`) to
   provide values valid in your environment.
 
 * Create `tests/vars.yaml` and `tests/secrets.yaml`, likewise by
-  copying and editing the included samples.
+  copying and editing the included samples (`tests/vars.sample.yaml`,
+  `tests/secrets.sample.yaml`).
 
 * Run `make test-minimal`.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,28 @@ mkdocs serve
 
 Click the link it outputs. As you save changes to files modified in your editor,
 the browser will automatically show the new content.
+
+
+# Tests
+
+This repository also includes a test suite for Adoption. Currently
+only one test target is defined:
+
+* `minimal` - a minimal test scenario, the eventual set of services in
+  this scenario should be the "core" services needed to launch a VM
+  (without Ceph, to keep environment size requirements small and make
+  it easy to set up).
+
+We can add more scenarios as we go (e.g. one that includes Ceph).
+
+## Executing the tests
+
+The interface between the execution infrastructure and the test suite
+is an Ansible inventory file. Inventory samples are provided. To
+execute the tests, follow this procedure.
+
+* Create `tests/inventory.yaml` file by copying and editing one of the
+  included samples (e.g. `tests/inventory.sample-crc-vagrant.yaml`) to
+  provide values valid in your environment.
+
+* Run `make test-minimal`.

--- a/README.md
+++ b/README.md
@@ -45,4 +45,7 @@ execute the tests, follow this procedure.
   included samples (e.g. `tests/inventory.sample-crc-vagrant.yaml`) to
   provide values valid in your environment.
 
+* Create `tests/vars.yaml` and `tests/secrets.yaml`, likewise by
+  copying and editing the included samples.
+
 * Run `make test-minimal`.

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+stdout_callback = yaml
+callback_whitelist = profile_json,profile_tasks
+roles_path = ./roles

--- a/tests/inventory.sample-crc-vagrant.yaml
+++ b/tests/inventory.sample-crc-vagrant.yaml
@@ -1,0 +1,11 @@
+adopter:
+  hosts:
+    localhost:
+      ansible_connection: local
+
+controllers:
+  hosts:
+    standalone:
+      ansible_ssh_host: standalone_hostname_or_ip
+      ansible_ssh_user: vagrant
+      ansible_ssh_private_key_file: ~/director_standalone/vagrant_private_key

--- a/tests/inventory.sample-crc-vagrant.yaml
+++ b/tests/inventory.sample-crc-vagrant.yaml
@@ -1,21 +1,4 @@
 all:
-  vars:
-      install_yamls_path: /CUSTOMIZE_THIS
-      reset_crc_storage: true
-
-      oc_header: |
-        source CUSTOMIZE_THIS.sh
-      oc_login_command: |
-        oc login -u kubeadmin -p crcadmin
-
-      cinder_password: CUSTOMIZE_THIS
-      glance_password: CUSTOMIZE_THIS
-      ironic_password: CUSTOMIZE_THIS
-      neutron_password: CUSTOMIZE_THIS
-      nova_password: CUSTOMIZE_THIS
-      octavia_password: CUSTOMIZE_THIS
-      placement_password: CUSTOMIZE_THIS
-
   hosts:
     localhost:
       ansible_connection: local

--- a/tests/inventory.sample-crc-vagrant.yaml
+++ b/tests/inventory.sample-crc-vagrant.yaml
@@ -1,11 +1,33 @@
-adopter:
+all:
+  vars:
+      install_yamls_path: /CUSTOMIZE_THIS
+      reset_crc_storage: true
+
+      oc_header: |
+        source CUSTOMIZE_THIS.sh
+      oc_login_command: |
+        oc login -u kubeadmin -p crcadmin
+
+      cinder_password: CUSTOMIZE_THIS
+      glance_password: CUSTOMIZE_THIS
+      ironic_password: CUSTOMIZE_THIS
+      neutron_password: CUSTOMIZE_THIS
+      nova_password: CUSTOMIZE_THIS
+      octavia_password: CUSTOMIZE_THIS
+      placement_password: CUSTOMIZE_THIS
+
   hosts:
     localhost:
       ansible_connection: local
-
-controllers:
-  hosts:
     standalone:
-      ansible_ssh_host: standalone_hostname_or_ip
       ansible_ssh_user: vagrant
-      ansible_ssh_private_key_file: ~/director_standalone/vagrant_private_key
+      ansible_ssh_host: CUSTOMIZE_THIS
+      ansible_ssh_private_key_file: CUSTOMIZE_THIS
+
+  children:
+    local:
+      hosts:
+        localhost:
+    controllers:
+      hosts:
+        standalone:

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -12,3 +12,11 @@
   gather_facts: no
   roles:
     - pcp_cleanup
+
+
+### BACKEND SERVICES ###
+
+- hosts: local
+  gather_facts: no
+  roles:
+    - backend_services

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -1,0 +1,14 @@
+- hosts: local
+  gather_facts: no
+  roles:
+    - prelude_local
+
+- hosts: controllers
+  gather_facts: no
+  roles:
+    - prelude_controller
+
+- hosts: local
+  gather_facts: no
+  roles:
+    - pcp_cleanup

--- a/tests/roles/backend_services/README.md
+++ b/tests/roles/backend_services/README.md
@@ -1,0 +1,10 @@
+# backend_services role
+
+This role aims to automate
+[backend services deployment doc](https://openstack-k8s-operators.github.io/data-plane-adoption/backend_services_deployment/)
+for testing purposes.
+
+## Variables
+
+See
+[defaults file](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/tests/roles/backend_services/defaults/main.yaml).

--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -1,3 +1,5 @@
+# Service account passwords (not service DB passwords) from the
+# original deployment.
 cinder_password: ''
 glance_password: ''
 ironic_password: ''

--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -1,0 +1,7 @@
+cinder_password: ''
+glance_password: ''
+ironic_password: ''
+neutron_password: ''
+nova_password: ''
+octavia_password: ''
+placement_password: ''

--- a/tests/roles/backend_services/meta/main.yaml
+++ b/tests/roles/backend_services/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -1,0 +1,80 @@
+- name: create osp-secret
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cd {{ install_yamls_path }}
+    make input
+
+- name: set service passwords
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {% if cinder_password %}
+        oc set data secret/osp-secret "CinderPassword={{ cinder_password }}"
+    {% endif %}
+    {% if glance_password %}
+        oc set data secret/osp-secret "GlancePassword={{ glance_password }}"
+    {% endif %}
+    {% if ironic_password %}
+        oc set data secret/osp-secret "IronicPassword={{ ironic_password }}"
+    {% endif %}
+    {% if neutron_password %}
+        oc set data secret/osp-secret "NeutronPassword={{ neutron_password }}"
+    {% endif %}
+    {% if nova_password %}
+        oc set data secret/osp-secret "NovaPassword={{ nova_password }}"
+    {% endif %}
+    {% if octavia_password %}
+        oc set data secret/osp-secret "OctaviaPassword={{ octavia_password }}"
+    {% endif %}
+    {% if placement_password %}
+        oc set data secret/osp-secret "PlacementPassword={{ placement_password }}"
+    {% endif %}
+
+- name: deploy backend services
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: core.openstack.org/v1beta1
+    kind: OpenStackControlPlane
+    metadata:
+      name: openstack
+    spec:
+      secret: osp-secret
+      storageClass: local-storage
+      mariadb:
+        template:
+          containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+          storageRequest: 500M
+      rabbitmq:
+        template:
+          replicas: 1
+
+      keystone:
+        enabled: false
+      cinder:
+        enabled: false
+      glance:
+        enabled: false
+      placement:
+        enabled: false
+      ovn:
+        enabled: false
+      ovs:
+        enabled: false
+      neutron:
+        enabled: false
+      nova:
+        enabled: false
+    EOF
+
+- name: wait for mariadb to start up
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc get pod mariadb-openstack -o jsonpath='{.status.phase}{"\n"}' | grep Running
+  register: mariadb_running_result
+  until: mariadb_running_result is success
+  retries: 60
+  delay: 2

--- a/tests/roles/common_defaults/README.md
+++ b/tests/roles/common_defaults/README.md
@@ -1,0 +1,9 @@
+# common_defaults role
+
+This role provides defaults for some commonly used variables in the
+test suite.
+
+## Variables
+
+See
+[defaults file](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/tests/roles/common_defaults/defaults/main.yaml).

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -1,0 +1,2 @@
+shell_header: |
+  set -euxo pipefail

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -1,2 +1,6 @@
+# Header to apply in 'shell' module invocations. If overriding, at
+# least 'set -e' should be kept to ensure that scripts that fail
+# somewhere in the middle will also fail the whole Ansible run as
+# expected.
 shell_header: |
   set -euxo pipefail

--- a/tests/roles/pcp_cleanup/README.md
+++ b/tests/roles/pcp_cleanup/README.md
@@ -1,0 +1,10 @@
+# pcp_cleanup role
+
+This role cleans up the podified control plane from the target
+OpenShift environment, removing any artifacts of a previous test suite
+run (even a failed one).
+
+## Variables
+
+See
+[defaults file](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/tests/roles/pcp_cleanup/defaults/main.yaml).

--- a/tests/roles/pcp_cleanup/defaults/main.yaml
+++ b/tests/roles/pcp_cleanup/defaults/main.yaml
@@ -1,0 +1,1 @@
+pcp_cleanup_enabled: true

--- a/tests/roles/pcp_cleanup/defaults/main.yaml
+++ b/tests/roles/pcp_cleanup/defaults/main.yaml
@@ -1,1 +1,2 @@
+# Whether the cleanup should be run or not.
 pcp_cleanup_enabled: true

--- a/tests/roles/pcp_cleanup/meta/main.yaml
+++ b/tests/roles/pcp_cleanup/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -15,8 +15,9 @@
     while oc get pod | grep mariadb-openstack; do
         sleep 2
     done
-  when: pcp_cleanup_enabled|bool
 
+    oc delete secret osp-secret
+  when: pcp_cleanup_enabled|bool
 
 - name: reset CRC storage
   ansible.builtin.shell: |

--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -1,0 +1,28 @@
+- name: clean up any remains of podified deployment
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+
+    oc delete --wait=false openstackcontrolplane/openstack || true
+    oc patch openstackcontrolplane openstack --type=merge --patch '
+    metadata:
+      finalizers: []
+    ' || true
+
+    while oc get pod | grep rabbitmq-server-0; do
+        sleep 2
+    done
+    while oc get pod | grep mariadb-openstack; do
+        sleep 2
+    done
+  when: pcp_cleanup_enabled|bool
+
+
+- name: reset CRC storage
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cd {{ install_yamls_path }}
+    make crc_storage_cleanup || true
+    make crc_storage
+  when: reset_crc_storage|bool

--- a/tests/roles/prelude_controller/README.md
+++ b/tests/roles/prelude_controller/README.md
@@ -1,0 +1,12 @@
+# prelude_controller role
+
+This role checks that original deployment controllers are reachable.
+
+## Variables
+
+None currently.
+
+<!--
+See
+[defaults file](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/tests/roles/prelude_controller/defaults/main.yaml).
+-->

--- a/tests/roles/prelude_controller/tasks/main.yaml
+++ b/tests/roles/prelude_controller/tasks/main.yaml
@@ -1,0 +1,2 @@
+- name: check connection
+  ansible.builtin.ping:

--- a/tests/roles/prelude_local/README.md
+++ b/tests/roles/prelude_local/README.md
@@ -1,0 +1,10 @@
+# backend_services role
+
+This role runs any test suite initialization tasks on the localhost.
+E.g. 'oc login' command to make sure we can talk to OpenShift
+subsequently.
+
+## Variables
+
+See
+[defaults file](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/tests/roles/prelude_local/defaults/main.yaml).

--- a/tests/roles/prelude_local/defaults/main.yaml
+++ b/tests/roles/prelude_local/defaults/main.yaml
@@ -1,0 +1,4 @@
+clone_install_yamls: false
+install_yamls_path: "{{ inventory_dir }}/install_yamls"
+
+reset_crc_storage: false

--- a/tests/roles/prelude_local/defaults/main.yaml
+++ b/tests/roles/prelude_local/defaults/main.yaml
@@ -1,4 +1,9 @@
+# When install_yamls repo is missing from the expected location,
+# should it be cloned? (If not, just fail the playbook.)
 clone_install_yamls: false
+# Path where install_yamls repo should be found.
 install_yamls_path: "{{ inventory_dir }}/install_yamls"
 
+# Whether 'make crc_storage_cleanup' + 'make crc_storage' should be
+# run before running the test suite.
 reset_crc_storage: false

--- a/tests/roles/prelude_local/meta/main.yaml
+++ b/tests/roles/prelude_local/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/prelude_local/tasks/main.yaml
+++ b/tests/roles/prelude_local/tasks/main.yaml
@@ -1,0 +1,22 @@
+- import_tasks: sanity_checks.yaml
+
+- name: clone install_yamls
+  ansible.builtin.git:
+    repo: https://github.com/openstack-k8s-operators/install_yamls
+    dest: "{{ install_yamls_path }}"
+  when:
+    - not install_yamls_makefile_stat.stat.exists
+    - clone_install_yamls|bool
+
+- name: perform oc login
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ oc_login_command }}
+
+- name: set up and use openstack namespace
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cd {{ install_yamls_path }}
+    make namespace

--- a/tests/roles/prelude_local/tasks/sanity_checks.yaml
+++ b/tests/roles/prelude_local/tasks/sanity_checks.yaml
@@ -1,0 +1,41 @@
+- name: undefined oc_login_command
+  ansible.builtin.fail:
+    msg: >-
+      Variable oc_login_command must be defined.
+  when:
+    - oc_login_command is not defined
+
+- name: test for oc CLI presence
+  ansible.builtin.shell: |
+    {{ oc_header }}
+    /usr/bin/command -v oc
+  failed_when: false
+  register: oc_cli_present_result
+
+- name: oc CLI not found
+  ansible.builtin.fail:
+    msg: >-
+      The 'oc' command was not found. As an alternative to making sure
+      oc is on $PATH before executing Ansible, it is also possible to
+      define a bash snippet in 'oc_header' variable that puts oc onto
+      $PATH. This snippet is included in every script that makes use
+      of oc.
+  when:
+    - oc_cli_present_result.rc != 0
+
+- name: test for install_yamls presence
+  ansible.builtin.stat:
+    path: "{{ install_yamls_path }}/Makefile"
+  register: install_yamls_makefile_stat
+
+- name: missing install_yamls
+  ansible.builtin.fail:
+    msg: >-
+      The install_yamls repo wasn't found. Either set
+      install_yamls_path to a valid install_yamls location, or set
+      clone_install_yamls to true to allow the test suite to clone
+      install_yamls into the default path (directory which contains
+      the Ansible inventory file).
+  when:
+    - not install_yamls_makefile_stat.stat.exists
+    - not clone_install_yamls|bool

--- a/tests/secrets.sample.yaml
+++ b/tests/secrets.sample.yaml
@@ -1,0 +1,10 @@
+oc_login_command: |
+  oc login -u kubeadmin -p CUSTOMIZE_THIS
+
+cinder_password: CUSTOMIZE_THIS
+glance_password: CUSTOMIZE_THIS
+ironic_password: CUSTOMIZE_THIS
+neutron_password: CUSTOMIZE_THIS
+nova_password: CUSTOMIZE_THIS
+octavia_password: CUSTOMIZE_THIS
+placement_password: CUSTOMIZE_THIS

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -1,0 +1,5 @@
+install_yamls_path: /CUSTOMIZE_THIS
+reset_crc_storage: true
+
+oc_header: |
+  source CUSTOMIZE_THIS.sh


### PR DESCRIPTION
So far the test suite only covers the steps upto "backend services deployment".


The interface between the execution infrastructure and the test suite
is an Ansible inventory file. Inventory samples are provided. To
execute the tests, follow this procedure.

* Create `tests/inventory.yaml` file by copying and editing one of the
  included samples (e.g. `tests/inventory.sample-crc-vagrant.yaml`) to
  provide values valid in your environment.

* Run `make test-minimal`.