### PR TITLE
[Neutron] Add missing network isolation parameters

### DIFF
--- a/docs/openstack/neutron_adoption.md
+++ b/docs/openstack/neutron_adoption.md
@@ -33,6 +33,13 @@ spec:
     template:
       databaseInstance: openstack
       secret: osp-secret
+      externalEndpoints:
+      - endpoint: internal
+        ipAddressPool: internalapi
+        loadBalancerIPs:
+        - 172.17.0.80
+      networkAttachments:
+      - internalapi
 '
 ```
 

--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -9,6 +9,13 @@
         template:
           databaseInstance: openstack
           secret: osp-secret
+          externalEndpoints:
+          - endpoint: internal
+            ipAddressPool: internalapi
+            loadBalancerIPs:
+            - 172.17.0.80
+          networkAttachments:
+          - internalapi
     '
 
 - name: wait for Neutron to start up


### PR DESCRIPTION
This would be useful when accessing the adopted neutron service from the EDPM Nodes.

Closes https://github.com/openstack-k8s-operators/data-plane-adoption/issues/118