### PR TITLE
Add kustomization to test overcloud deployment for container override

### DIFF
--- a/tests/config/base/kustomization.yaml
+++ b/tests/config/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- openstack_control_plane.yaml

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -1,0 +1,118 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+
+  cinder:
+    enabled: false
+    template:
+      cinderAPI: {}
+      cinderScheduler: {}
+      cinderBackup: {}
+      cinderVolumes: {}
+
+  dns:
+    enabled: true
+    template:
+      externalEndpoints:
+      - ipAddressPool: ctlplane
+        loadBalancerIPs:
+        - 192.168.122.80
+      options:
+      - key: server
+        values:
+        - 192.168.122.1
+      replicas: 1
+
+  glance:
+    enabled: false
+    template:
+      glanceAPIInternal: {}
+      glanceAPIExternal: {}
+
+  horizon:
+    enabled: false
+    template: {}
+
+  ironic:
+    enabled: false
+    template:
+      ironicConductors: []
+
+  keystone:
+    enabled: false
+    template: {}
+
+  manila:
+    enabled: false
+    template:
+      manilaAPI: {}
+      manilaScheduler: {}
+      manilaShares: {}
+
+  mariadb:
+    enabled: true
+    templates:
+      openstack:
+        storageRequest: 500M
+
+  memcached:
+    enabled: true
+    templates:
+      memcached:
+        replicas: 1
+
+  neutron:
+    enabled: false
+    template: {}
+
+  nova:
+    enabled: false
+    template: {}
+
+  ovn:
+    enabled: false
+    template:
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+      ovnDBCluster:
+        ovndbcluster-nb:
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
+        ovndbcluster-sb:
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
+
+  ovs:
+    enabled: false
+    template:
+      external-ids: {}
+
+  placement:
+    enabled: false
+    template: {}
+
+  rabbitmq:
+    templates:
+      rabbitmq:
+        externalEndpoint:
+          loadBalancerIPs:
+          - 172.17.0.85
+          ipAddressPool: internalapi
+          sharedIP: false
+        replicas: 1
+      rabbitmq-cell1:
+        externalEndpoint:
+          loadBalancerIPs:
+          - 172.17.0.86
+          ipAddressPool: internalapi
+          sharedIP: false
+        replicas: 1
+
+  telemetry:
+    enabled: false
+    template: {}

--- a/tests/config/periodic_ci/container_image_overrides.yaml
+++ b/tests/config/periodic_ci/container_image_overrides.yaml
@@ -1,0 +1,106 @@
+# This will be templated at run-time by the backend_services role to pass
+# the values for the container parameters (namespace, registry, tag)
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderAPI: {}
+      cinderScheduler: {}
+      cinderBackup: {}
+      cinderVolumes: {}
+
+  dns:
+    template:
+      externalEndpoints:
+      - ipAddressPool: ctlplane
+        loadBalancerIPs:
+        - 192.168.122.80
+      options:
+      - key: server
+        values:
+        - 192.168.122.1
+      replicas: 1
+
+  glance:
+    enabled: false
+    template:
+      glanceAPIInternal: {}
+      glanceAPIExternal: {}
+
+  horizon:
+    enabled: false
+    template: {}
+
+  ironic:
+    enabled: false
+    template:
+      ironicConductors: []
+
+  keystone:
+    enabled: false
+    template: {}
+
+  manila:
+    enabled: false
+    template:
+      manilaAPI: {}
+      manilaScheduler: {}
+      manilaShares: {}
+
+  mariadb:
+    templates:
+      openstack:
+        storageRequest: 500M
+
+  memcached:
+    enabled: true
+
+  neutron:
+    enabled: false
+    template: {}
+
+  nova:
+    enabled: false
+    template: {}
+
+  ovn:
+    enabled: false
+    template:
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+
+  ovs:
+    enabled: false
+    template:
+      external-ids: {}
+
+  placement:
+    enabled: false
+    template: {}
+
+  rabbitmq:
+    templates:
+      rabbitmq:
+        externalEndpoint:
+          loadBalancerIPs:
+          - 172.17.0.85
+          ipAddressPool: internalapi
+          sharedIP: false
+        replicas: 1
+      rabbitmq-cell1:
+        externalEndpoint:
+          loadBalancerIPs:
+          - 172.17.0.86
+          ipAddressPool: internalapi
+          sharedIP: false
+        replicas: 1
+
+  telemetry:
+    enabled: false
+    template: {}

--- a/tests/config/periodic_ci/kustomization.yaml
+++ b/tests/config/periodic_ci/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../base
+patchesStrategicMerge:
+- container_image_overrides.yaml

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -38,119 +38,39 @@
         oc set data secret/osp-secret "PlacementPassword={{ placement_password }}"
     {% endif %}
 
-- name: deploy backend services
+- name: when not a periodic CI job use the base deployment
+  when: not periodic|default(false)
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc apply -f - <<EOF
-    apiVersion: core.openstack.org/v1beta1
-    kind: OpenStackControlPlane
-    metadata:
-      name: openstack
-    spec:
-      secret: osp-secret
-      storageClass: local-storage
+    mkdir -p tmp
+    kustomize build base > tmp/test_deployment.yaml
+    oc apply -f tmp/test_deployment.yaml
+  args:
+    chdir: "../config"
 
