### PR TITLE
Small improvements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Perform the actions from the sub-documents in the following order:
 
 * [Deploy podified backend services](openstack/backend_services_deployment.md)
 
+* [Stop OpenStack services](openstack/stop_services.md)
+
 * [Copy MariaDB data](openstack/mariadb_copy.md)
 
 * [OVN adoption](openstack/ovn_adoption.md)

--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -210,6 +210,29 @@ sudo ip addr add 172.20.0.2/32 dev vlan23
 sudo ip addr add 172.21.0.2/32 dev vlan44
 ```
 
+### NTP Server
+
+Clock synchronization is important for both Ceph and OpenStack services, so
+both `ceph deploy` and `tripleo deploy` commands will make use of chrony to
+ensure the clock is properly in sync.
+
+We'll use the `NTP_SERVER` environmental variable to define the NTP server to
+use.
+
+If we are running alls these commands in a system inside the Red Hat network we
+should use the `clock.corp.redhat.com ` server:
+
+```
+export NTP_SERVER=clock.corp.redhat.com
+```
+
+And when running it from our own systems outside of the Red Hat network we can
+use any available server:
+
+```
+export NTP_SERVER=pool.ntp.org
+```
+
 ### Ceph
 
 These steps are based on [TripleO Standalone](https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/deployment/standalone.html)
@@ -284,7 +307,7 @@ sudo openstack overcloud ceph deploy \
      --skip-container-registry-config \
      --skip-user-create \
      --network-data network_data.yaml \
-     --ntp-server clock.corp.redhat.com \
+     --ntp-server $NTP_SERVER \
      --output $HOME/deployed_ceph.yaml
 ```
 Ceph should now be installed. Use `sudo cephadm shell -- ceph -s`
@@ -302,13 +325,15 @@ from the Networking section.
 Create standalone_parameters.yaml file and deploy standalone OpenStack
 using the following commands.
 
+Remember that should have exported the `NTP_SERVER` environmental variable
+earlier in the process.
+
 ```
 export NEUTRON_INTERFACE=eth0
 export CTLPLANE_IP=192.168.122.100
 export CTLPLANE_VIP=192.168.122.99
 export CIDR=24
 export DNS_SERVERS=192.168.122.1
-export NTP_SERVER=clock.corp.redhat.com
 export GATEWAY=192.168.122.1
 export BRIDGE="br-ctlplane"
 

--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -409,6 +409,17 @@ we can create a simple alias:
 alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=standalone openstack"
 ```
 
+### Route networks
+
+Route VLAN20 to have access to the MariaDB cluster:
+
+```
+EDPM_BRIDGE=$(sudo virsh dumpxml edpm-compute-0 | grep -oP "(?<=bridge=').*(?=')")
+sudo ip link add link $EDPM_BRIDGE name vlan20 type vlan id 20
+sudo ip addr add dev vlan20 172.17.0.222/24
+sudo ip link set up dev vlan20
+```
+
 ### Snapshot/revert
 
 When the deployment of the Standalone OpenStack is finished, it's a

--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -391,6 +391,24 @@ sudo openstack tripleo deploy \
   --output-dir $HOME
 ```
 
+### Convenience steps
+
+To make our life easier we can copy the deployment passwords we'll be using
+in the [backend services deployment phase of the data plane adoption](
+https://openstack-k8s-operators.github.io/data-plane-adoption/openstack/backend_services_deployment/).
+
+```
+scp -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/root/tripleo-standalone-passwords.yaml ~/
+```
+
+If we want to be able to easily run `openstack` commands from the host without
+actually installing the package and copying the configuration file from the VM
+we can create a simple alias:
+
+```
+alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=standalone openstack"
+```
+
 ### Snapshot/revert
 
 When the deployment of the Standalone OpenStack is finished, it's a

--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -198,6 +198,8 @@ To prevent this, copy
 [this standalone.j2 template file](development_environment_examples/standalone.j2)
 (which retains the VLANs above) into tripleo-ansible's `tripleo_network_config` role.
 ```
+wget https://openstack-k8s-operators.github.io/data-plane-adoption/contributing/development_environment_examples/standalone.j2
+
 sudo cp standalone.j2 /usr/share/ansible/roles/tripleo_network_config/templates/standalone.j2
 ```
 
@@ -297,6 +299,8 @@ Use the files created in the previous steps to install Ceph. Use
 so that Ceph uses the isolated networks for storage and storage management.
 
 ```
+wget https://openstack-k8s-operators.github.io/data-plane-adoption/contributing/development_environment_examples/network_data.yaml
+
 sudo openstack overcloud ceph deploy \
      --mon-ip $CEPH_IP \
      --ceph-spec $HOME/ceph_spec.yaml \
