### PR TITLE
Updates for Octavia adoption

### DIFF
--- a/docs/openstack/stop_openstack_services.md
+++ b/docs/openstack/stop_openstack_services.md
@@ -84,6 +84,12 @@ ServicesToStop=("tripleo_horizon.service"
                 "tripleo_glance_api.service"
                 "tripleo_neutron_api.service"
                 "tripleo_nova_api.service"
+                "tripleo_octavia_api.service"
+                "tripleo_octavia_driver_agent.service"
+                "tripleo_octavia_health_manager.service"
+                "tripleo_octavia_housekeeping.service"
+                "tripleo_octavia_rsyslog.service"
+                "tripleo_octavia_worker.service"
                 "tripleo_placement_api.service")
 
 PacemakerResourcesToStop=("openstack-cinder-volume"


### PR DESCRIPTION
- Add Octavia services to the services to stop

I was able to confirm that octavia databases get copied as part of the MariaDB data copy step already.