### PR TITLE
Add docs for Ironic dev/test adoption env

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ Perform the actions from the sub-documents in the following order:
 
 * [Dataplane adoption](openstack/edpm_adoption.md)
 
+* [Ironic adoption](openstack/ironic_adoption.md)
+
 If you face issues during adoption, check the
 [Troubleshooting](openstack/troubleshooting.md) document for common
 problems and solutions.

--- a/docs/openstack/ironic_adoption.md
+++ b/docs/openstack/ironic_adoption.md
@@ -1,0 +1,20 @@
+## Prerequisites
+
+* Previous Adoption steps completed. Notably, the service databases
+  must already be imported into the podified MariaDB.
+
+## Variables
+
+(There are no shell variables necessary currently.)
+
+## Pre-checks
+
+**TODO**
+
+## Procedure - Ironic adoption
+
+**TODO**
+
+## Post-checks
+
+**TODO**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - openstack/horizon_adoption.md
     - openstack/edpm_adoption.md
     - openstack/troubleshooting.md
+    - openstack/ironic_adoption.md
   - Ceph:
     - Ceph RBD migration: ceph/ceph_rbd.md
     - Ceph RGW migration: ceph/ceph_rgw.md


### PR DESCRIPTION
Add a section in development_environment.md with instructions to set up virtual baremetal VMs and deploy EDPM TripleO standalone with ironic as the compute driver.

Also add a bolierplate ironic_adoption.md <- TODO!