### PR TITLE
Add stop OSP services in sliding menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Overview: README.md
   - OpenStack:
     - openstack/backend_services_deployment.md
+    - openstack/stop_openstack_services.md
     - openstack/mariadb_copy.md
     - openstack/ovn_adoption.md
     - openstack/keystone_adoption.md


### PR DESCRIPTION
The data plane adoption procedure contains a doc on how to stop the OSP services right after the "Deploy podified backend services" doc. This is not reflect in the sliding menu.