-      cinder:
-        enabled: false
-        template:
-          cinderAPI: {}
-          cinderScheduler: {}
-          cinderBackup: {}
-          cinderVolumes: {}
+- name: when periodic, create kustomize container_images_overrides.yaml
+  when:
+    - periodic|default(false)
+    - container_registry is defined
+    - container_tag is defined
+    - container_namespace is defined
+  block:
+    - name: template out the override deployment
+      ansible.builtin.template:
+        src: container_overrides.j2
+        dest: "../config/periodic_ci/container_image_overrides.yaml"
+        force: true
 
-      dns:
-        enabled: true
-        template:
-          externalEndpoints:
-          - ipAddressPool: ctlplane
-            loadBalancerIPs:
-            - 192.168.122.80
-          options:
-          - key: server
-            values:
-            - 192.168.122.1
-          replicas: 1
-
-      glance:
-        enabled: false
-        template:
-          glanceAPIInternal: {}
-          glanceAPIExternal: {}
-
-      horizon:
-        enabled: false
-        template: {}
-
-      ironic:
-        enabled: false
-        template:
-          ironicConductors: []
-
-      keystone:
-        enabled: false
-        template: {}
-
-      manila:
-        enabled: false
-        template:
-          manilaAPI: {}
-          manilaScheduler: {}
-          manilaShares: {}
-
-      mariadb:
-        templates:
-          openstack:
-            storageRequest: 500M
-
-      memcached:
-        enabled: true
-        templates:
-          memcached:
-            replicas: 1
-
-      neutron:
-        enabled: false
-        template: {}
-
-      nova:
-        enabled: false
-        template: {}
-
-      ovn:
-        enabled: false
-        template:
-          ovnController:
-            external-ids:
-              system-id: "random"
-              ovn-bridge: "br-int"
-              ovn-encap-type: "geneve"
-
-      placement:
-        enabled: false
-        template: {}
-
-      rabbitmq:
-        templates:
-          rabbitmq:
-            externalEndpoint:
-              loadBalancerIPs:
-              - 172.17.0.85
-              ipAddressPool: internalapi
-              sharedIP: false
-            replicas: 1
-          rabbitmq-cell1:
-            externalEndpoint:
-              loadBalancerIPs:
-              - 172.17.0.86
-              ipAddressPool: internalapi
-              sharedIP: false
-            replicas: 1
-
-      telemetry:
-        enabled: false
-        template: {}
-    EOF
+    - name: run kustomize and create controlplane with container overrides
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        mkdir -p tmp
+        kustomize build periodic_ci > tmp/test_deployment.yaml
+        oc apply -f tmp/test_deployment.yaml
+      args:
+        chdir: "../config"
 
 - name: wait for mariadb to start up
   ansible.builtin.shell: |

--- a/tests/roles/backend_services/templates/container_overrides.j2
+++ b/tests/roles/backend_services/templates/container_overrides.j2
@@ -1,0 +1,76 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderAPI:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-api:{{ container_tag }}
+      cinderScheduler:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-scheduler:{{ container_tag }}
+      cinderBackup:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-backup:{{ container_tag }}
+      cinderVolumes:
+        volume1:
+            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-volume:{{ container_tag }}
+
+  glance:
+    template:
+      containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
+
+  horizon:
+    template:
+      containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-horizon:{{ container_tag }}
+
+  ironic:
+    template:
+      ironicConductors: []
+
+  keystone:
+    template:
+      containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-keystone:{{ container_tag }}
+
+  manila:
+    template:
+      manilaAPI:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-manila-api:{{ container_tag }}
+      manilaScheduler:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-manila-scheduler:{{ container_tag }}
+      manilaShares:
+        volume1:
+            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-manila-share:{{ container_tag }}
+
+  mariadb:
+    templates:
+      openstack:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-mariadb:{{ container_tag }}
+
+  memcached:
+    templates:
+      memcached:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-memcached:{{ container_tag }}
+
+  neutron:
+    template:
+      containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-neutron-server:{{ container_tag }}
+
+  nova:
+    enabled: false
+    template: {}
+
+  ovn:
+    template:
+      ovnController:
+        ovnContainerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-controller:{{ container_tag }}
+        ovsContainerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-base:{{ container_tag }}
+      ovnDBCluster:
+        ovndbcluster-nb:
+            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-nb-db-server:{{ container_tag }}
+        ovndbcluster-sb:
+            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-sb-db-server:{{ container_tag }}
+
+  placement:
+    template:
+      containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-placement-api:{{ container_tag }}
+

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -9,12 +9,10 @@
         template:
           ovnDBCluster:
             ovndbcluster-nb:
-              containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
               dbType: NB
               storageRequest: 10G
               networkAttachment: internalapi
             ovndbcluster-sb:
-              containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
               dbType: SB
               storageRequest: 10G
               networkAttachment: internalapi


### PR DESCRIPTION
This adds kustomization.yaml with base and periodic_ci config to allow us to override the container images.

Since we need to pass the container tag, namespace and registry to the periodic_ci kustomization we are templating the deploy file out using vars passed with the periodic job and placed in test vars.yaml