### PR TITLE
Remove unnecessary tags skip_ansible_lint from patch rabbitmq task

### DIFF
--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -129,5 +129,3 @@
       -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/cpu", "value": 500m}]'
     oc patch ${crname} --type json \
       -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/memory", "value": 500Mi}]'
-  tags:
-    - skip_ansible_lint


### PR DESCRIPTION
This task was added with [1] recently but we should remove the unneeded tags: that were brought over from the original [2].

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/43
[2] https://github.com/openstack-k8s-operators/install_yamls/blob/9f8c97f541afbe9750752c6e342299e3f0b110d9/ci/playbooks/deploy_podified_openstack.yaml#L70