### PR TITLE
Override default rabbmitq image for periodic CI

### DIFF
--- a/tests/roles/backend_services/templates/container_overrides.j2
+++ b/tests/roles/backend_services/templates/container_overrides.j2
@@ -79,3 +79,9 @@ spec:
     template:
       containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-placement-api:{{ container_tag }}
 
+  rabbitmq:
+    templates:
+      rabbitmq:
+        image: {{ container_registry }}/{{ container_namespace }}/openstack-rabbitmq:{{ container_tag }}
+      rabbitmq-cell1:
+        image: {{ container_registry }}/{{ container_namespace }}/openstack-rabbitmq:{{ container_tag }}


### PR DESCRIPTION
This adds the rabbmitmq and rabbmitmq-cell1 image override so we use the right registry, namespace and tag under test in the periodic job.