### PR TITLE
Fix container images used in periodic CI job for some services

### DIFF
--- a/tests/roles/backend_services/templates/container_overrides.j2
+++ b/tests/roles/backend_services/templates/container_overrides.j2
@@ -17,7 +17,10 @@ spec:
 
   glance:
     template:
-      containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
+      glanceAPIInternal:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
+      glanceAPIExternal:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
 
   horizon:
     template:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -34,7 +34,7 @@
         enabled: true
         template:
           databaseInstance: openstack
-          containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+          containerImage: {{ container_registry|default("quay.io") }}/{{ container_namespace|default("podified-antelope-centos9") }}/openstack-glance-api:{{ container_tag | default("current-podified") }}
           customServiceConfig: |
             [DEFAULT]
             enabled_backends=default_backend:rbd

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -121,7 +121,7 @@
         enabled: true
         template:
           ovnNorthd:
-            containerImage: quay.io/podified-antelope-centos9/openstack-ovn-northd:current-podified
+            containerImage: {{ container_registry|default("quay.io") }}/{{ container_namespace|default("podified-antelope-centos9") }}/openstack-ovn-northd:{{ container_tag | default("current-podified") }}
             networkAttachment: internalapi
             replicas: 1
     '


### PR DESCRIPTION
Some of the podified openstack services are still using the current-podified tag for the container image in the CI periodic line. This adds the overrides for glance and ovn.