### PR TITLE
Cinder API and scheduler adoption

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -133,7 +133,11 @@ podified OpenStack control plane services.
     cinder:
       enabled: false
       template:
+        cinderAPI: {}
+        cinderScheduler: {}
+        cinderBackup: {}
         cinderVolumes: {}
+
     ovn:
       enabled: false
       template: {}

--- a/docs/openstack/cinder_adoption.md
+++ b/docs/openstack/cinder_adoption.md
@@ -1,0 +1,53 @@
+# Cinder adoption
+
+## Prerequisites
+
+* Previous Adoption steps completed. Notably, the service databases
+  must already be imported into the podified MariaDB.
+
+## Variables
+
+(There are no shell variables necessary currently.)
+
+## Pre-checks
+
+## Procedure - Cinder adoption
+
+* Patch OpenStackControlPlane to deploy Cinder:
+
+  ```
+  oc patch openstackcontrolplane openstack --type=merge --patch '
+  spec:
+    cinder:
+      enabled: true
+      template:
+        databaseInstance: openstack
+        secret: osp-secret
+        cinderAPI:
+          replicas: 1
+          containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+        cinderScheduler:
+          replicas: 1
+          containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+        cinderBackup:
+          replicas: 0 # backend needs to be configured
+          containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+        cinderVolumes:
+          volume1:
+            containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+            replicas: 0 # backend needs to be configured
+  '
+  ```
+
+## Post-checks
+
+* See that Cinder endpoints are defined and pointing to the podified
+  FQDNs:
+
+  ```
+  export OS_CLIENT_CONFIG_FILE=clouds-adopted.yaml
+  export OS_CLOUD=adopted
+
+  openstack endpoint list | grep cinder
+  openstack volume list
+  ```

--- a/docs/openstack/cinder_adoption.md
+++ b/docs/openstack/cinder_adoption.md
@@ -49,5 +49,5 @@
   export OS_CLOUD=adopted
 
   openstack endpoint list | grep cinder
-  openstack volume list
+  openstack volume type list
   ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - openstack/keystone_adoption.md
     - openstack/glance_adoption.md
     - openstack/placement_adoption.md
+    - openstack/cinder_adoption.md
     - openstack/other_services_adoption.md
     - openstack/edpm_adoption.md
     - openstack/troubleshooting.md

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -19,4 +19,5 @@
     - keystone_adoption
     - glance_adoption
     - placement_adoption
+    - cinder_adoption
     # - dataplane_adoption  WIP

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -75,6 +75,9 @@
       cinder:
         enabled: false
         template:
+          cinderAPI: {}
+          cinderScheduler: {}
+          cinderBackup: {}
           cinderVolumes: {}
 
       ovn:

--- a/tests/roles/cinder_adoption/meta/main.yaml
+++ b/tests/roles/cinder_adoption/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -32,7 +32,7 @@
     oc get pod --selector=component=cinder-api -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
   register: cinder_running_result
   until: cinder_running_result is success
-  retries: 60
+  retries: 180
   delay: 2
 
 - name: check that Cinder is reachable and its endpoints are defined
@@ -43,8 +43,8 @@
     export OS_CLOUD=adopted
 
     openstack endpoint list | grep cinder
-    openstack volume list
+    openstack volume type list
   register: cinder_responding_result
   until: cinder_responding_result is success
-  retries: 15
+  retries: 60
   delay: 2

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -1,0 +1,50 @@
+- name: deploy podified Cinder scheduler and API
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '
+    spec:
+      cinder:
+        enabled: true
+        template:
+          databaseInstance: openstack
+          secret: osp-secret
+          cinderAPI:
+            replicas: 1
+            containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+          cinderScheduler:
+            replicas: 1
+            containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+          cinderBackup:
+            replicas: 0 # backend needs to be configured
+            containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+          cinderVolumes:
+            volume1:
+              containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+              replicas: 0 # backend needs to be configured
+    '
+
+- name: wait for Cinder to start up
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc get pod --selector=component=cinder-scheduler -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    oc get pod --selector=component=cinder-api -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+  register: cinder_running_result
+  until: cinder_running_result is success
+  retries: 60
+  delay: 2
+
+- name: check that Cinder is reachable and its endpoints are defined
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    export OS_CLIENT_CONFIG_FILE={{ adopted_clouds_yaml_path }}
+    export OS_CLOUD=adopted
+
+    openstack endpoint list | grep cinder
+    openstack volume list
+  register: cinder_responding_result
+  until: cinder_responding_result is success
+  retries: 15
+  delay: 2


### PR DESCRIPTION
Adding Cinder API and scheduler to the adoption procedure. Backend and Volume can be enabled with actual backend config.