### PR TITLE
Add logging to Makefile test-minimal target and configurable config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /tests/secrets.yaml
 /tests/playbooks/tmp
 /tests/vars.yaml
+/tests/logs
 
 # rendered docs
 /site

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 TEST_INVENTORY ?= tests/inventory.yaml
 TEST_VARS ?= tests/vars.yaml
 TEST_SECRETS ?= tests/secrets.yaml
+TEST_OUTFILE := tests/logs/test_minimal_out_$(shell date +%FT%T%Z).log
+TEST_CONFIG ?= tests/ansible.cfg
 
 test-minimal:
-	ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_minimal.yaml
+	mkdir -p tests/logs
+	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_minimal.yaml 2>&1 | tee $(TEST_OUTFILE)


### PR DESCRIPTION
This is needed for the wireup of the test-minimal test target at [1]

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/47392