### PR TITLE
Document Manila service adoption

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ Perform the actions from the sub-documents in the following order:
 
 * [Cinder adoption](openstack/cinder_adoption.md)
 
+* [Manila adoption](openstack/manila_adoption.md)
+
 * [Horizon adoption](openstack/horizon_adoption.md)
 
 * [Dataplane adoption](openstack/edpm_adoption.md)

--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -53,13 +53,14 @@ podified OpenStack control plane services.
   ```
   CINDER_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' CinderPassword:' | awk -F ': ' '{ print $2; }')
   GLANCE_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' GlancePassword:' | awk -F ': ' '{ print $2; }')
+  HEAT_AUTH_ENCRYPTION_KEY=$(cat ~/tripleo-standalone-passwords.yaml | grep ' HeatAuthEncryptionKey:' | awk -F ': ' '{ print $2; }')
+  HEAT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' HeatPassword:' | awk -F ': ' '{ print $2; }')
   IRONIC_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' IronicPassword:' | awk -F ': ' '{ print $2; }')
+  MANILA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' ManilaPassword:' | awk -F ': ' '{ print $2; }')
   NEUTRON_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' NeutronPassword:' | awk -F ': ' '{ print $2; }')
   NOVA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' NovaPassword:' | awk -F ': ' '{ print $2; }')
   OCTAVIA_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' OctaviaPassword:' | awk -F ': ' '{ print $2; }')
   PLACEMENT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' PlacementPassword:' | awk -F ': ' '{ print $2; }')
-  HEAT_AUTH_ENCRYPTION_KEY=$(cat ~/tripleo-standalone-passwords.yaml | grep ' HeatAuthEncryptionKey:' | awk -F ': ' '{ print $2; }')
-  HEAT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' HeatPassword:' | awk -F ': ' '{ print $2; }')
   ```
 
 ## Pre-checks
@@ -97,13 +98,14 @@ podified OpenStack control plane services.
   ```
   oc set data secret/osp-secret "CinderPassword=$CINDER_PASSWORD"
   oc set data secret/osp-secret "GlancePassword=$GLANCE_PASSWORD"
+  oc set data secret/osp-secret "HeatAuthEncryptionKey=$HEAT_AUTH_ENCRYPTION_KEY"
+  oc set data secret/osp-secret "HeatPassword=$HEAT_PASSWORD"
   oc set data secret/osp-secret "IronicPassword=$IRONIC_PASSWORD"
+  oc set data secret/osp-secret "ManilaPassword=$MANILA_PASSWORD"
   oc set data secret/osp-secret "NeutronPassword=$NEUTRON_PASSWORD"
   oc set data secret/osp-secret "NovaPassword=$NOVA_PASSWORD"
   oc set data secret/osp-secret "OctaviaPassword=$OCTAVIA_PASSWORD"
   oc set data secret/osp-secret "PlacementPassword=$PLACEMENT_PASSWORD"
-  oc set data secret/osp-secret "HeatPassword=$HEAT_PASSWORD"
-  oc set data secret/osp-secret "HeatAuthEncryptionKey=$HEAT_AUTH_ENCRYPTION_KEY"
   ```
 
 * Deploy OpenStackControlPlane. **Make sure to only enable DNS,

