### PR TITLE
Implementing full cleaning at the start

### DIFF
--- a/tests/roles/pcp_cleanup/README.md
+++ b/tests/roles/pcp_cleanup/README.md
@@ -1,8 +1,12 @@
 # pcp_cleanup role
 
-This role cleans up the podified control plane from the target
-OpenShift environment, removing any artifacts of a previous test suite
-run (even a failed one).
+This role cleans up the podified control plane and podifed data
+plane from the target OpenShift environment, removing any artifacts
+of a previous test suite run (even a failed one).
+
+This role also include the option of reverting standalone VM to
+pre adoption state .
+
 
 ## Variables
 

--- a/tests/roles/pcp_cleanup/defaults/main.yaml
+++ b/tests/roles/pcp_cleanup/defaults/main.yaml
@@ -4,3 +4,7 @@ pcp_cleanup_enabled: true
 # Whether 'make crc_storage_cleanup' + 'make crc_storage' should be
 # run before running the test suite.
 reset_crc_storage: false
+
+# Whether 'make standalone_revert' should be run before
+# running the test suite.
+standalone_revert_enabled: false

--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -3,6 +3,7 @@
     {{ shell_header }}
     {{ oc_header }}
 
+    oc delete --wait=false openstackdataplane/openstack || true
     oc delete --wait=false openstackcontrolplane/openstack || true
     oc patch openstackcontrolplane openstack --type=merge --patch '
     metadata:
@@ -18,6 +19,14 @@
 
     oc delete secret osp-secret || true
   when: pcp_cleanup_enabled|bool
+
+- name: revert standalone VM to snapshotted state
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cd {{ install_yamls_path }}/devsetup
+    make standalone_revert
+  when: standalone_revert_enabled|bool
 
 - name: reset CRC storage
   ansible.builtin.shell: |


### PR DESCRIPTION
This PR adds a change for pcp_cleanup role to delete openstackdataplane and optionally also revert the standalone VM . Closes issue https://github.com/openstack-k8s-operators/data-plane-adoption/issues/142