### PR TITLE
Cinder: Fix markdown formatting

### DIFF
--- a/docs/openstack/cinder_adoption.md
+++ b/docs/openstack/cinder_adoption.md
@@ -678,7 +678,7 @@ Our recommendation is to write the patch manifest into a file, for example
 
 ```bash
 oc patch openstackcontrolplane openstack --type=merge --patch-file=cinder.patch
- ```
+```
 
 For example, for the RBD deployment from the Development Guide the
 `cinder.patch` would look like this:


### PR DESCRIPTION
There's an extra space before a ``` that breaks the markdown formatting for the Cinder adoption. This patch fixes this issue.

Closes #89