### PR TITLE
Add symlink for top-level roles directory needed by zuul

### DIFF
--- a/roles
+++ b/roles
@@ -1,0 +1,1 @@
+tests/roles


### PR DESCRIPTION
This adds a symlink for the tests/roles directory so that zuul can discover and consume the test roles.

Needed by [1] where we are trying to wireup the test_minimal

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/47392