### PR TITLE
Stop tripleo libvirt services

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -27,6 +27,38 @@
     EOF
   ```
 
+* Stop the nova services.
+
+```bash
+
+# Update the services list to be stopped
+
+ServicesToStop=("tripleo_nova_api_cron.service"
+                "tripleo_nova_api.service"
+                "tripleo_nova_compute.service"
+                "tripleo_nova_conductor.service"
+                "tripleo_nova_libvirt.target"
+                "tripleo_nova_metadata.service"
+                "tripleo_nova_migration_target.service"
+                "tripleo_nova_scheduler.service"
+                "tripleo_nova_virtlogd_wrapper.service"
+                "tripleo_nova_virtnodedevd.service"
+                "tripleo_nova_virtproxyd.service"
+                "tripleo_nova_virtqemud.service"
+                "tripleo_nova_virtsecretd.service"
+                "tripleo_nova_virtstoraged.service"
+                "tripleo_nova_vnc_proxy.service")
+
+echo "Stopping nova services"
+
+for service in ${ServicesToStop[*]}; do
+    echo "Stopping the $service in each controller node"
+    $CONTROLLER1_SSH sudo systemctl stop $service
+    $CONTROLLER2_SSH sudo systemctl stop $service
+    $CONTROLLER3_SSH sudo systemctl stop $service
+done
+```
+
 * Deploy OpenStackDataPlane:
 
   ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ nav:
     - openstack/glance_adoption.md
     - openstack/placement_adoption.md
     - openstack/other_services_adoption.md
-    # - openstack/edpm_adoption.md
+    - openstack/edpm_adoption.md
     - openstack/troubleshooting.md
   - Ceph:
     - Ceph RBD migration: ceph/ceph_rbd.md

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -14,6 +14,46 @@
     $(cat {{ edpm_privatekey_path }} | base64 | sed 's/^/        /')
     EOF
 
+- name: set Nova copy shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    nova_shell_vars: |
+      CONTROLLER1_SSH="{{ controller1_ssh }}"
+      CONTROLLER2_SSH="{{ controller2_ssh }}"
+      CONTROLLER3_SSH="{{ controller3_ssh }}"
+
+- name: stop nova services
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ nova_shell_vars }}
+
+    ServicesToStop=("tripleo_nova_api_cron.service"
+                    "tripleo_nova_api.service"
+                    "tripleo_nova_compute.service"
+                    "tripleo_nova_conductor.service"
+                    "tripleo_nova_libvirt.target"
+                    "tripleo_nova_metadata.service"
+                    "tripleo_nova_migration_target.service"
+                    "tripleo_nova_scheduler.service"
+                    "tripleo_nova_virtlogd_wrapper.service"
+                    "tripleo_nova_virtnodedevd.service"
+                    "tripleo_nova_virtproxyd.service"
+                    "tripleo_nova_virtqemud.service"
+                    "tripleo_nova_virtsecretd.service"
+                    "tripleo_nova_virtstoraged.service"
+                    "tripleo_nova_vnc_proxy.service")
+
+    echo "Stopping nova services"
+
+    for service in ${ServicesToStop[*]}; do
+        echo "Stopping the service: $service in each controller node"
+        $CONTROLLER1_SSH sudo systemctl stop $service
+        $CONTROLLER2_SSH sudo systemctl stop $service
+        $CONTROLLER3_SSH sudo systemctl stop $service
+    done
+
 - name: deploy dataplane services
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
For ensuring EDPM can be successfully deployed, we need to Include a step to manually stop tripleo libvirt services