--- a/docs/openstack/ceph_backend_configuration.md
+++ b/docs/openstack/ceph_backend_configuration.md
@@ -19,7 +19,18 @@ CEPH_KEY=$($CEPH_SSH "cat /etc/ceph/ceph.client.openstack.keyring | base64 -w 0"
 CEPH_CONF=$($CEPH_SSH "cat /etc/ceph/ceph.conf | base64 -w 0")
 ```
 
-## Procedure - Ceph backend configuration
+## Modify capabilities of the "openstack" user to accommodate Manila
+
+On TripleO environments, the CephFS driver in Manila is configured to use 
+its own keypair. For convenience, let's modify the `openstack` user so that we 
+can use it across all OpenStack services.
+
+```
+$CEPH_SSH cephadm shell
+ceph auth caps client.openstack mgr 'allow *' mon 'allow r, profile rbd' osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, allow rw pool manila_data'
+```
+
+## Ceph backend configuration
 
 Create the `ceph-conf-files` secret, containing Ceph configuration:
 
@@ -72,6 +83,7 @@ spec:
           - CinderVolume
           - CinderBackup
           - GlanceAPI
+          - ManilaShare
           extraVolType: Ceph
           volumes:
           - name: ceph

--- a/docs/openstack/ceph_backend_configuration.md
+++ b/docs/openstack/ceph_backend_configuration.md
@@ -1,7 +1,7 @@
 # Ceph backend configuration (if applicable)
 
 If the original deployment uses a Ceph storage backend for any service
-(e.g. Glance, Cinder, Nova), the same backend must be used in the
+(e.g. Glance, Cinder, Nova, Manila), the same backend must be used in the
 adopted deployment and CRs must be configured accordingly.
 
 ## Prerequisites
@@ -25,9 +25,18 @@ On TripleO environments, the CephFS driver in Manila is configured to use
 its own keypair. For convenience, let's modify the `openstack` user so that we 
 can use it across all OpenStack services.
 
+Using the same user across the services serves two purposes:
+- The capabilities of the user required to interact with the Manila service 
+  became far simpler and hence, more became more secure with RHOSP 18.
+- It is simpler to create a common ceph secret (keyring and ceph config 
+  file) and propagate the secret to all services that need it.
+
 ```
 $CEPH_SSH cephadm shell
-ceph auth caps client.openstack mgr 'allow *' mon 'allow r, profile rbd' osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, allow rw pool manila_data'
+ceph auth caps client.openstack \
+  mgr 'allow *' \
+  mon 'allow r, profile rbd' \
+  osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, allow rw pool manila_data'
 ```
 
 ## Ceph backend configuration

--- a/docs/openstack/cinder_adoption.md
+++ b/docs/openstack/cinder_adoption.md
@@ -450,7 +450,7 @@ available in the w [OpenStack Cinder ecosystem
 page](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20OpenStack%20Platform&p=1&functionalCategories=Data%20storage)
 and add it under the specific's driver section using the `containerImage` key.
 For example, if we had a Pure Storage array and the driver was already certified
-for OSP18, then we would have something like this:
+for OSP1, then we would have something like this:
 
    ```yaml
    spec:

--- a/docs/openstack/cinder_adoption.md
+++ b/docs/openstack/cinder_adoption.md
@@ -450,7 +450,7 @@ available in the w [OpenStack Cinder ecosystem
 page](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20OpenStack%20Platform&p=1&functionalCategories=Data%20storage)
 and add it under the specific's driver section using the `containerImage` key.
 For example, if we had a Pure Storage array and the driver was already certified
-for OSP1, then we would have something like this:
+for OSP18, then we would have something like this:
 
    ```yaml
    spec:

--- a/docs/openstack/keystone_adoption.md
+++ b/docs/openstack/keystone_adoption.md
@@ -48,7 +48,7 @@
   ```bash
   openstack endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
 
-  for service in cinderv3 glance neutron nova placement swift; do
+  for service in cinderv3 glance manila manilav2 neutron nova placement swift; do
     openstack service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
   done
   ```

--- a/docs/openstack/manila_adoption.md
+++ b/docs/openstack/manila_adoption.md
@@ -42,7 +42,7 @@ manager service needs to be able to reach it.
 * Ensure that services such as [keystone](keystone_adoption.md) 
   and [memcached](backend_services_deployment.md) are available prior to 
   adopting manila services.
-* If tenant-driven networking was enabled (``driver_handles_share_servers=True`),
+* If tenant-driven networking was enabled (`driver_handles_share_servers=True`),
   ensure that [neutron](neutron_adoption.md) has been deployed prior to 
   adopting manila services.
 
