### PR TITLE
Adds ovn external-ids ovn-encap-type for dpa OpenStackControlPlane

### DIFF
--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -82,7 +82,12 @@
 
       ovn:
         enabled: false
-        template: {}
+        template:
+          ovnController:
+            external-ids:
+              system-id: "random"
+              ovn-bridge: "br-int"
+              ovn-encap-type: "geneve"
 
       ovs:
         enabled: false


### PR DESCRIPTION
Without this we get the following error trying to run the tests and when creating OpenStackControlPlane (backend_services)

    spec.ovn.template.ovnController.external-ids.ovn-encap-type:
        Unsupported value: \"\": supported values: \"geneve\", \"vxlan\""],