### PR TITLE
Ensure DNS is ready when starting standalone machine

### DIFF
--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -63,6 +63,7 @@ cd ..  # back to install_yamls
 make crc_storage
 make input
 make openstack
+make dns_deploy
 ```
 Use the [install_yamls devsetup](https://github.com/openstack-k8s-operators/install_yamls/tree/main/devsetup)
 to create a virtual machine connected to the isolated networks.


### PR DESCRIPTION
```
[root@standalone ~]# cat /etc/resolv.conf
# Generated by NetworkManager
search localdomain
nameserver 192.168.122.1
```
https://paste.opendev.org/show/bAxay8WNaGiC5Crs1uaG/