### PR TITLE
Document Development Environment based on install_yamls

### DIFF
--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -3,8 +3,8 @@ Development environment
 
 -----
 
-*This is a guide for install_yamls based Adoption environment. It is
-a work in progress. For now please use the previous
+*This is a guide for an install_yamls based Adoption environment with
+network isolation as an alternative to the
 [CRC and Vagrant TripleO Standalone](https://gitlab.cee.redhat.com/rhos-upgrades/data-plane-adoption-dev/-/tree/main/crc-and-vagrant)
 development environment guide.*
 
@@ -13,7 +13,7 @@ development environment guide.*
 The Adoption development environment utilizes
 [install_yamls](https://github.com/openstack-k8s-operators/install_yamls)
 for CRC VM creation and for creation of the VM that hosts the original
-OpenStack (currently in Standalone configuration).
+Wallaby OpenStack in Standalone configuration.
 
 ## Environment prep
 
@@ -49,6 +49,7 @@ GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@latest
 
 ## Deployment of CRC with network isolation
 
+
 ```
 cd install_yamls/devsetup
 PULL_SECRET=$HOME/pull-secret.txt CPUS=12 MEMORY=40000 DISK=100 make crc
@@ -63,17 +64,10 @@ make crc_storage
 make input
 make openstack
 ```
+Use the [install_yamls devsetup](https://github.com/openstack-k8s-operators/install_yamls/tree/main/devsetup)
+to create a virtual machine connected to the isolated networks.
 
-## Deployment of 17.1 Standalone with network isolation
-
-Instructions for OSP 17.1 Standalone deployment with network isolation
-are TBD, for now you can use the TripleO Wallaby Standalone without
-network isolation as documented in the [original dev setup
-repo](https://gitlab.cee.redhat.com/rhos-upgrades/data-plane-adoption-dev/-/tree/main/crc-and-vagrant).
-
-That will mean you can only adopt the OpenStack without utilizing the
-isolated networks.
-
+Create the edpm-compute-0 virtual machine.
 ```
 cd install_yamls/devsetup
 EDPM_COMPUTE_VCPUS=8 EDPM_COMPUTE_RAM=20 EDPM_COMPUTE_DISK_SIZE=70 make edpm_compute
@@ -81,33 +75,49 @@ EDPM_COMPUTE_VCPUS=8 EDPM_COMPUTE_RAM=20 EDPM_COMPUTE_DISK_SIZE=70 make edpm_com
 ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100
 ```
 
-In the compute node:
+## Deployment of Wallaby Standalone with network isolation
 
+The steps in this section should be run on the edpm-compute-0 virtual
+machine so that it's configured to host [TripleO Standalone](https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/deployment/standalone.html)
+with Ceph.
+
+Configure the repositories and install the necessary packages.
 ```
-export GATEWAY=192.168.122.1
-export CTLPLANE_IP=192.168.122.100
-export CTLPLANE_VIP=192.168.122.99
-export INTERNAL_IP=$(sed -e 's/192.168.122/172.17.0/' <<<"$CTLPLANE_IP")
-export STORAGE_IP=$(sed -e 's/192.168.122/172.18.0/' <<<"$CTLPLANE_IP")
-export TENANT_IP=$(sed -e 's/192.168.122/172.10.0/' <<<"$CTLPLANE_IP")
-export EXTERNAL_IP=$(sed -e 's/192.168.122/172.19.0/' <<<"$CTLPLANE_IP")
-export NEUTRON_INTERFACE=vlan44
-export NTP_SERVER=clock.corp.redhat.com
-
-sudo hostnamectl set-hostname standalone.localdomain
-sudo hostnamectl set-hostname standalone.localdomain --transient
-
 sudo dnf remove -y epel-release
 sudo dnf update -y
 sudo dnf install -y vim git curl util-linux lvm2 tmux wget
-url=https://trunk.rdoproject.org/centos9/component/tripleo/current/
-rpm_name=$(curl $url | grep python3-tripleo-repos | sed -e 's/<[^>]*>//g' | awk 'BEGIN { FS = ".rpm" } ; { print $1 }')
-rpm=$rpm_name.rpm
-sudo dnf install -y $url$rpm
+URL=https://trunk.rdoproject.org/centos9/component/tripleo/current/
+RPM_NAME=$(curl $URL | grep python3-tripleo-repos | sed -e 's/<[^>]*>//g' | awk 'BEGIN { FS = ".rpm" } ; { print $1 }')
+RPM=$RPM_NAME.rpm
+sudo dnf install -y $URL$RPM
 sudo -E tripleo-repos -b wallaby current-tripleo-dev ceph --stream
 sudo dnf repolist
 sudo dnf update -y
-sudo dnf install -y podman python3-tripleoclient
+sudo dnf install -y podman python3-tripleoclient util-linux lvm2 cephadm
+```
+Set the hostname.
+```
+sudo hostnamectl set-hostname standalone.localdomain
+sudo hostnamectl set-hostname standalone.localdomain --transient
+```
+Create a containers-prepare-parameters.yaml file.
+```
+openstack tripleo container image prepare default \
+  --output-env-file $HOME/containers-prepare-parameters.yaml
+```
+
+### Networking
+
+Use os-net-config to add VLAN interfaces which connect edpm-compute-0
+to the isolated networks configured by `install_yamls`.
+```
+export GATEWAY=192.168.122.1
+export CTLPLANE_IP=192.168.122.100
+export INTERNAL_IP=$(sed -e 's/192.168.122/172.17.0/' <<<"$CTLPLANE_IP")
+export STORAGE_IP=$(sed -e 's/192.168.122/172.18.0/' <<<"$CTLPLANE_IP")
+export STORAGE_MGMT_IP=$(sed -e 's/192.168.122/172.20.0/' <<<"$CTLPLANE_IP")
+export TENANT_IP=$(sed -e 's/192.168.122/172.10.0/' <<<"$CTLPLANE_IP")
+export EXTERNAL_IP=$(sed -e 's/192.168.122/172.19.0/' <<<"$CTLPLANE_IP")
 
 sudo mkdir -p /etc/os-net-config
 cat << EOF | sudo tee /etc/os-net-config/config.yaml
@@ -155,6 +165,14 @@ network_config:
     - ip_netmask: $STORAGE_IP/24
     routes: []
 
+  # storage_mgmt
+  - type: vlan
+    mtu: 1500
+    vlan_id: 23
+    addresses:
+    - ip_netmask: $STORAGE_MGMT_IP/24
+    routes: []
+
   # tenant
   - type: vlan
     mtu: 1500
@@ -170,66 +188,354 @@ network:
 EOF
 
 sudo systemctl enable network
-
 sudo os-net-config -c /etc/os-net-config/config.yaml
+```
 
-cat << EOF > $HOME/standalone_parameters.yaml
+The isolated networks from os-net-config config file above will
+be lost when `openstack tripleo deploy` is run because the default
+os-net-config template only has the Neutron public interface as a member.
+To prevent this, copy
+[this standalone.j2 template file](development_environment_examples/standalone.j2)
+(which retains the VLANs above) into tripleo-ansible's `tripleo_network_config` role.
+```
+sudo cp standalone.j2 /usr/share/ansible/roles/tripleo_network_config/templates/standalone.j2
+```
+
+Assign VIPs to the networks created when os-net-config was run.
+The tenant network on vlan22 does not require a VIP.
+```
+sudo ip addr add 172.17.0.2/32 dev vlan20
+sudo ip addr add 172.18.0.2/32 dev vlan21
+sudo ip addr add 172.19.0.2/32 dev vlan44
+sudo ip addr add 172.20.0.2/32 dev vlan23
+```
+
+### Ceph
+
+These steps are based on [TripleO Standalone](https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/deployment/standalone.html)
+to configure Ceph on the Standalone node to simulate an HCI or
+internal Ceph adoption. Ceph will be configured to use the Storage
+network (vlan21) and Storage Management network (vlan23). The storage
+management network, is not configured by default in an NG environment
+and does not need to be accessed by the NG environment as it is only
+used by Ceph (AKA the `cluster_network`) to make OSD replicas and NG
+will not be deploying Ceph. Post adoption this network will remain
+isolated and the Ceph cluster may be considered external.
+
+Assign the IP from vlan21 to a variable representing the Ceph IP.
+```
+export CEPH_IP=172.18.0.100
+```
+Create a block device with logical volumes to be used as an OSD.
+```
+sudo dd if=/dev/zero of=/var/lib/ceph-osd.img bs=1 count=0 seek=7G
+sudo losetup /dev/loop3 /var/lib/ceph-osd.img
+sudo pvcreate /dev/loop3
+sudo vgcreate vg2 /dev/loop3
+sudo lvcreate -n data-lv2 -l +100%FREE vg2
+```
+Create an OSD spec file which references the block device.
+```
+cat <<EOF > $HOME/osd_spec.yaml
+data_devices:
+  paths:
+    - /dev/vg2/data-lv2
+EOF
+```
+Use the Ceph IP and OSD spec file to create a Ceph spec file which
+will describe the Ceph cluster in a format cephadm can parse.
+```
+sudo openstack overcloud ceph spec \
+   --standalone \
+   --mon-ip $CEPH_IP \
+   --osd-spec $HOME/osd_spec.yaml \
+   --output $HOME/ceph_spec.yaml
+```
+Create the ceph-admin user by passing the Ceph spec created earlier.
+```
+sudo openstack overcloud ceph user enable \
+   --standalone \
+   $HOME/ceph_spec.yaml
+```
+Though Ceph will be configured to run on a single host via the
+--single-host-defaults option, this deployment only has a single OSD so
+it cannot replicate data even on the same host. Create an initial Ceph
+configuration to disable replication:
+```
+cat <<EOF > $HOME/initial_ceph.conf
+[global]
+osd pool default size = 1
+[mon]
+mon_warn_on_pool_no_redundancy = false
+EOF
+```
+Use the files created in the previous steps to install Ceph. Use
+[this network_data.yaml file](development_environment_examples/network_data.yaml)
+so that Ceph uses the isolated networks for storage and storage management.
+
+```
+sudo openstack overcloud ceph deploy \
+     --mon-ip $CEPH_IP \
+     --ceph-spec $HOME/ceph_spec.yaml \
+     --config $HOME/initial_ceph.conf \
+     --standalone \
+     --single-host-defaults \
+     --skip-hosts-config \
+     --skip-container-registry-config \
+     --skip-user-create \
+     --network-data network_data.yaml \
+     --ntp-server clock.corp.redhat.com \
+     --output $HOME/deployed_ceph.yaml
+```
+Ceph should now be installed. Use `sudo cephadm shell -- ceph -s`
+to confirm the Ceph cluster health.
+
+### OpenStack
+
+Use the files created in the previous steps including
+[this network_data.yaml file](development_environment_examples/network_data.yaml)
+and
+[this deployed_network.yaml file](development_environment_examples/deployed_network.yaml).
+The deployed_network.yaml file hard codes the IPs and VIPs configured
+from the Networking section.
+
+Create standalone_parameters.yaml file and deploy standalone OpenStack
+using the following commands.
+
+```
+export NEUTRON_INTERFACE=eth0
+export CTLPLANE_IP=192.168.122.100
+export CTLPLANE_VIP=192.168.122.99
+export CIDR=24
+export DNS_SERVERS=192.168.122.1
+export NTP_SERVER=clock.corp.redhat.com
+export GATEWAY=192.168.122.1
+export BRIDGE="br-ctlplane"
+
+cat <<EOF > standalone_parameters.yaml
 parameter_defaults:
   CloudName: $CTLPLANE_IP
-  # ControlPlaneStaticRoutes: []
   ControlPlaneStaticRoutes:
     - ip_netmask: 0.0.0.0/0
       next_hop: $GATEWAY
       default: true
+  Debug: true
   DeploymentUser: $USER
-  DnsServers:
-    - $GATEWAY
-  DockerInsecureRegistryAddress:
-    - $CTLPLANE_IP:8787
-  NeutronPublicInterface: $NEUTRON_INTERFACE
+  DnsServers: $DNS_SERVERS
   NtpServer: $NTP_SERVER
-  CloudDomain: localdomain
+  # needed for vip & pacemaker
+  KernelIpNonLocalBind: 1
+  DockerInsecureRegistryAddress:
+  - $CTLPLANE_IP:8787
+  NeutronPublicInterface: $NEUTRON_INTERFACE
+  # domain name used by the host
   NeutronDnsDomain: localdomain
-  NeutronBridgeMappings: datacentre:br-ctlplane
-  NeutronPhysicalBridge: br-ctlplane
+  # re-use ctlplane bridge for public net
+  NeutronBridgeMappings: datacentre:$BRIDGE
+  NeutronPhysicalBridge: $BRIDGE
   StandaloneEnableRoutedNetworks: false
   StandaloneHomeDir: $HOME
   InterfaceLocalMtu: 1500
+  # Needed if running in a VM
   NovaComputeLibvirtType: qemu
+  ValidateGatewaysIcmp: false
+  ValidateControllersIcmp: false
 EOF
-
-openstack tripleo container image prepare default \
-  --output-env-file $HOME/containers-prepare-parameters.yaml
-
-cat << EOF > $HOME/standalone.sh
-set -euxo pipefail
-
-if podman ps | grep keystone; then
-    echo "Looks like OpenStack is already deployed, not re-deploying."
-    exit 0
-fi
 
 sudo openstack tripleo deploy \
-  --templates \
-  --local-ip=$CTLPLANE_IP/24 \
-  --control-virtual-ip=$CTLPLANE_VIP \
+  --templates /usr/share/openstack-tripleo-heat-templates \
+  --standalone-role Standalone \
   -e /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml \
-  -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
-  -e "$HOME/containers-prepare-parameters.yaml" \
-  -e "$HOME/standalone_parameters.yaml" \
   -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
+  -e ~/containers-prepare-parameters.yaml \
+  -e standalone_parameters.yaml \
+  -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm.yaml \
+  -e ~/deployed_ceph.yaml \
+  -e /usr/share/openstack-tripleo-heat-templates/environments/deployed-network-environment.yaml \
+  -e deployed_network.yaml \
+  -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
+  -n network_data.yaml \
+  --local-ip=$CTLPLANE_IP/$CIDR \
+  --control-virtual-ip=$CTLPLANE_VIP \
   --output-dir $HOME
+```
 
+### Create a workload to adopt
+
+For this example we'll upload a Glance image and confirm it's using
+the Ceph cluster. Later you can adopt the Glance image in the NG
+deployment.
+
+Download a cirros image and convert it to raw format for Ceph.
+```
+IMG=cirros-0.5.2-x86_64-disk.img
+URL=http://download.cirros-cloud.net/0.5.2/$IMG
+RAW=$(echo $IMG | sed s/img/raw/g)
+curl -L -# $URL > $IMG
+qemu-img convert -f qcow2 -O raw $IMG $RAW
+```
+Upload the image to Glance.
+```
 export OS_CLOUD=standalone
-openstack endpoint list
+openstack image create cirros --disk-format=raw --container-format=bare < $RAW
+```
+Confirm the image UUID can be seen in Ceph's images pool.
+```
+sudo cephadm shell -- rbd -p images ls -l
+```
+
+## Complete the NG Deployment
+
+The remaining steps should be completed on the hypervisor hosting crc
+and edpm-compute-0.
+
+### Deploy NG Control Plane with Ceph
+
+Export the Ceph configuration from edpm-compute-0 into a secret.
+```
+SSH=$(ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100)
+KEY=$($SSH "cat /etc/ceph/ceph.client.openstack.keyring | base64 -w 0")
+CONF=$($SSH "cat /etc/ceph/ceph.conf | base64 -w 0")
+
+cat <<EOF > ceph_secret.yaml
+apiVersion: v1
+data:
+  ceph.client.openstack.keyring: $KEY
+  ceph.conf: $CONF
+kind: Secret
+metadata:
+  name: ceph-conf-files
+  namespace: openstack
+type: Opaque
 EOF
 
-bash standalone.sh | tee standalone.log
+oc create -f ceph_secret.yaml
+```
+Deploy the NG control plane with Ceph as backend for Glance and
+Cinder. As described in
+[the install_yamls README](https://github.com/openstack-k8s-operators/install_yamls/tree/main),
+use the sample config located at
+[https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml](https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml)
+but make sure to replace the `_FSID_` in the sample with the one from
+the secret created in the previous step.
+```
+curl -o /tmp/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml https://raw.githubusercontent.com/openstack-k8s-operators/openstack-operator/main/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+FSID=$(oc get secret ceph-conf-files -o json | jq -r '.data."ceph.conf"' | base64 -d | grep fsid | sed -e 's/fsid = //') && echo $FSID
+sed -i "s/_FSID_/${FSID}/" /tmp/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+oc apply -f /tmp/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
 ```
 
-## Cleanup of the environment
+A NG control plane which uses the same Ceph backend should now be
+functional. If you create a test image on the NG system to confirm
+it works from the configuration above, be sure to read the warning
+in the next section.
+
+Before beginning adoption testing or development you may wish to
+deploy an EDPM node as described in the following section.
+
+### Warning about two OpenStacks and one Ceph
+
+Though workloads can be created in the NG deployment to test, be
+careful not to confuse them with workloads from the Wallaby cluster
+to be migrated. The following scenario is now possible.
+
+A Glance image exists on the Wallaby OpenStack to be adopted.
+```
+[stack@standalone standalone]$ export OS_CLOUD=standalone
+[stack@standalone standalone]$ openstack image list
++--------------------------------------+--------+--------+
+| ID                                   | Name   | Status |
++--------------------------------------+--------+--------+
+| 33a43519-a960-4cd0-a593-eca56ee553aa | cirros | active |
++--------------------------------------+--------+--------+
+[stack@standalone standalone]$
+```
+If you now create an image with the NG cluster, then a Glance image
+will exsit on the NG OpenStack which will adopt the workloads of the
+wallaby.
+```
+[fultonj@hamfast ng]$ export OS_CLOUD=default
+[fultonj@hamfast ng]$ export OS_PASSWORD=12345678
+[fultonj@hamfast ng]$ openstack image list
++--------------------------------------+--------+--------+
+| ID                                   | Name   | Status |
++--------------------------------------+--------+--------+
+| 4ebccb29-193b-4d52-9ffd-034d440e073c | cirros | active |
++--------------------------------------+--------+--------+
+[fultonj@hamfast ng]$
+```
+Both Glance images are stored in the same Ceph pool.
+```
+[stack@standalone standalone]$ sudo cephadm shell -- rbd -p images ls -l
+Inferring fsid 7133115f-7751-5c2f-88bd-fbff2f140791
+Using recent ceph image quay.rdoproject.org/tripleowallabycentos9/daemon@sha256:aa259dd2439dfaa60b27c9ebb4fb310cdf1e8e62aa7467df350baf22c5d992d8
+NAME                                       SIZE     PARENT  FMT  PROT  LOCK
+33a43519-a960-4cd0-a593-eca56ee553aa         273 B            2
+33a43519-a960-4cd0-a593-eca56ee553aa@snap    273 B            2  yes
+4ebccb29-193b-4d52-9ffd-034d440e073c       112 MiB            2
+4ebccb29-193b-4d52-9ffd-034d440e073c@snap  112 MiB            2  yes
+[stack@standalone standalone]$
+```
+However, as far as each Glance service is concerned each has one
+image. Thus, in order to avoid confusion during adoption the test
+Glance image on the NG OpenStack should be deleted.
+```
+openstack image delete 4ebccb29-193b-4d52-9ffd-034d440e073c
+```
+Connecting the NG OpenStack to the existing Ceph cluster is part of
+the adoption procedure so that the data migration can be minimized
+but understand the implications of the above example.
+
+### Deploy edpm-compute-1
+
+edpm-compute-0 is not available as a standard EDPM system to be
+managed by [edpm-ansible](https://openstack-k8s-operators.github.io/edpm-ansible)
+or
+[dataplane-operator](https://openstack-k8s-operators.github.io/dataplane-operator)
+because it hosts the wallaby deployment which will be adopted
+and after adoption it will only host the Ceph server.
+
+Use the [install_yamls devsetup](https://github.com/openstack-k8s-operators/install_yamls/tree/main/devsetup)
+to create additional virtual machines and be sure
+that the `EDPM_COMPUTE_SUFFIX` is set to `1` or greater.
+Do not set `EDPM_COMPUTE_SUFFIX` to `0` or you could delete
+the Wallaby system created in the previous section.
+
+When deploying EDPM nodes add an `extraMounts` like the following in
+the `OpenStackDataPlane` CR `nodeTemplate` so that they will be
+configured to use the same Ceph cluster.
 
 ```
-cd install_yamls/devsetup
-make crc_cleanup
+    edpm-compute:
+      nodeTemplate:
+        extraMounts:
+        - extraVolType: Ceph
+          volumes:
+          - name: ceph
+            secret:
+              secretName: ceph-conf-files
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true
 ```
+
+A NG data plane which uses the same Ceph backend should now be
+functional. Be careful about not confusing new workloads to test the
+NG OpenStack with the Wallaby OpenStack as described in the previous
+section.
+
+### Begin Adoption Testing or Development
+
+We should now have:
+
+- An NG glance service based on Antelope running on CRC
+- An TripleO-deployed glance serviced running on edpm-compute-0
+- Both services have the same Ceph backend
+- Each service has their own independent database
+
+An environment above is assumed to be available in the
+[Glance Adoption documentation](https://openstack-k8s-operators.github.io/data-plane-adoption/openstack/glance_adoption). You
+may now follow other Data Plane Adoption procedures described in the
+[documentation](https://openstack-k8s-operators.github.io/data-plane-adoption).
+The same pattern can be applied to other services.

--- a/docs/contributing/development_environment_examples/deployed_network.yaml
+++ b/docs/contributing/development_environment_examples/deployed_network.yaml
@@ -1,0 +1,175 @@
+resource_registry:
+  OS::TripleO::Network::Ports::ControlPlaneVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_vip_ctlplane.yaml
+  OS::TripleO::Network::Ports::StorageVipPort: network/ports/deployed_vip_storage.yaml
+
+  OS::TripleO::Network::Ports::StorageMgmtVipPort: network/ports/deployed_vip_storage_mgmt.yaml
+  OS::TripleO::Network::Ports::InternalApiVipPort: network/ports/deployed_vip_internal_api.yaml
+  # Tenant network does not use VIPs
+  OS::TripleO::Network::Ports::ExternalVipPort: network/ports/deployed_vip_external.yaml
+  OS::TripleO::Network: /usr/share/openstack-tripleo-heat-templates/network/deployed_networks.yaml
+parameter_defaults:
+  NodePortMap:
+    standalone:
+      ctlplane:
+        ip_address: 192.168.122.100
+        ip_subnet: 192.168.122.1/24
+        ip_address_uri: 192.168.122.100
+      storage:
+        ip_address: 172.18.0.100
+        ip_subnet: 172.18.0.1/24
+        ip_address_uri: 172.18.0.100
+      storage_mgmt:
+        ip_address: 172.20.0.100
+        ip_subnet: 172.20.0.1/24
+        ip_address_uri: 172.20.0.100
+      internal_api:
+        ip_address: 172.17.0.100
+        ip_subnet: 172.17.0.1/24
+        ip_address_uri: 172.17.0.100
+      tenant:
+        ip_address: 172.10.0.100
+        ip_subnet: 172.10.0.1/24
+        ip_address_uri: 172.10.0.100
+      external:
+        ip_address: 172.19.0.100
+        ip_subnet: 172.19.0.1/24
+        ip_address_uri: 172.19.0.100
+  ControlPlaneVipData:
+    fixed_ips:
+    - ip_address: 192.168.122.99
+    name: control_virtual_ip
+    network:
+      tags:
+      - 192.168.122.0/24
+    subnets:
+    - ip_version: 4
+  VipPortMap:
+    storage:
+      ip_address: 172.18.0.2
+      ip_address_uri: 172.18.0.2
+      ip_subnet: 172.18.0.2/24
+    storage_mgmt:
+      ip_address: 172.20.0.2
+      ip_address_uri: 172.20.0.2
+      ip_subnet: 172.20.0.2/24
+    internal_api:
+      ip_address: 172.17.0.2
+      ip_address_uri: 172.17.0.2
+      ip_subnet: 172.17.0.2/24
+    # tenant:
+    #   ip_address: 172.10.0.2
+    #   ip_address_uri: 172.10.0.2
+    #   ip_subnet: 172.10.0.2/24
+    external:
+      ip_address: 172.19.0.2
+      ip_address_uri: 172.19.0.2
+      ip_subnet: 172.19.0.2/24
+  DeployedNetworkEnvironment:
+    net_cidr_map:
+      storage:
+      - 172.18.0.0/24
+      storage_mgmt:
+      - 172.20.0.0/24
+      internal_api:
+      - 172.17.0.0/24
+      tenant:
+      - 172.10.0.0/24
+      external:
+      - 172.19.0.0/24
+    net_ip_version_map:
+      storage: 4
+      storage_mgmt: 4
+      internal_api: 4
+      tenant: 4
+      external: 4
+    net_attributes_map:
+      storage:
+        network:
+          dns_domain: storage.mydomain.tld.
+          mtu: 1500
+          name: storage
+          tags:
+          - tripleo_network_name=Storage
+          - tripleo_net_idx=0
+          - tripleo_service_net_map_replace=storage
+          - tripleo_vip=true
+        subnets:
+          storage_subnet:
+            cidr: 172.18.0.0/24
+            dns_nameservers: []
+            gateway_ip: null
+            host_routes: []
+            ip_version: 4
+            name: storage_subnet
+      storage_mgmt:
+        network:
+          dns_domain: storagemgmt.mydomain.tld.
+          mtu: 1500
+          name: storage_mgmt
+          tags:
+          - tripleo_network_name=StorageMgmt
+          - tripleo_net_idx=0
+          - tripleo_service_net_map_replace=storage_mgmt
+          - tripleo_vip=true
+        subnets:
+          storage_mgmt_subnet:
+            cidr: 172.20.0.0/24
+            dns_nameservers: []
+            gateway_ip: null
+            host_routes: []
+            ip_version: 4
+            name: storage_mgmt_subnet
+      internal_api:
+        network:
+          dns_domain: internal.mydomain.tld.
+          mtu: 1500
+          name: internal_api
+          tags:
+          - tripleo_network_name=InternalApi
+          - tripleo_net_idx=0
+          - tripleo_service_net_map_replace=internal
+          - tripleo_vip=true
+        subnets:
+          internal_api_subnet:
+            cidr: 172.17.0.0/24
+            dns_nameservers: []
+            gateway_ip: null
+            host_routes: []
+            ip_version: 4
+            name: internal_api_subnet
+      tenant:
+        network:
+          dns_domain: tenant.mydomain.tld.
+          mtu: 1500
+          name: tenant
+          tags:
+          - tripleo_network_name=Tenant
+          - tripleo_net_idx=0
+          - tripleo_service_net_map_replace=tenant
+          - tripleo_vip=false
+        subnets:
+          tenant_subnet:
+            cidr: 172.10.0.0/24
+            dns_nameservers: []
+            gateway_ip: null
+            host_routes: []
+            ip_version: 4
+            name: tenant_subnet
+      external:
+        network:
+          dns_domain: external.mydomain.tld.
+          mtu: 1500
+          name: external
+          tags:
+          - tripleo_network_name=External
+          - tripleo_net_idx=0
+          - tripleo_service_net_map_replace=external
+          - tripleo_vip=true
+        subnets:
+          external_subnet:
+            cidr: 172.19.0.0/24
+            dns_nameservers: []
+            gateway_ip: null
+            host_routes: []
+            ip_version: 4
+            name: external_subnet

--- a/docs/contributing/development_environment_examples/network_data.yaml
+++ b/docs/contributing/development_environment_examples/network_data.yaml
@@ -1,0 +1,60 @@
+- name: Storage
+  mtu: 1500
+  vip: true
+  vlan: 21
+  name_lower: storage
+  dns_domain: storage.mydomain.tld.
+  service_net_map_replace: storage
+  subnets:
+    storage_subnet:
+      ip_subnet: '172.18.0.0/24'
+      allocation_pools: [{'start': '172.18.0.4', 'end': '172.18.0.250'}]
+
+- name: StorageMgmt
+  mtu: 1500
+  vip: true
+  vlan: 23
+  name_lower: storage_mgmt
+  dns_domain: storagemgmt.mydomain.tld.
+  service_net_map_replace: storage_mgmt
+  subnets:
+    storage_mgmt_subnet:
+      ip_subnet: '172.20.0.0/24'
+      allocation_pools: [{'start': '172.20.0.4', 'end': '172.20.0.250'}]
+
+- name: InternalApi
+  mtu: 1500
+  vip: true
+  vlan: 20
+  name_lower: internal_api
+  dns_domain: internal.mydomain.tld.
+  service_net_map_replace: internal
+  subnets:
+    internal_api_subnet:
+      ip_subnet: '172.17.0.0/24'
+      allocation_pools: [{'start': '172.17.0.4', 'end': '172.17.0.250'}]
+
+- name: Tenant
+  mtu: 1500
+  vip: false  # Tenant network does not use VIPs
+  vlan: 22
+  name_lower: tenant
+  dns_domain: tenant.mydomain.tld.
+  service_net_map_replace: tenant
+  subnets:
+    tenant_subnet:
+      ip_subnet: '172.10.0.0/24'
+      allocation_pools: [{'start': '172.10.0.4', 'end': '172.10.0.250'}]
+
+- name: External
+  mtu: 1500
+  vip: true
+  vlan: 44
+  gateway_ip: '172.19.0.1'
+  name_lower: external
+  dns_domain: external.mydomain.tld.
+  service_net_map_replace: external
+  subnets:
+    external_subnet:
+      ip_subnet: '172.19.0.0/24'
+      allocation_pools: [{'start': '172.19.0.4', 'end': '172.19.0.250'}]

--- a/docs/contributing/development_environment_examples/standalone.j2
+++ b/docs/contributing/development_environment_examples/standalone.j2
@@ -1,0 +1,67 @@
+---
+{% set control_virtual_ip = deployed_server_port_map.control_virtual_ip.fixed_ips[0].ip_address %}
+{% set public_virtual_ip = deployed_server_port_map.public_virtual_ip.fixed_ips[0].ip_address %}
+{% if ':' in control_virtual_ip %}
+{%   set control_virtual_cidr = 128 %}
+{% else %}
+{%   set control_virtual_cidr = 32 %}
+{%   endif %}
+{% if ':' in public_virtual_ip %}
+{%   set public_virtual_cidr = 128 %}
+{% else %}
+{%   set public_virtual_cidr = 32 %}
+{%   endif %}
+network_config:
+- type: ovs_bridge
+  name: br-ctlplane
+  use_dhcp: false
+  mtu: {{ local_mtu }}
+  ovs_extra:
+  - br-set-external-id br-ctlplane bridge-id br-ctlplane
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+  - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+  routes: {{ ctlplane_host_routes }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ dns_search_domains }}
+  members:
+    - type: interface
+      name: {{ neutron_public_interface_name }}
+      primary: true
+      mtu: {{ local_mtu }}
+    - type: vlan
+      mtu: 1500
+      vlan_id: 20
+      addresses:
+      - ip_netmask:
+          172.17.0.100/24
+      routes: []
+    - type: vlan
+      mtu: 1500
+      vlan_id: 21
+      addresses:
+      - ip_netmask:
+          172.18.0.100/24
+      routes: []
+    - type: vlan
+      mtu: 1500
+      vlan_id: 22
+      addresses:
+      - ip_netmask:
+          172.10.0.100/24
+      routes: []
+    - type: vlan
+      mtu: 1500
+      vlan_id: 44
+      addresses:
+      - ip_netmask:
+          172.19.0.100/24
+      routes: []
+    - type: vlan
+      mtu: 1500
+      vlan_id: 23
+      addresses:
+      - ip_netmask:
+          172.20.0.100/24
+      routes: []


### PR DESCRIPTION
This version of the documents describe how to use install_yamls/devsetup to configure edpm-compute-0 with isolated networks which can access the NG control plane on k8s. It then covers installing OpenStack Wallaby using TripleO Standalone on the edpm-compute-0 node with network isolation and Ceph and provides example environment files. It then explains how to add an NG deployment to the environment and leaves the reader linked to the adoption procedures they can follow in the new environment.