@@ -83,31 +83,31 @@ environment:
 
 ```yaml
   spec:
-     manila:
-       enabled: true
-       template:
-         manilaAPI:
-           customServiceConfig: |
-              [oslo_policy]
-              policy_file=/etc/manila/policy.yaml
-         extraMounts:
-         - extraVol:
-           - extraVolType: Undefined
-             mounts:
-             - mountPath: /etc/manila/
-               name: policy
-               readOnly: true
-             propagation:
-             - ManilaAPI
-             volumes:
-             - name: policy
-               projected:
-                 sources:
-                 - configMap:
-                     name: manila-policy
-                     items:
-                       - key: policy
-                         path: policy.yaml
+    manila:
+      enabled: true
+      template:
+        manilaAPI:
+          customServiceConfig: |
+             [oslo_policy]
+             policy_file=/etc/manila/policy.yaml
+        extraMounts:
+        - extraVol:
+          - extraVolType: Undefined
+            mounts:
+            - mountPath: /etc/manila/
+              name: policy
+              readOnly: true
+            propagation:
+            - ManilaAPI
+            volumes:
+            - name: policy
+              projected:
+                sources:
+                - configMap:
+                    name: manila-policy
+                    items:
+                      - key: policy
+                        path: policy.yaml
 
 ```
 - The Manila API service needs the `enabled_share_protocols` option to be 
@@ -156,7 +156,7 @@ environment:
              enabled_share_backends=pure-1
              [pure-1]
              driver_handles_share_servers = False
-             share_backend_name = pure
+             share_backend_name = pure-1
              share_driver = manila.share.drivers.purestorage.flashblade.FlashBladeShareDriver
              flashblade_mgmt_vip = 203.0.113.15
              flashblade_data_vip = 203.0.10.14

--- a/docs/openstack/manila_adoption.md
+++ b/docs/openstack/manila_adoption.md
@@ -1,16 +1,226 @@
 # Manila adoption
 
-WIP
+OpenStack Manila is the Shared File Systems service. It provides OpenStack 
+users with a self-service API to create and manage file shares. File 
+shares (or simply, "shares"), are built for concurrent read/write access by 
+any number of clients. This, coupled with the inherent elasticity of the 
+underlying storage makes the Shared File Systems service essential in
+cloud environments with require RWX ("read write many") persistent storage.
+
+# Networking
+
+File shares in OpenStack are accessed directly over a network. Hence, it is
+essential to plan the networking of the cloud to create a successful and 
+sustainable orchestration layer for shared file systems.
+
+Manila supports two levels of storage networking abstractions - one where 
+users can directly control the networking for their respective file shares; 
+and another where the storage networking is configured by the OpenStack 
+administrator. It is important to ensure that the networking in the Red Hat 
+OpenStack Platform 17.1 matches your network plans for your new cloud after 
+adoption. This ensures that tenant workloads remain connected to 
+storage through the adoption process, even as the control plane suffers a 
+minor interruption. Manila's control plane services are not in the data 
+path; and shutting down the API, scheduler and share manager services will 
+not impact access to existing shared file systems.
+
+Typically, storage and storage device management networks are separate. 
+Manila services only need access to the storage device management network. 
+For example, if a Ceph cluster was used in the deployment, the "storage" 
+network refers to the Ceph cluster's public network, and Manila's share 
+manager service needs to be able to reach it.
 
 ## Prerequisites
 
