### PR TITLE
Ensure that neutron db is adopted correctly

### DIFF
--- a/docs/openstack/mariadb_copy.md
+++ b/docs/openstack/mariadb_copy.md
@@ -94,6 +94,13 @@ SOURCE_MARIADB_IP=127.17.0.100
   EOF
   ```
 
+* Before restoring the databases from .sql files, we need to ensure that the neutron
+database name is "neutron" and not "ovs_neutron" by running the command:
+
+  ```
+  sed -i '/^CREATE DATABASE/s/ovs_neutron/neutron/g;/^USE/s/ovs_neutron/neutron/g' ovs_neutron.sql
+  ```
+
 * Restore the databases from .sql files into the podified MariaDB:
 
   ```

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -57,6 +57,29 @@
 
     EOF
 
+- name:  Replace neutron database name
+  ansible.builtin.shell: |
+    cd {{ mariadb_copy_tmp_dir }}
+    sed -i '/^CREATE DATABASE/s/ovs_neutron/neutron/g;/^USE/s/ovs_neutron/neutron/g' ovs_neutron.sql
+
+- name: Check name on creation
+  ansible.builtin.lineinfile:
+    path: "{{ mariadb_copy_tmp_dir }}/ovs_neutron.sql"
+    regexp: (^CREATE DATABASE.*`)(neutron)(`.*)
+    state: absent
+  check_mode: yes
+  register: create_database
+  failed_when: create_database.found == 0
+
+- name: Check name on usage
+  ansible.builtin.lineinfile:
+    path: "{{ mariadb_copy_tmp_dir }}/ovs_neutron.sql"
+    regexp: (^USE.*`)(neutron)(`.*)
+    state: absent
+  check_mode: yes
+  register: use_database
+  failed_when: use_database.found == 0
+
 - name: restore databases
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
On a OSP Wallaby environment the neutron DB will be called "ovs_neutron" but neutron pod expects the database to be called "neutron"