### PR TITLE
Add to docs the ovn external-ids ovn-encap-type test suite change

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -140,7 +140,12 @@ podified OpenStack control plane services.
 
     ovn:
       enabled: false
-      template: {}
+      template:
+        ovnController:
+          external-ids:
+            system-id: "random"
+            ovn-bridge: "br-int"
+            ovn-encap-type: "geneve"
 
     ovs:
       enabled: false


### PR DESCRIPTION
Recently merged commit 7d5401a2e5de82e0f9a276a8edf1ee65ac9c0570 added the geneve ovn-encap-type external id to the ovn section of OpenStackControlPlane on the test suite but not on the docs. This commit adds it to the documentation too.