### PR TITLE
Remove Heat hack for keystone endpoint

### DIFF
--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -15,11 +15,6 @@
         apiOverride:
           route: {}
         template:
-          customServiceConfig: |
-            [DEFAULT]
-            debug = true
-            [keystone_authtoken]
-            insecure = true
           databaseInstance: openstack
           databaseUser: heat
           rabbitMqClusterName: rabbitmq


### PR DESCRIPTION
Heat was using the Public Keystone endpoint instead of internal. This caused issues with the self-signed certificate validation. This is fixed by: https://github.com/openstack-k8s-operators/heat-operator/pull/270

Depends-On: https://github.com/openstack-k8s-operators/heat-operator/pull/270