### PR TITLE
Use openstackdataplanenodeset in cleanup

### DIFF
--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -3,7 +3,7 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc delete --wait=false openstackdataplane/openstack || true
+    oc delete --wait=false openstackdataplanedeployment/openstack || true
     oc delete --wait=false openstackcontrolplane/openstack || true
     oc patch openstackcontrolplane openstack --type=merge --patch '
     metadata:


### PR DESCRIPTION
The pcp_cleanup role still uses the openstackdataplane kind, which was
replaced by openstackdataplanenodeset. This changes corrects it for the
case where the tests are run again in the same environment.

EDIT: I got wrong the replacement kind, should be `OpenStackDataPlaneDeployment`, updated the PR.