### PR TITLE
Use cluster service network IPs for OVN sb/nb and switch from podman and hostpath to oc run/exec and pvc

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -19,6 +19,7 @@
 - name: Adoption
   hosts: local
   gather_facts: false
+  force_handlers: true
   module_defaults:
     ansible.builtin.shell:
       executable: /bin/bash

--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -1,1 +1,3 @@
-ovn_copy_tmp_dir: tmp/ovn
+ovn_image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
+storage_class_name: crc-csi-hostpath-provisioner
+storage_reclaim_policy: delete

--- a/tests/roles/ovn_adoption/handlers/main.yaml
+++ b/tests/roles/ovn_adoption/handlers/main.yaml
@@ -1,0 +1,6 @@
+- name: delete adoption helper pod and pvc
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc delete pod ovn-copy-data
+    {% if storage_reclaim_policy.lower() == "delete" %}oc delete pvc ovn-data{% endif %}

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -29,37 +29,104 @@
   retries: 60
   delay: 2
 
-- name: get podified OVN NB ovsdb-server IP
+# NOTE: w/o pods readiness gates, a service IP is not immediately comes in, so we wait
+- name: get podified OVN NB ovsdb-server service cluster IP
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get pod ovsdbserver-nb-0 -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | \
-    jq 'map(. | select(.name=="openstack/internalapi"))[0].ips[0]' | \
-    tr -d '"'
+    oc get svc --selector "statefulset.kubernetes.io/pod-name=ovsdbserver-nb-0" -ojsonpath='{.items[0].spec.clusterIP}'
   register: podified_ovn_nb_ip_result
+  until: podified_ovn_nb_ip_result is success
+  retries: 10
+  delay: 2
 
 - name: get podified OVN SB ovsdb-server IP
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get pod ovsdbserver-sb-0 -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | \
-    jq 'map(. | select(.name=="openstack/internalapi"))[0].ips[0]' | \
-    tr -d '"'
+    oc get svc --selector "statefulset.kubernetes.io/pod-name=ovsdbserver-sb-0" -ojsonpath='{.items[0].spec.clusterIP}'
   register: podified_ovn_sb_ip_result
+  until: podified_ovn_sb_ip_result is success
+  retries: 10
+  delay: 2
 
 - name: set OVN copy shell vars
   no_log: "{{ use_no_log }}"
   ansible.builtin.set_fact:
     ovn_copy_shell_vars: |
+      STORAGE_CLASS={{ storage_class_name }}
       PODIFIED_OVSDB_NB_IP={{ podified_ovn_nb_ip_result.stdout }}
       PODIFIED_OVSDB_SB_IP={{ podified_ovn_sb_ip_result.stdout }}
-      OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
+      OVSDB_IMAGE={{ ovn_image }}
 
       SOURCE_OVSDB_IP={{ source_ovndb_ip }}
 
       CONTROLLER1_SSH="{{ controller1_ssh }}"
       CONTROLLER2_SSH="{{ controller2_ssh }}"
       CONTROLLER3_SSH="{{ controller3_ssh }}"
+
+- name: start an adoption helper pod
+  ansible.builtin.shell: |-
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ ovn_copy_shell_vars }}
+
+    oc apply -f - <<EOF
+    ---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ovn-data
+      labels:
+        app: adoption
+    spec:
+      storageClassName: $STORAGE_CLASS
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ovn-copy-data
+      annotations:
+        openshift.io/scc: anyuid
+      labels:
+        app: adoption
+    spec:
+      containers:
+      - image: $OVSDB_IMAGE
+        command: [ "sh", "-c", "sleep infinity"]
+        name: adoption
+        volumeMounts:
+        - mountPath: /backup
+          name: ovn-data
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - name: ovn-data
+        persistentVolumeClaim:
+          claimName: ovn-data
+    EOF
+  changed_when: true
+  notify: delete adoption helper pod and pvc
+
+- name: wait for the pod to come up
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc wait --for condition=Ready pod/ovn-copy-data --timeout=30s
+  register: ovn_data_pod_result
+  until: ovn_data_pod_result is success
+  retries: 2
+  delay: 6
 
 - name: stop northd service
   no_log: "{{ use_no_log }}"
@@ -79,12 +146,8 @@
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
 
-    mkdir -p {{ ovn_copy_tmp_dir }}
-    cd {{ ovn_copy_tmp_dir }}
-
-    client="podman run -i --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $OVSDB_IMAGE ovsdb-client"
-    ${client} backup tcp:$SOURCE_OVSDB_IP:6641 > ovs-nb.db
-    ${client} backup tcp:$SOURCE_OVSDB_IP:6642 > ovs-sb.db
+    oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6641 > /backup/ovs-nb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6642 > /backup/ovs-sb.db"
 
 - name: upgrade OVN databases to the latest schema from podified ovsdb-servers
   no_log: "{{ use_no_log }}"
@@ -93,10 +156,8 @@
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
 
-    cd {{ ovn_copy_tmp_dir }}
-
-    podman run -it --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $OVSDB_IMAGE bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_NB_IP:6641 > ./ovs-nb.ovsschema && ovsdb-tool convert ovs-nb.db ./ovs-nb.ovsschema"
-    podman run -it --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $OVSDB_IMAGE bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_SB_IP:6642 > ./ovs-sb.ovsschema && ovsdb-tool convert ovs-sb.db ./ovs-sb.ovsschema"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_NB_IP:6641 > /backup/ovs-nb.ovsschema && ovsdb-tool convert /backup/ovs-nb.db /backup/ovs-nb.ovsschema"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_SB_IP:6642 > /backup/ovs-sb.ovsschema && ovsdb-tool convert /backup/ovs-sb.db /backup/ovs-sb.ovsschema"
 
 - name: restore OVN database backups to podified ovsdb-servers
   no_log: "{{ use_no_log }}"
@@ -105,10 +166,8 @@
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
 
-    cd {{ ovn_copy_tmp_dir }}
-
-    podman run -it --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $OVSDB_IMAGE bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_NB_IP:6641 < ovs-nb.db"
-    podman run -it --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $OVSDB_IMAGE bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_SB_IP:6642 < ovs-sb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
 
 - name: deploy podified OVN northd service to keep databases in sync
   ansible.builtin.shell: |

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -3,6 +3,9 @@ install_yamls_path: ~/install_yamls #CUSTOMIZE_THIS
 # Whether to use 'make crc_storage_cleanup; make crc_storage' before the test
 reset_crc_storage: true
 
+storage_class_name: crc-csi-hostpath-provisioner #CUSTOMIZE_THIS
+storage_reclaim_policy: delete # or retain
+
 # Snippet to get the desired 'oc' command onto $PATH.
 oc_header: |
   eval $(crc oc-env)


### PR DESCRIPTION
Pod IP may change, invalidating the automated test suit execution.
OVN DB south/north-bound endpoints should be as well accessible on
the standard k8s clusterIP services network. Use that instead of
fetching IPs on internalAPI openstack network.

Switch from podman to oc run, in order to access the clusterIP
service network. This also solves connectivity problems when
deploying openstack CR that uses isolnet, and podman fails
accessing IPs on internalAPI service network. Use storageclass
(defaults to crc-csi-hostpath-provisioner) insetad of Instead of local
host directories.

Add storage_reclaim_policy and storage_class_name ansible var to
control that PVC behavior.                                                                                                                                                       

Use force_handlers=true for the minimal test playbook so
that the handlers trigger on errors as well.

Partial JIRA https://issues.redhat.com/browse/OSPRH-365