### PR TITLE
Move glance to the new API definition

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -150,8 +150,7 @@ podified OpenStack control plane services.
     glance:
       enabled: false
       template:
-        glanceAPIInternal: {}
-        glanceAPIExternal: {}
+        glanceAPI: {}
 
     horizon:
       enabled: false

--- a/docs/openstack/glance_adoption.md
+++ b/docs/openstack/glance_adoption.md
@@ -42,7 +42,7 @@ spec:
       databaseInstance: openstack
       storageClass: "local-storage"
       storageRequest: 10G
-      glanceAPIInternal:
+      glanceAPI:
         override:
           service:
             metadata:
@@ -52,9 +52,6 @@ spec:
                 metallb.universe.tf/loadBalancerIPs: 172.17.0.80
             spec:
               type: LoadBalancer
-        networkAttachments:
-        - storage
-      glanceAPIExternal:
         networkAttachments:
         - storage
 '
@@ -90,7 +87,7 @@ spec:
         store_description=Ceph glance store backend.
       storageClass: "local-storage"
       storageRequest: 10G
-      glanceAPIInternal:
+      glanceAPI:
         override:
           service:
             metadata:
@@ -100,9 +97,6 @@ spec:
                 metallb.universe.tf/loadBalancerIPs: 172.17.0.80
             spec:
               type: LoadBalancer
-        networkAttachments:
-        - storage
-      glanceAPIExternal:
         networkAttachments:
         - storage
 EOF

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -34,8 +34,7 @@ spec:
   glance:
     enabled: false
     template:
-      glanceAPIInternal: {}
-      glanceAPIExternal: {}
+      glanceAPI: {}
 
   horizon:
     enabled: false

--- a/tests/config/periodic_ci/container_image_overrides.yaml
+++ b/tests/config/periodic_ci/container_image_overrides.yaml
@@ -32,8 +32,7 @@ spec:
   glance:
     enabled: false
     template:
-      glanceAPIInternal: {}
-      glanceAPIExternal: {}
+      glanceAPI: {}
 
   horizon:
     enabled: false

--- a/tests/roles/backend_services/templates/container_overrides.j2
+++ b/tests/roles/backend_services/templates/container_overrides.j2
@@ -17,9 +17,7 @@ spec:
 
   glance:
     template:
-      glanceAPIInternal:
-        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
-      glanceAPIExternal:
+      glanceAPI:
         containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
 
   horizon:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -12,7 +12,7 @@
           databaseInstance: openstack
           storageClass: "local-storage"
           storageRequest: 10G
-          glanceAPIInternal:
+          glanceAPI:
             override:
               service:
                 metadata:
@@ -22,9 +22,6 @@
                     metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                 spec:
                   type: LoadBalancer
-            networkAttachments:
-            - storage
-          glanceAPIExternal:
             networkAttachments:
             - storage
     '
@@ -52,7 +49,7 @@
             store_description=Ceph glance store backend.
           storageClass: "local-storage"
           storageRequest: 10G
-          glanceAPIInternal:
+          glanceAPI:
             override:
               service:
                 metadata:
@@ -62,9 +59,6 @@
                     metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                 spec:
                   type: LoadBalancer
-            networkAttachments:
-            - storage
-          glanceAPIExternal:
             networkAttachments:
             - storage
     '


### PR DESCRIPTION
`GlanceAPI` has been simplified by patches [1][2], and the implication of those patches is a change in the `CRD` used to define the `glanceAPI` service.
This patch aligns both the existing documentation and the test suite to work with the new way of deploying glance.

** **Marking as a draft as [1] and [2] are still under review** **

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/329
[2] https://github.com/openstack-k8s-operators/openstack-operator/pull/514