### PR TITLE
Update OpenStackDataPlane vars

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -1,12 +1,7 @@
 registry_name: "quay.io"
-registry_namespace: "tripleozedcentos9"
-image_tag: "current-tripleo"
+registry_namespace: "podified-antelope-centos9"
+image_tag: "current-podified"
 ansibleSSHPrivateKeySecret: dataplane-adoption-secret
 openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 deployStrategy:
   deploy: false
-networkAttachments:
-  - ctlplane
-  - internalapi
-  - storage
-  - tenant

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -152,7 +152,7 @@
       roles:
         edpmadoption:
           deployStrategy: {{ deployStrategy }}
-          networkAttachments: {{ networkAttachments }}
+          networkAttachments: $(oc get network-attachment-definitions -o json | jq -r "[.items[].metadata.name]")
           services:
             - configure-network
           env:
@@ -170,11 +170,13 @@
               service_net_map:
                 nova_api_network: internal_api
                 nova_libvirt_network: internal_api
+
               # edpm_network_config
               # Default nic config template for a EDPM compute node
               # These vars are edpm_network_config role vars
               edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
               edpm_network_config_hide_sensitive_logs: false
+              #
               # These vars are for the network config templates themselves and are
               # considered EDPM network defaults.
               neutron_physical_bridge_name: br-ctlplane
@@ -210,23 +212,24 @@
                 InternalApi: internal_api
                 Storage: storage
                 Tenant: tenant
+
               # edpm_nodes_validation
               edpm_nodes_validation_validate_controllers_icmp: false
               edpm_nodes_validation_validate_gateway_icmp: false
 
-              edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user_-secret@rabbitmq.openstack.svc:5672
-              edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:172.17.0.31:6642
-              edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
-              edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+              edpm_ovn_metadata_agent_DEFAULT_transport_url: $(oc get secret rabbitmq-transport-url-neutron-neutron-transport -o json | jq -r .data.transport_url | base64 -d)
+              edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: $(oc get ovndbcluster ovndbcluster-sb -o json | jq -r .status.dbAddress)
+              edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: $(oc get svc nova-metadata-internal -o json |jq -r '.status.loadBalancer.ingress[0].ip')
+              edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 1234567842
               edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
               edpm_chrony_ntp_servers:
-              - clock.corp.redhat.com
+              - pool.ntp.org
 
               ctlplane_dns_nameservers:
               - 192.168.121.1
               dns_search_domains: []
               edpm_ovn_dbs:
-              - 172.17.0.31
+              - $(oc get ovndbcluster ovndbcluster-sb -o json | jq -r '.status.networkAttachments."openstack/internalapi"[0]')
 
               edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
               edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
@@ -237,7 +240,6 @@
 
               gather_facts: false
               enable_debug: false
-              verbosity: 4
               # edpm firewall, change the allowed CIDR if needed
               edpm_sshd_configure_firewall: true
               edpm_sshd_allowed_ranges: ['192.168.122.0/24']


### PR DESCRIPTION
dataplane is successfully deployed:
```
[dpadev@osp-dev-05 director_standalone]$ oc get osdp
NAME        STATUS   MESSAGE
openstack   True     DataPlane ready
```
but standalone host isn't showing up:
```
[dpadev@osp-dev-05 director_standalone]oc rsh openstackclient
sh-5.1$ openstack compute service list

+--------------------------------------+----------------+------------------------+----------+---------+-------+----------------------------+
| ID                                   | Binary         | Host                   | Zone     | Status  | State | Updated At                 |
+--------------------------------------+----------------+------------------------+----------+---------+-------+----------------------------+
| dd910f7f-de46-477d-9642-2e7e6864a05f | nova-conductor | nova-cell1-conductor-0 | internal | enabled | up    | 2023-05-05T19:35:51.000000 |
| 429c1d45-63fb-456d-86d6-3a992699e899 | nova-conductor | nova-cell0-conductor-0 | internal | enabled | up    | 2023-05-05T19:35:55.000000 |
| 34e7b894-9533-4216-b5fb-b8bd5b834804 | nova-scheduler | nova-scheduler-0       | internal | enabled | up    | 2023-05-05T19:35:57.000000 |
+--------------------------------------+----------------+------------------------+----------+---------+-------+----------------------------+

sh-5.1$ openstack network agent list

+--------------------------------------+----------------------+--------------------+-------------------+-------+-------+----------------+
| ID                                   | Agent Type           | Host               | Availability Zone | Alive | State | Binary         |
+--------------------------------------+----------------------+--------------------+-------------------+-------+-------+----------------+
| 77eedc86-cdcf-48bd-9abf-29902ecfe1c5 | OVN Controller agent | crc-9ltqk-master-0 |                   | :-)   | UP    | ovn-controller |
+--------------------------------------+----------------------+--------------------+-------------------+-------+-------+----------------+

sh-5.1$ openstack hypervisor list


```
trying to fix this by updating the ansible vars