### PR TITLE
Adding dataplane node secret to the docs

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -146,6 +146,7 @@ done
           deploy: false
         hostName: standalone
         node:
+          ansibleSSHPrivateKeySecret: dataplane-adoption-secret
           ansibleVars:
             ctlplane_ip: 192.168.122.100
           networks:


### PR DESCRIPTION
It was updated on the test, but it was missing in the docs