### PR TITLE
Remove remaining container images from test roles

### DIFF
--- a/tests/roles/backend_services/templates/container_overrides.j2
+++ b/tests/roles/backend_services/templates/container_overrides.j2
@@ -13,7 +13,7 @@ spec:
         containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-backup:{{ container_tag }}
       cinderVolumes:
         volume1:
-            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-volume:{{ container_tag }}
+          containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-volume:{{ container_tag }}
 
   glance:
     template:
@@ -42,7 +42,7 @@ spec:
         containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-manila-scheduler:{{ container_tag }}
       manilaShares:
         volume1:
-            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-manila-share:{{ container_tag }}
+          containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-manila-share:{{ container_tag }}
 
   mariadb:
     templates:
@@ -71,9 +71,11 @@ spec:
         ovsContainerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-base:{{ container_tag }}
       ovnDBCluster:
         ovndbcluster-nb:
-            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-nb-db-server:{{ container_tag }}
+          containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-nb-db-server:{{ container_tag }}
         ovndbcluster-sb:
-            containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-sb-db-server:{{ container_tag }}
+          containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-sb-db-server:{{ container_tag }}
+      ovnNorthd:
+        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-ovn-northd:{{ container_tag }}
 
   placement:
     template:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -40,7 +40,6 @@
         enabled: true
         template:
           databaseInstance: openstack
-          containerImage: {{ container_registry|default("quay.io") }}/{{ container_namespace|default("podified-antelope-centos9") }}/openstack-glance-api:{{ container_tag | default("current-podified") }}
           customServiceConfig: |
             [DEFAULT]
             enabled_backends=default_backend:rbd

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -121,7 +121,6 @@
         enabled: true
         template:
           ovnNorthd:
-            containerImage: {{ container_registry|default("quay.io") }}/{{ container_namespace|default("podified-antelope-centos9") }}/openstack-ovn-northd:{{ container_tag | default("current-podified") }}
             networkAttachment: internalapi
             replicas: 1
     '


### PR DESCRIPTION
The two containerImage parameters removed here are the only ones remaining in the test roles. For normal usage, this is defaulted in the operators and we shouldn't need to set it.

For periodic CI, these values are overriden with particular non-latest container URLs via the kustomization mechanism.

So i think these shouldn't be necessary and can be removed too.

Related:

https://github.com/openstack-k8s-operators/data-plane-adoption/issues/110 https://github.com/openstack-k8s-operators/data-plane-adoption/pull/165