### PR TITLE
Filter by mariadb service cluster IP instead

### DIFF
--- a/docs/openstack/mariadb_copy.md
+++ b/docs/openstack/mariadb_copy.md
@@ -37,8 +37,8 @@ just illustrative, use values that are correct for your environment:
 ```
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 
-PODIFIED_MARIADB_IP=$(oc get -o yaml pod mariadb-openstack | grep podIP: | awk '{ print $2; }')
-PODIFIED_CELL1_MARIADB_IP=$(oc get -o yaml pod  mariadb-openstack-cell1  | grep podIP: | awk '{ print $2; }')
+PODIFIED_MARIADB_IP=$(oc get svc --selector "cr=mariadb-openstack" -ojsonpath='{.items[0].spec.clusterIP}')
+PODIFIED_CELL1_MARIADB_IP=$(oc get svc --selector "cr=mariadb-openstack-cell1" -ojsonpath='{.items[0].spec.clusterIP}')
 PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
 
 # Replace with your environment's MariaDB IP:

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -1,15 +1,15 @@
-- name: get podified MariaDB IP
+- name: get podified MariaDB service cluster IP
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get -o yaml pod mariadb-openstack | grep podIP: | awk '{ print $2; }'
+    oc get svc --selector "cr=mariadb-openstack" -ojsonpath='{.items[0].spec.clusterIP}'
   register: podified_mariadb_ip_result
 
 - name: get podified cell1 MariaDB IP
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get -o yaml pod mariadb-openstack-cell1 | grep podIP: | awk '{ print $2; }'
+    oc get svc --selector "cr=mariadb-openstack-cell1" -ojsonpath='{.items[0].spec.clusterIP}'
   register: podified_cell1_mariadb_ip_result
 
 - name: set MariaDB copy shell vars


### PR DESCRIPTION
Filtered pod IP may change, if pod restarts. Use the service cluster IP which never changes.