### PR TITLE
Moves the reset_crc_storage_var to the pcp_cleanup role

### DIFF
--- a/tests/roles/pcp_cleanup/defaults/main.yaml
+++ b/tests/roles/pcp_cleanup/defaults/main.yaml
@@ -1,2 +1,6 @@
 # Whether the cleanup should be run or not.
 pcp_cleanup_enabled: true
+
+# Whether 'make crc_storage_cleanup' + 'make crc_storage' should be
+# run before running the test suite.
+reset_crc_storage: false

--- a/tests/roles/prelude_local/defaults/main.yaml
+++ b/tests/roles/prelude_local/defaults/main.yaml
@@ -3,7 +3,3 @@
 clone_install_yamls: false
 # Path where install_yamls repo should be found.
 install_yamls_path: "{{ inventory_dir }}/install_yamls"
-
-# Whether 'make crc_storage_cleanup' + 'make crc_storage' should be
-# run before running the test suite.
-reset_crc_storage: false


### PR DESCRIPTION
This var is used by pcp_cleanup not prelude_local so lets move to the right defaults file. This was noticed as undefined var in [1]

[1] https://logserver.rdoproject.org/23/46923/7/check/data-plane-adoption-github-rdo-centos-8-crc-centos-9-standalone/7ba1034/job-output.txt