### PR TITLE
[WIP] /bin/sh is not /bin/bash

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -52,3 +52,19 @@ the browser will automatically show the new content.
   try to be concise in writing to keep the docs consumable (but not to
   a point of making things difficult to understand or omitting
   important things).
+
+* A bash alias can be created for long command however when implementing
+  them in the test roles you should transform them to avoid command not
+  found errors.
+  From:
+  ```
+  alias openstack="oc exec -t openstackclient -- openstack"
+
+  openstack endpoint list | grep network
+  ```
+  TO:
+  ```
+  alias openstack="oc exec -t openstackclient -- openstack"
+
+  ${BASH_ALIASES[openstack]} endpoint list | grep network
+  ```

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -29,3 +29,25 @@ samples are provided. To run the tests, follow this procedure:
   `tests/secrets.sample.yaml`).
 
 * Run `make test-minimal`.
+
+
+## Running tests on systems where /bin/sh is not /bin/bash
+
+ansible.builtin.command and ansible.builtin.shell use /bin/sh by default.
+for portability reason when using either command or shell modules you should
+not assume /bin/sh is bash and assume it is simply a posix compliant shell
+
+In this repo that requirement is relax for the ansible.builtin.shell
+module as we configure module_defaults
+
+```
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
+```
+
+module_defaults are configure per playbook play so if you are adding a new
+play or playbook you will need to copy this to ensure compatibility
+
+note the command module always uses /bin/sh so we should avoid bash specific
+syntax when using command or just use the shell module instead.

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,4 +1,3 @@
 [defaults]
-stdout_callback = yaml
 callback_whitelist = profile_json,profile_tasks
 roles_path = ./roles

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -1,18 +1,27 @@
 - name: Prelude
   hosts: local
   gather_facts: no
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
   roles:
     - prelude_local
 
 - name: Cleanup
   hosts: local
   gather_facts: no
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
   roles:
     - pcp_cleanup
 
 - name: Adoption
   hosts: local
   gather_facts: no
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
   roles:
     - backend_services
     - stop_openstack_services

--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -1,12 +1,18 @@
 - name: Prelude
   hosts: local
   gather_facts: no
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
   roles:
     - prelude_local
 
 - name: Cleanup
   hosts: local
   gather_facts: no
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
   roles:
     - pcp_cleanup
 
@@ -15,6 +21,9 @@
   gather_facts: no
   vars:
     glance_backend: ceph
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
   roles:
     - backend_services
     - stop_openstack_services

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -43,8 +43,8 @@
     {{ oc_header }}
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    openstack endpoint list | grep cinder
-    openstack volume type list
+    ${BASH_ALIASES[openstack]} endpoint list | grep cinder
+    ${BASH_ALIASES[openstack]} volume type list
   register: cinder_responding_result
   until: cinder_responding_result is success
   retries: 60

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -78,8 +78,8 @@
     {{ oc_header }}
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    openstack endpoint list | grep glance
-    openstack image list
+    ${BASH_ALIASES[openstack]} endpoint list | grep glance
+    ${BASH_ALIASES[openstack]} image list
   register: glance_responding_result
   until: glance_responding_result is success
   retries: 15

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -25,6 +25,16 @@
   retries: 60
   delay: 2
 
+- name: wait for openstackclient pod to start up
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc get pod --selector=app=openstackclient -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+  register: osc_running_result
+  until: osc_running_result is success
+  retries: 60
+  delay: 2
+
 - name: check that Keystone is reachable and its endpoints are defined
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -32,10 +42,10 @@
 
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    openstack endpoint list | grep keystone
+    ${BASH_ALIASES[openstack]} endpoint list | grep keystone
   register: keystone_responding_result
   until: keystone_responding_result is success
-  retries: 15
+  retries: 60
   delay: 2
 
 - name: clean up services and endpoints
@@ -45,8 +55,8 @@
 
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    openstack endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
+    ${BASH_ALIASES[openstack]} endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
 
     for service in cinderv3 glance neutron nova placement swift; do
-      openstack service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
+      ${BASH_ALIASES[openstack]} service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
     done

--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -27,8 +27,8 @@
     {{ oc_header }}
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    openstack endpoint list | grep network
-    openstack network list
+    ${BASH_ALIASES[openstack]} endpoint list | grep network
+    ${BASH_ALIASES[openstack]} network list
   register: neutron_responding_result
   until: neutron_responding_result is success
   retries: 15

--- a/tests/roles/placement_adoption/tasks/main.yaml
+++ b/tests/roles/placement_adoption/tasks/main.yaml
@@ -35,10 +35,10 @@
     {{ oc_header }}
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    openstack endpoint list | grep placement
+    ${BASH_ALIASES[openstack]} endpoint list | grep placement
 
-    openstack endpoint list | grep placement | grep public
-    PLACEMENT_PUBLIC_URL=$(openstack endpoint list -c 'Service Name' -c 'Service Type' -c URL | grep placement | grep public | awk '{ print $6; }')
+    ${BASH_ALIASES[openstack]} endpoint list | grep placement | grep public
+    PLACEMENT_PUBLIC_URL=$(${BASH_ALIASES[openstack]} endpoint list -c 'Service Name' -c 'Service Type' -c URL | grep placement | grep public | awk '{ print $6; }')
     curl "$PLACEMENT_PUBLIC_URL" | grep '"versions"'
   register: placement_responding_result
   until: placement_responding_result is success

--- a/tests/roles/prelude_local/tasks/sanity_checks.yaml
+++ b/tests/roles/prelude_local/tasks/sanity_checks.yaml
@@ -5,10 +5,12 @@
   when:
     - oc_login_command is not defined
 
+# command is a built in bash so dont use an absolute path as it will not
+# exist depending on the bash version used.
 - name: test for oc CLI presence
   ansible.builtin.shell: |
     {{ oc_header }}
-    /usr/bin/command -v oc
+    command -v oc
   failed_when: false
   register: oc_cli_present_result
 


### PR DESCRIPTION
The ansible shell and command modules /bin/sh not the login
shell of a remote user.
command is alwasy /bin/sh where as the shell module
can sepcify a executable to use as the shell.

This change correct some of our missuse of the shell module
by explictly using /bin/bash in places that explictly need it
We proably should use this everywhere we currently have shell
but this change only updates the minimal set of task that
need to be changed.

this change also adds some docs for how to set
shell_header ot make most of the bash commands work
without explict code change. this will now not work in allcases
which is why some shell task are explictly updated to bash.