-WIP
+* Ensure that manila systemd services (api, cron, scheduler) are 
+  [stopped](stop_openstack_services.md#stopping-control-plane-services).
+* Ensure that manila pacemaker services ("openstack-manila-share") are 
+  [stopped](stop_openstack_services.md#stopping-control-plane-services).
+* Ensure that the [database migration](mariadb_copy.md) has completed.
+* Ensure that OpenShift nodes where `manila-share` service will be deployed 
+  can reach the management network that the storage system is in.
+* Ensure that services such as [keystone](keystone_adoption.md) 
+  and [memcached](backend_services_deployment.md) are available prior to 
+  adopting manila services.
+* If tenant-driven networking was enabled (``driver_handles_share_servers=True`),
+  ensure that [neutron](neutron_adoption.md) has been deployed prior to 
+  adopting manila services.
 
-## Procedure - Neutron adoption
+## Procedure - Manila adoption
 
-As already done for [Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md), the Neutron Adoption follows the same pattern.
+### Copying configuration from the RHOSP 17.1 deployment
 
-Patch OpenStackControlPlane to deploy Manila:
+Define the `CONTROLLER1_SSH` environment variable, if it [hasn't been 
+defined](stop_openstack_services.md#variables) already. Then copy the 
+configuration file from RHOSP 17.1 for reference.
+
+```
+$CONTROLLER1_SSH cat /var/lib/config-data/puppet-generated/manila/etc/manila/manila.conf | awk '!/^ *#/ && NF' > ~/manila.conf
+```
+
+Review this configuration, alongside any configuration changes that were noted
+since RHOSP 17.1. Not all of it makes sense to bring into the new cloud 
+environment:
+
+<!--- TODO link config diff tables for RHOSP 17.1 (Wallaby) to RHOSP 18 (Antelope) --->
+
+- The manila operator is capable of setting up database related configuration
+  (`[database]`), service authentication (`auth_strategy`,
+  `[keystone_authtoken]`), message bus configuration 
+  (`transport_url`, `control_exchange`), the default paste config
+  (`api_paste_config`) and inter-service communication configuration (`
+  [neutron]`, `[nova]`, `[cinder]`, `[glance]` `[oslo_messaging_*]`). So 
+  all of these can be ignored.
+- Ignore the `osapi_share_listen` configuration. In RHOSP 18, we rely on 
+  OpenShift's routes and ingress.
+- Pay attention to policy overrides. In RHOSP 18, manila ships with a secure 
+  default RBAC, and overrides may not be necessary. Please review RBAC 
+  defaults by using the [Oslo policy generator](https://docs.openstack.org/oslo.policy/latest/cli/oslopolicy-policy-generator.html)
+  tool. If a custom policy is necessary, you must provide it either as a 
+  `ConfigMap`. The following sample configuration illustrates how a 
+  `ConfigMap` called `manila-policy` can be set up with the contents of a 
+  file called `policy.yaml`.
+
+```yaml
+  spec:
+     manila:
+       enabled: true
+       template:
+         manilaAPI:
+           customServiceConfig: |
+              [oslo_policy]
+              policy_file=/etc/manila/policy.yaml
+         extraMounts:
+         - extraVol:
+           - extraVolType: Undefined
+             mounts:
+             - mountPath: /etc/manila/
+               name: policy
+               readOnly: true
+             propagation:
+             - ManilaAPI
+             volumes:
+             - name: policy
+               projected:
+                 sources:
+                 - configMap:
+                     name: manila-policy
+                     items:
+                       - key: policy
+                         path: policy.yaml
+
+```
+- The Manila API service needs the `enabled_share_protocols` option to be 
+  added in the `customServiceConfig` section in `manila: template: manilaAPI`.
+- If you had scheduler overrides, add them to the `customServiceConfig` 
+  section in `manila: template: manilaScheduler`.
+- If you had multiple storage backend drivers configured with RHOSP 17.1, 
+  you will need to split them up when deploying RHOSP 18. Each storage 
+  backend driver needs to use its own instance of the `manila-share` 
+  service.
+- If a storage backend driver needs a custom container image, find it on the 
+  [RHOSP Ecosystem Catalog](https://catalog.redhat.com/software/containers/search?gs&q=manila)
+  and set `manila: template: manilaShares: <custom name> : containerImage` 
+  value. The following example illustrates multiple storage backend drivers, 
+  using custom container images.
+
+```yaml
+  spec:
+    manila:
+      enabled: true
+      template:
+        manilaAPI:
+          replicas: 2
+        manilaScheduler:
+          replicas: 3
+        manilaShares:
+         netapp:
+           customServiceConfig: |
+             [DEFAULT]
+             debug = true
+             enabled_share_backends=netapp
+             [netapp]
+             driver_handles_share_servers=False
+             share_backend_name=netapp
+             share_driver=manila.share.drivers.netapp.common.NetAppDriver
+             netapp_storage_family=ontap_cluster
+             netapp_transport_type=http
+           replicas: 1
+         pure:
+            customServiceConfig: |
+             [DEFAULT]
+             debug = true
+             enabled_share_backends=pure-1
+             [pure-1]
+             driver_handles_share_servers=False
+             share_backend_name=pure
+             share_driver=manila.share.drivers.purestorage.flashblade.FlashBladeShareDriver
+             flashblade_mgmt_vip=10.1.2.3
+             flashblade_data_vip=10.1.2.4
+            containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
+            replicas: 1
+```
+
+- If providing sensitive information, such as passwords, hostnames and 
+  usernames, it is recommended to use OpenShift secrets, and the
+  `customServiceConfigSecrets` key. An example:
+
+```shell
+
+cat << __EOF__ > ~/netapp_secrets.conf
+
+[netapp]
+netapp_server_hostname = 203.0.113.10
+netapp_login = fancy_netapp_user
+netapp_password = secret_netapp_password
+netapp_vserver = mydatavserver
+__EOF__
+
+oc create secret generic osp-secret-manila-netapp --from-file=~/netapp_secrets.conf -n openstack
+```
+
+- `customConfigSecrets` can be used in any service, the following is a 
+  config example using the secret we created as above. 
+
+```yaml
+  spec:
+    manila:
+      enabled: true
+      template:
+        < . . . >
+        manilaShares:
+         netapp:
+           customServiceConfig: |
+             [DEFAULT]
+             debug = true
+             enabled_share_backends=netapp
+             [netapp]
+             driver_handles_share_servers=False
+             share_backend_name=netapp
+             share_driver=manila.share.drivers.netapp.common.NetAppDriver
+             netapp_storage_family=ontap_cluster
+             netapp_transport_type=http
+           customServiceConfigSecrets:
+             - osp-secret-manila-netapp
+           replicas: 1
+    < . . . >
+```
+
+- If you need to present extra files to any of the services, you can use 
+  `extraMounts`. For example, when using ceph, you'd need Manila's ceph 
+  user's keyring file as well as the `ceph.conf` configuration file 
+  available. These are mounted via `extraMounts` as done with the example 
+  below.
+- Ensure that the names of the backends (`share_backend_name`) remain as they 
+  did on RHOSP 17.1.
+- It is recommended to set the replica count of the `manilaAPI` service and 
+  the `manilaScheduler` service to 3. You should ensure to set the replica 
+  count of the `manilaShares` service/s to 1.   
+
+### Deploying the manila control plane 
+
+Patch OpenStackControlPlane to deploy Manila; here's an example that uses 
+Native CephFS:
 
 ```
 cat << __EOF__ > ~/manila.patch
@@ -35,21 +245,21 @@ spec:
                 type: LoadBalancer
     template:
       manilaAPI:
-        replicas: 1
+        replicas: 3
         customServiceConfig: |
           [DEFAULT]
           enabled_share_protocols = cephfs
       manilaScheduler:
-        replicas: 1
+        replicas: 3
       manilaShares:
-        share1:
+        cephfs:
           replicas: 1
           customServiceConfig: |
             [DEFAULT]
-            enabled_share_backends = cephfs
-            [cephfs]
+            enabled_share_backends = tripleo_ceph
+            [tripleo_ceph]
             driver_handles_share_servers=False
-            share_backend_name=cephfs
+            share_backend_name=tripleo_ceph
             share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
             cephfs_conf_path=/etc/ceph/ceph.conf
             cephfs_auth_id=openstack
@@ -57,7 +267,6 @@ spec:
             cephfs_volume_mode=0755
             cephfs_protocol_helper_type=CEPHFS
 __EOF__
-
 
 oc patch openstackcontrolplane openstack --type=merge --patch-file=~/manila.patch
 ```

--- a/docs/openstack/manila_adoption.md
+++ b/docs/openstack/manila_adoption.md
@@ -1,0 +1,110 @@
+# Manila adoption
+
+WIP
+
+## Prerequisites
+
+WIP
+
+## Procedure - Neutron adoption
+
+As already done for [Keystone](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md), the Neutron Adoption follows the same pattern.
+
+Patch OpenStackControlPlane to deploy Manila:
+
+```
+cat << __EOF__ > ~/manila.patch
+spec:
+  manila:
+    enabled: true
+    apiOverride:
+      route: {}
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      manilaAPI:
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+    template:
+      manilaAPI:
+        replicas: 1
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_share_protocols = cephfs
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          replicas: 1
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_share_backends = cephfs
+            [cephfs]
+            driver_handles_share_servers=False
+            share_backend_name=cephfs
+            share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+            cephfs_conf_path=/etc/ceph/ceph.conf
+            cephfs_auth_id=openstack
+            cephfs_cluster_name=ceph
+            cephfs_volume_mode=0755
+            cephfs_protocol_helper_type=CEPHFS
+__EOF__
+
+
+oc patch openstackcontrolplane openstack --type=merge --patch-file=~/manila.patch
+```
+
+## Post-checks
+
+### Inspect the resulting manila service pods
+
+```bash
+oc get pods -l service=manila 
+```
+
+### Check that Manila API service is registered in Keystone
+
+```bash
+openstack service list | grep manila
+```
+
+```bash
+openstack endpoint list | grep manila
+
+| 1164c70045d34b959e889846f9959c0e | regionOne | manila       | share        | True    | internal  | http://manila-internal.openstack.svc:8786/v1/%(project_id)s        |
+| 63e89296522d4b28a9af56586641590c | regionOne | manilav2     | sharev2      | True    | public    | https://manila-public-openstack.apps-crc.testing/v2                |
+| af36c57adcdf4d50b10f484b616764cc | regionOne | manila       | share        | True    | public    | https://manila-public-openstack.apps-crc.testing/v1/%(project_id)s |
+| d655b4390d7544a29ce4ea356cc2b547 | regionOne | manilav2     | sharev2      | True    | internal  | http://manila-internal.openstack.svc:8786/v2                       |
+```
+
+### Verify resources
+
+We can now test the health of the service
+
+```bash
+openstack share service list
+openstack share pool list --detail
+```
+
+We can check on existing workloads
+
+```bash
+openstack share list
+openstack share snapshot list
+```
+
+We can create further resources
+```bash
+openstack share create cephfs 10 --snapshot mysharesnap --name myshareclone
+```
+
+
+

--- a/docs/openstack/manila_adoption.md
+++ b/docs/openstack/manila_adoption.md
@@ -219,6 +219,9 @@ oc create secret generic osp-secret-manila-netapp --from-file=~/netapp_secrets.c
 - It is recommended to set the replica count of the `manilaAPI` service and 
   the `manilaScheduler` service to 3. You should ensure to set the replica 
   count of the `manilaShares` service/s to 1.   
+- Ensure that the appropriate storage management network is specified in the 
+  `manilaShares` section. The example below connects the `manilaShares` 
+  instance with the CephFS backend driver to the `storage` network. 
 
 ### Deploying the manila control plane 
 
@@ -269,6 +272,8 @@ spec:
             cephfs_cluster_name=ceph
             cephfs_volume_mode=0755
             cephfs_protocol_helper_type=CEPHFS
+          networkAttachments:
+              - storage
 __EOF__
 ```
 

--- a/docs/openstack/stop_openstack_services.md
+++ b/docs/openstack/stop_openstack_services.md
@@ -51,6 +51,7 @@ etc.
 openstack server list --all-projects -c ID -c Status |grep -E '\| .+ing \|'
 openstack volume list --all-projects -c ID -c Status |grep -E '\| .+ing \|'| grep -vi error
 openstack volume backup list --all-projects -c ID -c Status |grep -E '\| .+ing \|' | grep -vi error
+openstack share list --all-projects -c ID -c Status |grep -E '\| .+ing \|'| grep -vi error
 openstack image list -c ID -c Status |grep -E '\| .+ing \|'
 ```
 
@@ -82,12 +83,16 @@ ServicesToStop=("tripleo_horizon.service"
                 "tripleo_cinder_scheduler.service"
                 "tripleo_cinder_backup.service"
                 "tripleo_glance_api.service"
+                "tripleo_manila_api.service"
+                "tripleo_manila_api_cron.service"
+                "tripleo_manila_scheduler.service"
                 "tripleo_neutron_api.service"
                 "tripleo_nova_api.service"
                 "tripleo_placement_api.service")
 
 PacemakerResourcesToStop=("openstack-cinder-volume"
-                          "openstack-cinder-backup")
+                          "openstack-cinder-backup"
+                          "openstack-manila-share")
 
 echo "Stopping systemd OpenStack services"
 for service in ${ServicesToStop[*]}; do

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - openstack/placement_adoption.md
     - openstack/cinder_adoption.md
     - openstack/horizon_adoption.md
+    - openstack/manila_adoption.md
     - openstack/edpm_adoption.md
     - openstack/ironic_adoption.md
     - openstack/heat_adoption.md


### PR DESCRIPTION
- Document steps to tear down RHOSP 17.1 manila services, and adopt them into RHOSP 18
- Provide config samples for Native CephFS adoption

Todo in future commits:
- Ceph MDS migration (a data plane service on "integrated" ceph clusters)
- CephFS NFS migration (a data plane service when a "ceph_nfs" service was used with RHOSP 17.1) 