### PR TITLE
Document ovn version mismatch workaround

### DIFF
--- a/docs/openstack/ovn_adoption.md
+++ b/docs/openstack/ovn_adoption.md
@@ -109,10 +109,23 @@ oc exec -it ovsdbserver-sb-0 -- ovn-sbctl list Chassis
 ${COMPUTE_SSH} sudo podman exec -it ovn_controller ovs-vsctl set open . external_ids:ovn-remote=tcp:$PODIFIED_OVSDB_SB_IP:6642
 ```
 
+You should now see the following warning in the `ovn_controller` container logs:
+
+```
+2023-03-16T21:40:35Z|03095|ovsdb_cs|WARN|tcp:172.17.1.50:6642: clustered database server has stale data; trying another server
+```
+
 - Reset RAFT state for all compute ovn-controller instances.
 
 ```bash
 ${COMPUTE_SSH} sudo podman exec -it ovn_controller ovn-appctl -t ovn-controller sb-cluster-state-reset
+```
+
+This should complete connection of the controller process to the new remote. See in logs:
+
+```
+2023-03-16T21:42:31Z|03134|main|INFO|Resetting southbound database cluster state
+2023-03-16T21:42:33Z|03135|reconnect|INFO|tcp:172.17.1.50:6642: connected
 ```
 
 - Alternatively, just restart ovn-controller on original compute nodes.

--- a/docs/openstack/troubleshooting.md
+++ b/docs/openstack/troubleshooting.md
@@ -5,9 +5,15 @@ and how to solve them.
 
 ## ErrImagePull due to missing authentication
 
-The deployed containers pull the images from private containers
-registries that can potentially return authentication errors like:
-`Failed to pull image "registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0": rpc error: code = Unknown desc = unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials.`
+The deployed containers pull the images from private containers registries that
+can potentially return authentication errors like:
+
+```
+Failed to pull image "registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0":
+rpc error: code = Unknown desc = unable to retrieve auth token: invalid
+username/password: unauthorized: Please login to the Red Hat Registry using
+your Customer Portal credentials.
+```
 
 An example of a failed pod:
 
@@ -19,23 +25,26 @@ An example of a failed pod:
   Warning  Failed          2m5s (x4 over 3m38s)   kubelet            Failed to pull image "registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0": rpc error: code  ... can be found here: https://access.redhat.com/RegistryAuthentication
   Warning  Failed          2m5s (x4 over 3m38s)   kubelet            Error: ErrImagePull
   Normal   BackOff         110s (x7 over 3m38s)   kubelet            Back-off pulling image "registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0"
-
 ```
 
-To solve this issue we need to get a valid pull-secret from the official [Red Hat console site](https://console.redhat.com/openshift/install/pull-secret),
-store this pull secret locally in a machine with access to the Kubernetes API (service node), and then run:
+To solve this issue we need to get a valid pull-secret from the official [Red
+Hat console site](https://console.redhat.com/openshift/install/pull-secret),
+store this pull secret locally in a machine with access to the Kubernetes API
+(service node), and then run:
 
 ```
 oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=<pull_secret_location.json>
 ```
 
-The previous command will make available the authentication information in all the cluster's compute nodes,
-then trigger a new pod deployment to pull the container image with:
+The previous command will make available the authentication information in all
+the cluster's compute nodes, then trigger a new pod deployment to pull the
+container image with:
 
 ```
 kubectl delete pod rabbitmq-server-0 -n openstack
 ```
 
-And the pod should be able to pull the image successfully.
-For more information about what container registries requires what
-type of authentication, check the [official docs](https://access.redhat.com/RegistryAuthentication).
+And the pod should be able to pull the image successfully.  For more
+information about what container registries requires what type of
+authentication, check the [official
+docs](https://access.redhat.com/RegistryAuthentication).


### PR DESCRIPTION
This workaround is needed until containers get a fresh OVN 22.12+. Also added some log message context to OVN page.