### PR TITLE
[fallback solution] Temporarily revert test suite to using local openstack CLI

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -41,7 +41,8 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
+    export OS_CLIENT_CONFIG_FILE={{ adopted_clouds_yaml_path }}
+    export OS_CLOUD=adopted
 
     openstack endpoint list | grep cinder
     openstack volume type list

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -5,6 +5,10 @@
 shell_header: |
   set -euxo pipefail
 
+# Path to the clouds-adopted.yaml file for talking to the adopted
+# cloud.
+adopted_clouds_yaml_path: tmp/clouds-adopted.yaml
+
 # Whether to use no_log on tasks which may output potentially
 # sensitive data.
 use_no_log: true

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -38,7 +38,8 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
+    export OS_CLIENT_CONFIG_FILE={{ adopted_clouds_yaml_path }}
+    export OS_CLOUD=adopted
 
     openstack endpoint list | grep glance
     openstack image list

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -15,6 +15,27 @@
           - 172.17.0.80
     '
 
+- name: create clouds-adopted.yaml
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cat > {{ adopted_clouds_yaml_path }} <<EOF
+    clouds:
+      adopted:
+        auth:
+          auth_url: '{{ auth_url }}'
+          password: '{{ admin_password }}'
+          project_domain_name: Default
+          project_name: admin
+          user_domain_name: Default
+          username: admin
+        cacert: ''
+        identity_api_version: '3'
+        region_name: regionOne
+        volume_api_version: '3'
+    EOF
+
 - name: wait for Keystone to start up
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -29,8 +50,8 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-
-    alias openstack="oc exec -t openstackclient -- openstack"
+    export OS_CLIENT_CONFIG_FILE={{ adopted_clouds_yaml_path }}
+    export OS_CLOUD=adopted
 
     openstack endpoint list | grep keystone
   register: keystone_responding_result
@@ -42,11 +63,14 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
+    export OS_CLIENT_CONFIG_FILE={{ adopted_clouds_yaml_path }}
+    export OS_CLOUD=adopted
 
-    alias openstack="oc exec -t openstackclient -- openstack"
+    openstack endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs openstack endpoint delete || true
 
-    openstack endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
-
-    for service in cinderv3 glance neutron nova placement swift; do
-      openstack service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
-    done
+    openstack service list | awk '/ cinderv3 /{ print $2; }' | xargs openstack service delete || true
+    openstack service list | awk '/ glance /{ print $2; }' | xargs openstack service delete || true
+    openstack service list | awk '/ neutron /{ print $2; }' | xargs openstack service delete || true
+    openstack service list | awk '/ nova /{ print $2; }' | xargs openstack service delete || true
+    openstack service list | awk '/ placement /{ print $2; }' | xargs openstack service delete || true
+    openstack service list | awk '/ swift /{ print $2; }' | xargs openstack service delete || true

--- a/tests/roles/placement_adoption/tasks/main.yaml
+++ b/tests/roles/placement_adoption/tasks/main.yaml
@@ -33,7 +33,8 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
+    export OS_CLIENT_CONFIG_FILE={{ adopted_clouds_yaml_path }}
+    export OS_CLOUD=adopted
 
     openstack endpoint list | grep placement
 


### PR DESCRIPTION
This reverts parts of 1e5904b53880409388b36ad3e03f044e299dfd92 and 7a95e0568d5d6385abc1d400f1297d2866437922 to relieve pressure off openstackclient pod CR transition away from openstack-operator.

We can revert this revert once we have the openstackclient pod again.