### PR TITLE
Clarify what's the critical path of dev env setup

### DIFF
--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -408,7 +408,23 @@ Confirm the image UUID can be seen in Ceph's images pool.
 sudo cephadm shell -- rbd -p images ls -l
 ```
 
-## Complete the NG Deployment
+## Performing the Data Plane Adoption
+
+The development environment is now set up, you can go to the [Adoption
+documentation](https://openstack-k8s-operators.github.io/data-plane-adoption/)
+and perform adoption manually, or run the [test
+suite](https://openstack-k8s-operators.github.io/data-plane-adoption/contributing/tests/)
+against your environment.
+
+----
+
+----
+
+## Experimenting with an additional compute node
+
+The following is not on the critical path of preparing the development
+environment for Adoption, but it shows how to make the environment
+work with an additional compute node VM.
 
 The remaining steps should be completed on the hypervisor hosting crc
 and edpm-compute-0.


### PR DESCRIPTION
vs. what is extra with an additional Compute node.

This is something that we ran into today in our "office hours", we should probably be primarily directing folks towards deploying the simple "standalone + CRC" variant initially.