### PR TITLE
Use service selector for openstackclient pod

### DIFF
--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -37,7 +37,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get pod --selector=app=openstackclient -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    oc get pod --selector=service=openstackclient -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
   register: osc_running_result
   until: osc_running_result is success
   retries: 60


### PR DESCRIPTION
Recently the openstackclient pod moved to using app to service as
a selector, this change updates the check in the tests to use the right
label.

It appears this change in openstack-operator was the trigger:
https://github.com/openstack-k8s-operators/openstack-operator/pull/502
