### PR TITLE
Add sample env file to persist adoption settings

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -230,8 +230,9 @@ podified OpenStack control plane services.
 
 ## Post-checks
 
-* Check that MariaDB is running.
+* Check that MariaDBs running.
 
   ```
   oc get pod mariadb-openstack -o jsonpath='{.status.phase}{"\n"}'
+  oc get pod mariadb-openstack-cell1 -o jsonpath='{.status.phase}{"\n"}'
   ```

--- a/docs/openstack/mariadb_copy.md
+++ b/docs/openstack/mariadb_copy.md
@@ -104,7 +104,7 @@ COLLATION=utf8_general_ci
   EOF
   ```
 
-* Restore the databases from .sql files into the podified MariaDB:
+* Restore the databases from .sql files into the podified MariaDBs:
 
   ```
   # db schemas to rename on import

--- a/docs/openstack/ovn_adoption.md
+++ b/docs/openstack/ovn_adoption.md
@@ -63,7 +63,7 @@ ${client} backup tcp:$SOURCE_OVSDB_IP:6642 > ovs-sb.db
 oc patch openstackcontrolplane openstack --type=merge --patch '
 spec:
   ovn:
-    enabled: true
+    enabled: true
     template:
       ovnDBCluster:
         ovndbcluster-nb:
@@ -142,7 +142,7 @@ $ ${COMPUTE_SSH} sudo systemctl restart tripleo_ovn_controller.service
 oc patch openstackcontrolplane openstack --type=merge --patch '
 spec:
   ovn:
-    enabled: true
+    enabled: true
     template:
       ovnNorthd:
         networkAttachment: internalapi

--- a/samples/env
+++ b/samples/env
@@ -1,0 +1,41 @@
+sudo virsh start edpm-compute-0
+crc start
+eval $(crc oc-env)
+oc login -u kubeadmin -p 12345678 https://api.crc.testing:6443
+
+export EDPM_COMPUTE_DISK_SIZE=40
+export EDPM_COMPUTE_CEPH_ENABLED=false
+export EDPM_COMPUTE_VCPUS=4
+export EDPM_COMPUTE_RAM=8
+
+export ADMIN_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' AdminPassword:' | awk -F ': ' '{ print $2; }')
+export CINDER_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' CinderPassword:' | awk -F ': ' '{ print $2; }')
+export GLANCE_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' GlancePassword:' | awk -F ': ' '{ print $2; }')
+export IRONIC_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' IronicPassword:' | awk -F ': ' '{ print $2; }')
+export NEUTRON_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' NeutronPassword:' | awk -F ': ' '{ print $2; }')
+export NOVA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' NovaPassword:' | awk -F ': ' '{ print $2; }')
+export OCTAVIA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' OctaviaPassword:' | awk -F ': ' '{ print $2; }')
+export PLACEMENT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' PlacementPassword:' | awk -F ': ' '{ print $2; }')
+export CONTROLLER_SSH="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100"
+export COMPUTE_SSH="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100"
+export CONTROLLER1_SSH="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100"
+export CONTROLLER2_SSH=""
+export CONTROLLER3_SSH=""
+export PODIFIED_MARIADB_IP=$(oc get svc --selector "cr=mariadb-openstack" -ojsonpath='{.items[0].spec.clusterIP}')
+export MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+export PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
+export PODIFIED_CELL1_MARIADB_IP=$(oc get svc --selector "cr=mariadb-openstack-cell1" -ojsonpath='{.items[0].spec.clusterIP}')
+export SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
+export SOURCE_MARIADB_IP=${SOURCE_MARIADB_IP:?"Enter source mariadb IP"}
+export SOURCE_MARIADB_IP=${SOURCE_MARIADB_IP:-192.168.122.100}
+export CHARACTER_SET=utf8
+export COLLATION=utf8_general_ci
+
+export OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
+export SOURCE_OVSDB_IP=${SOURCE_OVSDB_IP:?"Enter source OVN south DB IP"}
+export SOURCE_OVSDB_IP=${SOURCE_OVSDB_IP:-192.168.122.100}
+export PODIFIED_OVSDB_NB_IP=$(kubectl get po ovsdbserver-nb-0 -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | jq 'map(. | select(.name=="openstack/internalapi"))[0].ips[0]' | tr -d '"')
+export PODIFIED_OVSDB_SB_IP=$(kubectl get po ovsdbserver-sb-0 -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | jq 'map(. | select(.name=="openstack/internalapi"))[0].ips[0]' | tr -d '"')
+
+alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=standalone openstack"
+alias openstackng="oc exec -t openstackclient -- openstack"


### PR DESCRIPTION
    Add sample env file to persist adoption settings
    
    Provide a sample env file to recover settings after rebooting the
    hypervisor. It is mostly useful for resuming of the interrupted manual
    steps, when following the documentation. Especially, when the
    hypervisor is a VM in a cloud provider, like PSI.
    
    The helper env file ensures that the already deployed crc and edpm
    standalone host (compute 0) are running, logs in to crc, exports env
    vars and makes aliases for openstack and podman CLI to exec it on the
    standalone edpm host via ssh.
    
    This saves time, but requires the documented manual steps and the
    sample env file contents to be in sync. There is already such a
    requirement for the documentated scripts and test suits. We could
    leverage code generation in the future to update docs and tests
    automatically, when the scripted commands get updated in a commit.
    While the scripts and env files, like that sample env file, should
    then become the only source of truth.
    
    NOTE: Stability of CRC and EDPM hosts after restarting in unrelated,
    but it shows reliable enough for simple adoption scenarios.
    
    Additionally, follow-up multi-cell DB adoption patch with service
    IP selection and trivial typos fixing.
