### PR TITLE
Cinder: Remove duplicated cinderAPI

### DIFF
--- a/docs/openstack/cinder_adoption.md
+++ b/docs/openstack/cinder_adoption.md
@@ -708,13 +708,12 @@ spec:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
+        replicas: 1
         externalEndpoints:
         - endpoint: internal
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
-      cinderAPI:
-        replicas: 1
         customServiceConfig: |
           [DEFAULT]
           default_volume_type=tripleo


### PR DESCRIPTION
In one of the Cinder YAML examples we have `cinderAPI` twice, remove one of them.

Related #112