### PR TITLE
Dev env docs: fix network addresses on vlans

### DIFF
--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -116,8 +116,8 @@ export CTLPLANE_IP=192.168.122.100
 export INTERNAL_IP=$(sed -e 's/192.168.122/172.17.0/' <<<"$CTLPLANE_IP")
 export STORAGE_IP=$(sed -e 's/192.168.122/172.18.0/' <<<"$CTLPLANE_IP")
 export STORAGE_MGMT_IP=$(sed -e 's/192.168.122/172.20.0/' <<<"$CTLPLANE_IP")
-export TENANT_IP=$(sed -e 's/192.168.122/172.10.0/' <<<"$CTLPLANE_IP")
-export EXTERNAL_IP=$(sed -e 's/192.168.122/172.19.0/' <<<"$CTLPLANE_IP")
+export TENANT_IP=$(sed -e 's/192.168.122/172.19.0/' <<<"$CTLPLANE_IP")
+export EXTERNAL_IP=$(sed -e 's/192.168.122/172.21.0/' <<<"$CTLPLANE_IP")
 
 sudo mkdir -p /etc/os-net-config
 cat << EOF | sudo tee /etc/os-net-config/config.yaml
@@ -206,8 +206,8 @@ The tenant network on vlan22 does not require a VIP.
 ```
 sudo ip addr add 172.17.0.2/32 dev vlan20
 sudo ip addr add 172.18.0.2/32 dev vlan21
-sudo ip addr add 172.19.0.2/32 dev vlan44
 sudo ip addr add 172.20.0.2/32 dev vlan23
+sudo ip addr add 172.21.0.2/32 dev vlan44
 ```
 
 ### Ceph

--- a/docs/contributing/development_environment_examples/deployed_network.yaml
+++ b/docs/contributing/development_environment_examples/deployed_network.yaml
@@ -27,13 +27,13 @@ parameter_defaults:
         ip_subnet: 172.17.0.1/24
         ip_address_uri: 172.17.0.100
       tenant:
-        ip_address: 172.10.0.100
-        ip_subnet: 172.10.0.1/24
-        ip_address_uri: 172.10.0.100
-      external:
         ip_address: 172.19.0.100
         ip_subnet: 172.19.0.1/24
         ip_address_uri: 172.19.0.100
+      external:
+        ip_address: 172.21.0.100
+        ip_subnet: 172.21.0.1/24
+        ip_address_uri: 172.21.0.100
   ControlPlaneVipData:
     fixed_ips:
     - ip_address: 192.168.122.99
@@ -57,13 +57,13 @@ parameter_defaults:
       ip_address_uri: 172.17.0.2
       ip_subnet: 172.17.0.2/24
     # tenant:
-    #   ip_address: 172.10.0.2
-    #   ip_address_uri: 172.10.0.2
-    #   ip_subnet: 172.10.0.2/24
+    #   ip_address: 172.19.0.2
+    #   ip_address_uri: 172.19.0.2
+    #   ip_subnet: 172.19.0.2/24
     external:
-      ip_address: 172.19.0.2
-      ip_address_uri: 172.19.0.2
-      ip_subnet: 172.19.0.2/24
+      ip_address: 172.21.0.2
+      ip_address_uri: 172.21.0.2
+      ip_subnet: 172.21.0.2/24
   DeployedNetworkEnvironment:
     net_cidr_map:
       storage:
@@ -73,9 +73,9 @@ parameter_defaults:
       internal_api:
       - 172.17.0.0/24
       tenant:
-      - 172.10.0.0/24
-      external:
       - 172.19.0.0/24
+      external:
+      - 172.21.0.0/24
     net_ip_version_map:
       storage: 4
       storage_mgmt: 4
@@ -149,7 +149,7 @@ parameter_defaults:
           - tripleo_vip=false
         subnets:
           tenant_subnet:
-            cidr: 172.10.0.0/24
+            cidr: 172.19.0.0/24
             dns_nameservers: []
             gateway_ip: null
             host_routes: []
@@ -167,7 +167,7 @@ parameter_defaults:
           - tripleo_vip=true
         subnets:
           external_subnet:
-            cidr: 172.19.0.0/24
+            cidr: 172.21.0.0/24
             dns_nameservers: []
             gateway_ip: null
             host_routes: []

--- a/docs/contributing/development_environment_examples/network_data.yaml
+++ b/docs/contributing/development_environment_examples/network_data.yaml
@@ -43,18 +43,18 @@
   service_net_map_replace: tenant
   subnets:
     tenant_subnet:
-      ip_subnet: '172.10.0.0/24'
-      allocation_pools: [{'start': '172.10.0.4', 'end': '172.10.0.250'}]
+      ip_subnet: '172.19.0.0/24'
+      allocation_pools: [{'start': '172.19.0.4', 'end': '172.19.0.250'}]
 
 - name: External
   mtu: 1500
   vip: true
   vlan: 44
-  gateway_ip: '172.19.0.1'
+  gateway_ip: '172.21.0.1'
   name_lower: external
   dns_domain: external.mydomain.tld.
   service_net_map_replace: external
   subnets:
     external_subnet:
-      ip_subnet: '172.19.0.0/24'
-      allocation_pools: [{'start': '172.19.0.4', 'end': '172.19.0.250'}]
+      ip_subnet: '172.21.0.0/24'
+      allocation_pools: [{'start': '172.21.0.4', 'end': '172.21.0.250'}]

--- a/docs/contributing/development_environment_examples/standalone.j2
+++ b/docs/contributing/development_environment_examples/standalone.j2
@@ -49,14 +49,14 @@ network_config:
       vlan_id: 22
       addresses:
       - ip_netmask:
-          172.10.0.100/24
+          172.19.0.100/24
       routes: []
     - type: vlan
       mtu: 1500
       vlan_id: 44
       addresses:
       - ip_netmask:
-          172.19.0.100/24
+          172.21.0.100/24
       routes: []
     - type: vlan
       mtu: 1500


### PR DESCRIPTION
On CRC side, vlan22 is for tenant network and uses 172.19.0.x. On our side it had 172.10.0.x. This is now being fixed in the sample dataplane CR [1] and we should fix it in Adoption dev envs too.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/209