@@ -329,6 +333,8 @@ Remember that should have exported the `NTP_SERVER` environmental variable
 earlier in the process.
 
 ```
+wget https://openstack-k8s-operators.github.io/data-plane-adoption/contributing/development_environment_examples/deployed_network.yaml
+
 export NEUTRON_INTERFACE=eth0
 export CTLPLANE_IP=192.168.122.100
 export CTLPLANE_VIP=192.168.122.99

--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -38,6 +38,11 @@ podified OpenStack control plane services.
   ADMIN_PASSWORD=SomePassword
   ```
 
+  To use the existing OpenStack deployment password:
+  ```
+  ADMIN_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' AdminPassword:' | awk -F ': ' '{ print $2; }')
+  ```
+
 * Set service password variables to match the original deployment.
   Database passwords can differ in podified environment, but
   synchronizing the service account passwords is a required step.

--- a/docs/openstack/mariadb_copy.md
+++ b/docs/openstack/mariadb_copy.md
@@ -13,6 +13,8 @@ cluster.
   * Podified MariaDB and RabbitMQ are running. No other podified
     control plane services are running.
 
+  * OpenStack services have been stopped
+
   * There must be network routability between:
 
     * The adoption host and the original MariaDB.
@@ -24,6 +26,8 @@ cluster.
       podified MariaDB*.
 
 * Podman package is installed
+
+* `CONTROLLER1_SSH`, `CONTROLLER2_SSH`, and `CONTROLLER3_SSH` are configured.
 
 ## Variables
 
@@ -37,11 +41,8 @@ MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podifi
 SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
 PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
 
-# Replace with your environment's MariaDB IP and SSH commands to reach controller machines:
+# Replace with your environment's MariaDB IP:
 SOURCE_MARIADB_IP=192.168.122.100
-CONTROLLER1_SSH="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100"
-CONTROLLER2_SSH=""
-CONTROLLER3_SSH=""
 ```
 
 ## Pre-checks
@@ -66,62 +67,6 @@ CONTROLLER3_SSH=""
   oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
       mysql -h "$PODIFIED_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
   ```
-
-## Procedure - stopping control plane services
-
-From each controller node, it is necessary to stop the
-control-plane services to avoid inconsistencies in the
-data migrated for the data-plane adoption procedure.
-
-1- Connect to all the controller nodes and stop the control
-plane services.
-
-2- Stop the services.
-
-3- Make sure all the services are stopped
-
-These steps can be automated with a simple script that relies on the previously
-defined `CONTROLLER#_SSH` environmental variables:
-
-```bash
-
-# Update the services list to be stopped
-
-ServicesToStop=("tripleo_horizon.service"
-                "tripleo_keystone.service"
-                "tripleo_cinder_api.service"
-                "tripleo_cinder_api_cron.service"
-                "tripleo_cinder_scheduler.service"
-                "tripleo_glance_api.service"
-                "tripleo_neutron_api.service"
-                "tripleo_nova_api.service"
-                "tripleo_placement_api.service")
-
-echo "Stopping systemd OpenStack services"
-for service in ${ServicesToStop[*]}; do
-    for i in {1..3}; do
-        SSH_CMD=CONTROLLER${i}_SSH
-        if [ ! -z "${!SSH_CMD}" ]; then
-            echo "Stopping the $service in controller $i"
-            ${!SSH_CMD} sudo systemctl stop $service
-        fi
-    done
-done
-
-echo "Checking systemd OpenStack services"
-for service in ${ServicesToStop[*]}; do
-    for i in {1..3}; do
-        SSH_CMD=CONTROLLER${i}_SSH
-        if [ ! -z "${!SSH_CMD}" ]; then
-            echo "Checking status of $service in controller $i"
-            if ! ${!SSH_CMD} systemctl show $service | grep ActiveState=inactive >/dev/null; then
-               echo "ERROR: Service $service still running on controller $i"
-            fi
-        fi
-    done
-done
-```
-
 
 ## Procedure - data copy
 

