### PR TITLE
Disable horizon adoption test temporarily due to timeout OSPCIX-82

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -32,5 +32,6 @@
     - glance_adoption
     - placement_adoption
     - cinder_adoption
-    - horizon_adoption
     - dataplane_adoption
+    # TODO(marios) enable after https://issues.redhat.com/browse/OSPCIX-82
+    # - horizon_adoption


### PR DESCRIPTION
This blocks the current-podified promotion [1]

[1] https://issues.redhat.com/browse/OSPCIX-82