### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -110,7 +110,7 @@ podified OpenStack control plane services.
     mariadb:
       templates:
         openstack:
-          containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
           storageRequest: 500M
 
     rabbitmq:

--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -169,12 +169,12 @@ done
               edpm_ovn_dbs:
               - 172.17.0.31
 
-              edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
-              edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-              edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
-              edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-              edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-              edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+              edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+              edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+              edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
+              edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+              edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+              edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
 
               gather_facts: false
               enable_debug: false

--- a/docs/openstack/glance_adoption.md
+++ b/docs/openstack/glance_adoption.md
@@ -51,13 +51,13 @@ spec:
     enabled: true
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+      containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
       storageClass: "local-storage"
       storageRequest: 10G
       glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
       glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
 '
 ```
 
@@ -107,7 +107,7 @@ spec:
     enabled: true
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+      containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
       customServiceConfig: |
         [DEFAULT]
         enabled_backends=default_backend:rbd
@@ -121,9 +121,9 @@ spec:
       storageClass: "local-storage"
       storageRequest: 10G
       glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
       glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   extraMounts:
     - extraVol:
       - propagation:

--- a/docs/openstack/keystone_adoption.md
+++ b/docs/openstack/keystone_adoption.md
@@ -22,7 +22,7 @@
       enabled: true
       template:
         secret: osp-secret
-        containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
         databaseInstance: openstack
   '
   ```

--- a/docs/openstack/mariadb_copy.md
+++ b/docs/openstack/mariadb_copy.md
@@ -30,7 +30,7 @@ just illustrative, use values that are correct for your environment:
 
 ```
 PODIFIED_MARIADB_IP=$(oc get -o yaml pod mariadb-openstack | grep podIP: | awk '{ print $2; }')
-MARIADB_IMAGE=quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 
 # Use your environment's values for these:
 EXTERNAL_MARIADB_IP=192.168.24.3

--- a/docs/openstack/other_services_adoption.md
+++ b/docs/openstack/other_services_adoption.md
@@ -29,16 +29,16 @@ their own guides (e.g. like
     #   template:
     #     cinderAPI:
     #       replicas: 1
-    #       containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+    #       containerImage: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
     #     cinderScheduler:
     #       replicas: 1
-    #       containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+    #       containerImage: quay.io/podified-antelope-centos9/openstack-cinder-scheduler:current-podified
     #     cinderBackup:
     #       replicas: 1
-    #       containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+    #       containerImage: quay.io/podified-antelope-centos9/openstack-cinder-backup:current-podified
     #     cinderVolumes:
     #       volume1:
-    #         containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+    #         containerImage: quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified
     #         replicas: 1
 
     ovn:
@@ -47,23 +47,23 @@ their own guides (e.g. like
         ovnDBCluster:
           ovndbcluster-nb:
             replicas: 1
-            containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+            containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
             dbType: NB
             storageRequest: 10G
           ovndbcluster-sb:
             replicas: 1
-            containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
+            containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
             dbType: SB
             storageRequest: 10G
         ovnNorthd:
           replicas: 1
-          containerImage: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-northd:current-podified
 
     ovs:
       enabled: true
       template:
         ovsContainerImage: "quay.io/skaplons/ovs:latest"
-        ovnContainerImage: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
+        ovnContainerImage: "quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"
         external-ids:
           system-id: "random"
           ovn-bridge: "br-int"
@@ -73,7 +73,7 @@ their own guides (e.g. like
       enabled: true
       template:
         databaseInstance: openstack
-        containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
         secret: osp-secret
 
     # nova:

--- a/docs/openstack/ovn_adoption.md
+++ b/docs/openstack/ovn_adoption.md
@@ -31,7 +31,7 @@ Define the shell variables used in the steps below. The values are
 just illustrative, use values that are correct for your environment:
 
 ```bash
-OVSDB_IMAGE=quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
 EXTERNAL_OVSDB_IP=172.17.1.49
 
 # ssh commands to reach the original controller machines
@@ -67,17 +67,17 @@ spec:
     template:
       ovnDBCluster:
         ovndbcluster-nb:
-          containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
           dbType: NB
           storageRequest: 10G
           networkAttachment: internalapi
         ovndbcluster-sb:
-          containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
           dbType: SB
           storageRequest: 10G
           networkAttachment: internalapi
       ovnNorthd:
-        containerImage: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-ovn-northd:current-podified
         networkAttachment: internalapi
 '
 ```

--- a/docs/openstack/placement_adoption.md
+++ b/docs/openstack/placement_adoption.md
@@ -19,7 +19,7 @@
     placement:
       enabled: true
       template:
-        containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+        containerImage: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
         databaseInstance: openstack
         secret: osp-secret
   '

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -52,7 +52,7 @@
       mariadb:
         templates:
           openstack:
-            containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+            containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
             storageRequest: 500M
 
       rabbitmq:

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -1,6 +1,6 @@
 registry_name: "quay.io"
-registry_namespace: "tripleozedcentos9"
-image_tag: "current-tripleo"
+registry_namespace: "podified-antelope-centos9"
+image_tag: "current-podified"
 ansibleSSHPrivateKeySecret: dataplane-adoption-secret
 openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 deployStrategy:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -8,13 +8,13 @@
         enabled: true
         template:
           databaseInstance: openstack
-          containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
           storageClass: "local-storage"
           storageRequest: 10G
           glanceAPIInternal:
-            containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+            containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
           glanceAPIExternal:
-            containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+            containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     '
 
 - name: wait for Glance to start up

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -8,7 +8,7 @@
         enabled: true
         template:
           secret: osp-secret
-          containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
           databaseInstance: openstack
     '
 

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -10,7 +10,7 @@
   ansible.builtin.set_fact:
     mariadb_copy_shell_vars: |
       PODIFIED_MARIADB_IP={{ podified_mariadb_ip_result.stdout }}
-      MARIADB_IMAGE=quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+      MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 
       EXTERNAL_MARIADB_IP={{ external_mariadb_ip }}
       EXTERNAL_DB_ROOT_PASSWORD="{{ external_db_root_password }}"

--- a/tests/roles/placement_adoption/tasks/main.yaml
+++ b/tests/roles/placement_adoption/tasks/main.yaml
@@ -7,7 +7,7 @@
       placement:
         enabled: true
         template:
-          containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+          containerImage: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
           databaseInstance: openstack
           secret: osp-secret
     '


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

Note that the openstack-tripleoclient container was replaced by the openstack-openstackclient container during migration to TCIB.

[1] https://github.com/openstack-k8s-operators/tcib