--- a/docs/openstack/mariadb_copy.md
+++ b/docs/openstack/mariadb_copy.md
@@ -90,6 +90,8 @@ defined `CONTROLLER#_SSH` environmental variables:
 ServicesToStop=("tripleo_horizon.service"
                 "tripleo_keystone.service"
                 "tripleo_cinder_api.service"
+                "tripleo_cinder_api_cron.service"
+                "tripleo_cinder_scheduler.service"
                 "tripleo_glance_api.service"
                 "tripleo_neutron_api.service"
                 "tripleo_nova_api.service"

--- a/docs/openstack/stop_services.md
+++ b/docs/openstack/stop_services.md
@@ -80,6 +80,8 @@ ServicesToStop=("tripleo_horizon.service"
                 "tripleo_nova_api.service"
                 "tripleo_placement_api.service")
 
+PacemakerResourcesToStop=("haproxy-bundle")
+
 echo "Stopping systemd OpenStack services"
 for service in ${ServicesToStop[*]}; do
     for i in {1..3}; do
@@ -102,5 +104,17 @@ for service in ${ServicesToStop[*]}; do
             fi
         fi
     done
+done
+
+echo "Stopping pacemaker OpenStack services"
+for i in {1..3}; do
+    SSH_CMD=CONTROLLER${i}_SSH
+    if [ ! -z "${!SSH_CMD}" ]; then
+        echo "Using controller $i to run pacemaker commands"
+        for resource in ${PacemakerResourcesToStop[*]}; do
+            ${!SSH_CMD} sudo pcs resource disable $resource
+        done
+        break
+    fi
 done
 ```

--- a/docs/openstack/stop_services.md
+++ b/docs/openstack/stop_services.md
@@ -1,0 +1,106 @@
+# Stop OpenStack services
+
+Before we can start with the adoption we need to make sure that the OpenStack
+services have been stopped.
+
+This is an important step to avoid inconsistencies in the data migrated for the
+data-plane adoption procedure caused by resource changes after the DB has been
+copied to the new deployment.
+
+Some services are easy to stop because they only perform short asynchronous
+operations, but other services are a bit more complex to gracefully stop
+because they perform synchronous or long running operations that we may want to
+complete instead of aborting them.
+
+Since gracefully stopping all services is non-trivial and beyond the scope of
+this guide we'll proceed with the force method but present a couple of
+recommendations on how to check some things in the services.
+
+## Variables
+
+Define the shell variables used in the steps below. The values are
+just illustrative, use values that are correct for your environment:
+
+```
+CONTROLLER1_SSH="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100"
+CONTROLLER2_SSH=""
+CONTROLLER3_SSH=""
+```
+
+We chose to use these ssh variables with the ssh commands instead of using
+ansible to try to create instructions that are independent on where they are
+running, but ansible commands could be used to achieve the same result if we
+are in the right host, for example to stop a service:
+
+```
+. stackrc ansible -i $(which tripleo-ansible-inventory) Controller -m shell -a "sudo systemctl stop tripleo_horizon.service" -b
+```
+
+## Pre-checks
+
+We can stop OpenStack services at any moment, but we may leave things in an
+undesired state, so at the very least we should have a look to confirm that
+there are no long running operations that require other services.
+
+Ensure that there are no ongoing instance live migrations, volume migrations
+(online or offline), volume creation, backup restore, attaching, detaching,
+etc.
+
+```
+openstack server list --all-projects -c ID -c Status |grep -E '\| .+ing \|'
+openstack volume list --all-projects -c ID -c Status |grep -E '\| .+ing \|'| grep -vi error
+openstack volume backup list --all-projects -c ID -c Status |grep -E '\| .+ing \|' | grep -vi error
+openstack image list -c ID -c Status |grep -E '\| .+ing \|'
+```
+
+
+## Stopping control plane services
+
+We can stop OpenStack services at any moment, but we may leave things in an
+undesired state, so at the very least we should have a look to confirm that
+there are no ongoing  operations.
+
+1- Connect to all the controller nodes.
+2- Stop the services.
+3- Make sure all the services are stopped.
+
+These steps can be automated with a simple script that relies on the previously
+defined environmental variables and function:
+
+```bash
+
+# Update the services list to be stopped
+ServicesToStop=("tripleo_horizon.service"
+                "tripleo_keystone.service"
+                "tripleo_cinder_api.service"
+                "tripleo_cinder_api_cron.service"
+                "tripleo_cinder_scheduler.service"
+                "tripleo_glance_api.service"
+                "tripleo_neutron_api.service"
+                "tripleo_nova_api.service"
+                "tripleo_placement_api.service")
+
+echo "Stopping systemd OpenStack services"
+for service in ${ServicesToStop[*]}; do
+    for i in {1..3}; do
+        SSH_CMD=CONTROLLER${i}_SSH
+        if [ ! -z "${!SSH_CMD}" ]; then
+            echo "Stopping the $service in controller $i"
+            ${!SSH_CMD} sudo systemctl stop $service
+        fi
+    done
+done
+
+echo "Checking systemd OpenStack services"
+for service in ${ServicesToStop[*]}; do
+    for i in {1..3}; do
+        SSH_CMD=CONTROLLER${i}_SSH
+        if [ ! -z "${!SSH_CMD}" ]; then
+            echo "Checking status of $service in controller $i"
+            if ! ${!SSH_CMD} systemctl show $service | grep ActiveState=inactive >/dev/null; then
+               echo "ERROR: Service $service still running on controller $i"
+            fi
+        fi
+    done
+done
+```


### PR DESCRIPTION
This PR includes a series of small improvements to the development environment document and the adoption process.

There is a specific commit for each of the improvements:

- Development Environment:
  - Route mariadb VLAN
  - Mention different NTP servers
  - Include wget commands
  - Nit on the ADMIN_PASSWORD
  - Add convenience steps

- Adoption:
  - Small improvements on the mariadb process
  - Stop cinder scheduler and api cron
  - Split description on stopping the services
  - Stop HAProxy