### PR TITLE
Add missing manila into the backend_services initial deployment

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -154,6 +154,13 @@ podified OpenStack control plane services.
       enabled: false
       template:
         ironicConductors: []
+
+    manila:
+      enabled: false
+      template:
+        manilaAPI: {}
+        manilaScheduler: {}
+        manilaShares: {}
   EOF
   ```
 

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -97,6 +97,13 @@
         enabled: false
         template:
           ironicConductors: []
+
+      manila:
+        enabled: false
+        template:
+            manilaAPI: {}
+            manilaScheduler: {}
+            manilaShares: {}
     EOF
 
 - name: wait for mariadb to start up


### PR DESCRIPTION
Adds the manila service (enabled false) into the initial deploy spec: for backend_services role. Otherwise we get the error at [1]

[1] https://logserver.rdoproject.org/23/46923/17/check/data-plane-adoption-github-rdo-centos-8-crc-centos-9-standalone/58aa0dd/logs/subnode-1/home/zuul-worker/test_minimal_out_2023-04-10T15:40:05UTC.log.txt.gz