### PR TITLE
Patch rabbit to reduce resource consumption during test run for ci

### DIFF
--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -116,3 +116,18 @@
   until: mariadb_running_result is success
   retries: 60
   delay: 2
+
+- name: Patch rabbitmq resources for lower resource consumption
+  changed_when: false
+  ansible.builtin.shell: |
+    crname=$(oc get openstackcontrolplane -o name)
+    oc patch ${crname} --type json \
+      -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/cpu", "value": 500m}]'
+    oc patch ${crname} --type json \
+      -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/memory", "value": 500Mi}]'
+    oc patch ${crname} --type json \
+      -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/cpu", "value": 500m}]'
+    oc patch ${crname} --type json \
+      -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/memory", "value": 500Mi}]'
+  tags:
+    - skip_ansible_lint


### PR DESCRIPTION
Related pull request at [1] and patch at [2]

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/37
[2] https://review.rdoproject.org/r/c/rdo-jobs/+/48480