### PR TITLE
Set replicas for memcached

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -163,6 +163,9 @@ podified OpenStack control plane services.
 
     memcached:
       enabled: true
+      templates:
+        memcached:
+          replicas: 1
 
     neutron:
       enabled: false

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -99,6 +99,9 @@
 
       memcached:
         enabled: true
+        templates:
+          memcached:
+            replicas: 1
 
       neutron:
         enabled: false


### PR DESCRIPTION
Set the number of replicas to 1, as otherwise no memcached pod is
created and it prevents keystone coming up.
