### PR TITLE
Fix OVS CR validation issue

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -140,7 +140,8 @@ podified OpenStack control plane services.
 
     ovs:
       enabled: false
-      template: {}
+      template:
+        external-ids: {}
 
     neutron:
       enabled: false

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -83,7 +83,8 @@
 
       ovs:
         enabled: false
-        template: {}
+        template:
+          external-ids: {}
 
       neutron:
         enabled: false


### PR DESCRIPTION
Fixes this error:
The OpenStackControlPlane "openstack" is invalid:
spec.ovs.template.external-ids.ovn-encap-type: Unsupported value: "": supported values: "geneve", "vxlan"