### PR TITLE
Fix both RBD and RGW links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,4 +28,5 @@ collocated on the Controller hosts ("internal Ceph"), then Ceph
 services need to be moved out of Controller hosts as the last step of
 the OpenStack adoption. Follow this documentation:
 
-* [Ceph cluster migration (RBD)](ceph.md)
+* [Ceph RBD migration](ceph_rbd.md)
+* [Ceph RGW migration](ceph_rgw.md)


### PR DESCRIPTION
This patch fixes the broken links at the bottom of the `README`. 
Ceph has now multiple sections and procedures according to the daemons that should be migrated, and the doc is updated accordingly.