### PR TITLE
[DNM] Renaming network related variables to align with edpm naming scheme

### DIFF
--- a/docs/ceph/ceph_rgw.md
+++ b/docs/ceph/ceph_rgw.md
@@ -205,7 +205,7 @@ network_config:
   - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
   routes: {{ storage_host_routes }}
 - type: ovs_bridge
-  name: {{ neutron_physical_bridge_name }}
+  name: {{ edpm_network_config_bridge_name }}
   dns_servers: {{ ctlplane_dns_nameservers }}
   domain: {{ dns_search_domains }}
   use_dhcp: false

--- a/docs/contributing/development_environment_examples/standalone.j2
+++ b/docs/contributing/development_environment_examples/standalone.j2
@@ -27,7 +27,7 @@ network_config:
   domain: {{ dns_search_domains }}
   members:
     - type: interface
-      name: {{ neutron_public_interface_name }}
+      name: {{ edpm_network_config_interface_name }}
       primary: true
       mtu: {{ local_mtu }}
     - type: vlan

--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -152,8 +152,8 @@ done
               #
               # These vars are for the network config templates themselves and are
               # considered EDPM network defaults.
-              neutron_physical_bridge_name: br-ctlplane
-              neutron_public_interface_name: eth1
+              edpm_network_config_bridge_name: br-ctlplane
+              edpm_network_config_interface_name: eth1
               ctlplane_mtu: 1500
               ctlplane_subnet_cidr: 24
               ctlplane_gateway_ip: 192.168.122.1

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -142,8 +142,8 @@
               #
               # These vars are for the network config templates themselves and are
               # considered EDPM network defaults.
-              neutron_physical_bridge_name: br-ctlplane
-              neutron_public_interface_name: eth1
+              edpm_network_config_bridge_name: br-ctlplane
+              edpm_network_config_interface_name: eth1
               ctlplane_mtu: 1500
               ctlplane_subnet_cidr: 24
               ctlplane_gateway_ip: 192.168.122.1


### PR DESCRIPTION
The variables `neutron_public_interface_name` and `neutron_physical_bridge_name` have been renamed in edpm-ansible collection. This change hasn't been propagated correctly however. Therefore all the other occurrences have to be changed, to make sure that the role will affect deployment as requested.  
 
Please exercise caution while reviewing this PR. There is a considerable chance of new bugs being introduced as side effects.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/201 