### PR TITLE
Nova: workloads adoption, mariadb pre-/post-checks

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -7,11 +7,17 @@ Wallaby (or OSP 17.1) OpenStack in Standalone configuration.
 
 == Environment prep
 
+Get dataplane adoption repo:
+[,bash]
+----
+git clone https://github.com/openstack-k8s-operators/data-plane-adoption.git ~/data-plane-adoption
+----
+
 Get install_yamls:
 
 [,bash]
 ----
-git clone https://github.com/openstack-k8s-operators/install_yamls.git
+git clone https://github.com/openstack-k8s-operators/install_yamls.git ~/install_yamls
 ----
 
 Install tools for operator development:
@@ -44,7 +50,7 @@ a RedFish BMC emulator.
 
 [,bash]
 ----
-cd ..  # back to install_yamls
+cd ~/install_yamls
 make nmstate
 make namespace
 cd devsetup  # back to install_yamls/devsetup
@@ -112,7 +118,7 @@ To use Wallaby content instead, run the following:
 
 [,bash]
 ----
-cd install_yamls/devsetup
+cd ~/install_yamls/devsetup
 make standalone
 ----
 
@@ -261,11 +267,20 @@ ping -c 4 $(openstack server show baremetal-test -f json -c addresses | jq -r .a
 
 '''
 
+==== Virtual Machine Steps
+
 [,bash]
 ----
-export OS_CLOUD=standalone
-source ~/install_yamls/devsetup/scripts/edpm-deploy-instance.sh
+cd ~/data-plane-adoption
+bash tests/roles/development_environment/templates/pre_launch.bash
 ----
+
+'''
+
+==== Ceph Storage Steps
+
+Make sure a cinder-volume backend is properly configured, or skip below steps
+to create a test workload without volume attachments.
 
 Confirm the image UUID can be seen in Ceph's images pool.
 

--- a/docs_user/modules/openstack-backend_services_deployment.adoc
+++ b/docs_user/modules/openstack-backend_services_deployment.adoc
@@ -9,8 +9,12 @@ podified OpenStack control plane services.
 
 == Prerequisites
 
-* The cloud which we want to adopt is up and running. It's on
+* The source cloud which we want to adopt is up and running. It's on
 OpenStack Wallaby release.
+* A VM instance named `test` is running on the source cloud and its
+floating IP is set into `FIP` env var. You can use a
+xref:../docs_dev/assemblies/development_environment.adoc#virtual-machine-steps[helper script]
+to create that test VM.
 * The `openstack-operator` is deployed, but `OpenStackControlPlane` is
 *not* deployed.
 +

--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -15,12 +15,16 @@ ____
 == Variables
 
 Define the shell variables used in the Fast-forward upgrade steps below.
+Set `FIP` to the floating IP address of the `test` VM pre-created earlier on the source cloud.
 Define the map of compute node name, IP pairs.
 The values are just illustrative, use values that are correct for your environment:
 
 [,bash]
 ----
 PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
+
+alias openstack="oc exec -t openstackclient -- openstack"
+FIP=192.168.122.20
 declare -A computes
 export computes=(
   ["standalone.localdomain"]="192.168.122.100"
@@ -428,7 +432,7 @@ ____
 +
 [,bash]
 ----
-  oc exec -it openstack-cell1-galera-0 -- mysql --user=root --password=${PODIFIED_DB_ROOT_PASSWORD} \
+  oc exec -it openstack-galera-0 -c galera -- mysql --user=root --password=${PODIFIED_DB_ROOT_PASSWORD} \
     -e "select a.version from nova_cell1.services a join nova_cell1.services b where a.version!=b.version and a.binary='nova-compute';"
 ----
 +
@@ -534,4 +538,22 @@ The above query should return an empty result as a completion criterion.
 ----
   oc exec -it nova-cell0-conductor-0 -- nova-manage db online_data_migrations
   oc exec -it nova-cell1-conductor-0 -- nova-manage db online_data_migrations
+----
+
+* Verify if Nova services con stop the existing test VM instance:
++
+[,bash]
+----
+${BASH_ALIASES[openstack]} server list | grep -qF '| test | ACTIVE |' && openstack server stop test
+${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |'
+${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test | grep "it is in power state shutdown" || echo PASS
+----
+
+* Verify if Nova services can start the existing test VM instance:
++
+[,bash]
+----
+${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |' && openstack server start test
+${BASH_ALIASES[openstack]} server list | grep -F '| test | ACTIVE |'
+${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test --fit-width -f json | jq -r '.state' | grep running
 ----

--- a/docs_user/modules/openstack-mariadb_copy.adoc
+++ b/docs_user/modules/openstack-mariadb_copy.adoc
@@ -17,6 +17,7 @@ ____
  ** The OpenStackControlPlane resource must be already created at this point.
  ** Podified MariaDB and RabbitMQ are running. No other podified
 control plane services are running.
+ ** Required services specific topology xref:openstack-pull_openstack_configuration.adoc#get-services-topology-specific-configuration[configuration collected]
  ** OpenStack services have been xref:stop_openstack_services.adoc[stopped]
  ** There must be network routability between:
   *** The adoption host and the original MariaDB.
@@ -34,39 +35,29 @@ just illustrative, use values that are correct for your environment:
 
 [,bash]
 ----
-MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
-
 PODIFIED_MARIADB_IP=$(oc get svc --selector "mariadb/name=openstack" -ojsonpath='{.items[0].spec.clusterIP}')
 PODIFIED_CELL1_MARIADB_IP=$(oc get svc --selector "mariadb/name=openstack-cell1" -ojsonpath='{.items[0].spec.clusterIP}')
 PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
-
-# Replace with your environment's MariaDB IP:
-SOURCE_MARIADB_IP=192.168.122.100
-SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
 
 # The CHARACTER_SET and collation should match the source DB
 # if the do not then it will break foreign key relationships
 # for any tables that are created in the future as part of db sync
 CHARACTER_SET=utf8
 COLLATION=utf8_general_ci
+
+MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+# Replace with your environment's MariaDB IP:
+SOURCE_MARIADB_IP=192.168.122.100
+SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
 ----
 
 == Pre-checks
 
-* Test connection to the original DB (show databases):
+* Get the count of not-OK source databases:
 +
 [,bash]
 ----
-podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
-    mysql -h "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;'
-----
-
-* Run mysqlcheck on the original DB to look for things that are not OK:
-+
-[,bash]
-----
-podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
-    mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root "-p$SOURCE_DB_ROOT_PASSWORD" | grep -v OK
+test -z "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"  || [ "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK" = " " ]
 ----
 
 * Test connection to podified DBs (show databases):
@@ -74,9 +65,9 @@ podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
 [,bash]
 ----
 oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-    mysql -h "$PODIFIED_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
+    mysql -rsh "$PODIFIED_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
 oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-    mysql -h "$PODIFIED_CELL1_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
+    mysql -rsh "$PODIFIED_CELL1_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
 ----
 
 == Procedure - data copy
@@ -163,29 +154,52 @@ EOF
     oc run ${container_name} --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
         mysql -h "${db_server}" -uroot "-p${db_password}" "${db_name}" < "${db_file}"
 done
-oc exec -it openstack-galera-0 -- mysql --user=root --password=${db_server_password_map["default"]} -e \
+oc exec -it openstack-galera-0 -c galera -- mysql --user=root --password=${db_server_password_map["default"]} -e \
     "update nova_api.cell_mappings set name='cell1' where name='default';"
-oc exec -it openstack-cell1-galera-0 -- mysql --user=root --password=${db_server_password_map["default"]} -e \
+oc exec -it openstack-cell1-galera-0 -c galera -- mysql --user=root --password=${db_server_password_map["default"]} -e \
     "delete from nova_cell1.services where host not like '%nova-cell1-%' and services.binary != 'nova-compute';"
 ----
 
 == Post-checks
 
+Compare the following outputs with the topology specific configuration
+xref:openstack-pull_openstack_configuration.adoc#get-services-topology-specific-configuration[collected earlier]:
+
 * Check that the databases were imported correctly:
 +
 [,bash]
 ----
-oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-mysql -h "${PODIFIED_MARIADB_IP}" -uroot "-p${PODIFIED_DB_ROOT_PASSWORD}" -e 'SHOW databases;' \
-    | grep keystone
+# use 'oc exec' and 'mysql -rs' to maintain formatting
+dbs=$(oc exec openstack-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+echo $dbs | grep -Eq '\bkeystone\b'
+
 # ensure neutron db is renamed from ovs_neutron
-oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-mysql -h "${PODIFIED_MARIADB_IP}" -uroot "-p${PODIFIED_DB_ROOT_PASSWORD}" -e 'SHOW databases;' \
-    | grep neutron
+echo $dbs | grep -Eq '\bneutron\b'
+echo $PULL_OPENSTACK_CONFIGURATION_DATABASES | grep -Eq '\bovs_neutron\b'
+
 # ensure nova cell1 db is extracted to a separate db server and renamed from nova to nova_cell1
-oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-mysql -h "${PODIFIED_CELL1_MARIADB_IP}" -uroot "-p${PODIFIED_DB_ROOT_PASSWORD}" -e 'SHOW databases;' \
-    | grep nova_cell1
+c1dbs=$(oc exec openstack-cell1-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+echo $c1dbs | grep -Eq '\bnova_cell1\b'
+
+# ensure default cell renamed to cell1, and the cell UUIDs retained intact
+novadb_mapped_cells=$(oc exec openstack-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" \
+  nova_api -e 'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')
+uuidf='\S{8,}-\S{4,}-\S{4,}-\S{4,}-\S{12,}'
+left_behind=$(comm -23 \
+  <(echo $PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS | grep -oE " $uuidf \S+") \
+  <(echo $novadb_mapped_cells | tr -s "| " " " | grep -oE " $uuidf \S+"))
+changed=$(comm -13 \
+  <(echo $PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS | grep -oE " $uuidf \S+") \
+  <(echo $novadb_mapped_cells | tr -s "| " " " | grep -oE " $uuidf \S+"))
+test $(grep -Ec ' \S+$' <<<$left_behind) -eq 1
+default=$(grep -E ' default$' <<<$left_behind)
+test $(grep -Ec ' \S+$' <<<$changed) -eq 1
+grep -qE " $(awk '{print $1}' <<<$default) cell1$" <<<$changed
+
+# ensure the registered Nova compute service name has not changed
+novadb_svc_records=$(oc exec openstack-cell1-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" \
+  nova_cell1 -e "select host from services where services.binary='nova-compute' order by host asc;")
+diff -Z <(echo $novadb_svc_records) <(echo $PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES)
 ----
 
 * During the pre/post checks the pod `mariadb-client` might have returned a pod security warning

--- a/docs_user/modules/openstack-nova_adoption.adoc
+++ b/docs_user/modules/openstack-nova_adoption.adoc
@@ -17,8 +17,8 @@ must already be imported into the podified MariaDB;
  ** the xref:glance_adoption.adoc[Glance service] needs to be imported;
  ** the xref:ovn_adoption.adoc[OVN DB services] need to be imported;
  ** the xref:neutron_adoption.adoc[Neutron service] needs to be imported;
- ** Required services specific topology link:pull_openstack_configuration.md#get-services-topology-specific-configuration[configuration collected];
- ** OpenStack services have been xref:stop_openstack_services.adoc[stopped]
+ ** Required services specific topology xref:openstack-pull_openstack_configuration.adoc#get-services-topology-specific-configuration[configuration collected];
+ ** OpenStack services have been xref:openstack-stop_openstack_services.adoc[stopped]
 
 == Variables
 
@@ -132,3 +132,26 @@ podified FQDNs and that Nova API responds.
 openstack endpoint list | grep nova
 openstack server list
 ----
+
+Compare the following outputs with the topology specific configuration
+xref:openstack-pull_openstack_configuration.adoc#get-services-topology-specific-configuration[collected earlier]:
+
+* Query the superconductor for cell1 existance and compare it to pre-adoption values:
++
+[,bash]
+----
+echo $PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS
+oc rsh nova-cell0-conductor-0 nova-manage cell_v2 list_cells | grep -F '| cell1 |'
+----
++
+The expected changes to happen:
+
+ ** cell1's `nova` DB and user name become `nova_cell1`.
+ ** Default cell is renamed to `cell1` (in a multi-cell setup, it should become indexed as the last cell instead).
+ ** RabbitMQ transport URL no longer uses `guest`.
+
+____
+*NOTE* At this point, Nova control plane services have yet taken control over
+existing Nova compute workloads. That would become possible to verify only after
+xref:./edpm_adoption.adoc[EDPM adoption] completed.
+____

--- a/docs_user/modules/openstack-pull_openstack_configuration.adoc
+++ b/docs_user/modules/openstack-pull_openstack_configuration.adoc
@@ -90,3 +90,65 @@ Once it's done, you should have into your local path a directory per services su
       ▾ glance/
       ▾ keystone/
 ----
+
+== Get services topology specific configuration
+
+Define the shell variables used in the steps below. The values are
+just illustrative, use values that are correct for your environment:
+
+[,bash]
+----
+MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+SOURCE_MARIADB_IP=192.168.122.100
+SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
+----
+
+Export shell variables for the following outputs to compare it with post-adoption values later on:
+
+* Test connection to the original DB:
++
+[,bash]
+----
+export PULL_OPENSTACK_CONFIGURATION_DATABASES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+    mysql -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+echo "$PULL_OPENSTACK_CONFIGURATION_DATABASES"
+----
++
+Note the `nova`, `nova_api`, `nova_cell0` databases residing in the same DB host.
+
+* Run mysqlcheck on the original DB to look for things that are not OK:
++
+[,bash]
+----
+export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+    mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root "-p$SOURCE_DB_ROOT_PASSWORD" | grep -v OK)
+echo "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
+----
+
+* Get Nova cells mappings from database:
++
+[,bash]
+----
+export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+    -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+    'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')
+echo "$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
+----
+
+* Get the host names of the registered Nova compute services:
++
+[,bash]
+----
+export PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+    -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+    "select host from nova.services where services.binary='nova-compute';")
+echo "$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES"
+----
+
+* Get the list of mapped Nova cells:
++
+[,bash]
+----
+export PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS=$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)
+echo "$PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS"
+----

--- a/docs_user/modules/openstack-stop_openstack_services.adoc
+++ b/docs_user/modules/openstack-stop_openstack_services.adoc
@@ -62,6 +62,10 @@ openstack share list --all-projects -c ID -c Status |grep -E '\| .+ing \|'| grep
 openstack image list -c ID -c Status |grep -E '\| .+ing \|'
 ----
 
+Also collect the xref:openstack-pull_openstack_configuration.adoc#get-services-topology-specific-configuration[topology configuration],
+before stopping services required to gather it live. You will need it to compare it
+with the post-adoption values later on.
+
 == Stopping control plane services
 
 We can stop OpenStack services at any moment, but we may leave things in an

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
 nav:
   - Overview: README.md
   - OpenStack:
+    - contributing/development_environment.md
     - openstack/planning.md
     - openstack/backend_services_deployment.md
     - openstack/pull_openstack_configuration.md

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -24,7 +24,9 @@
     ansible.builtin.shell:
       executable: /bin/bash
   roles:
+    - development_environment
     - backend_services
+    - pull_openstack_configuration
     - stop_openstack_services
     - mariadb_copy
     - ovn_adoption

--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -28,7 +28,9 @@
     ansible.builtin.shell:
       executable: /bin/bash
   roles:
+    - development_environment
     - backend_services
+    - pull_openstack_configuration
     - stop_openstack_services
     - mariadb_copy
     - ovn_adoption

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -316,3 +316,7 @@
 - name: Complete Nova services Wallaby->Antelope FFU
   ansible.builtin.include_tasks:
     file: nova_ffu.yaml
+
+- name: Adopted Nova FFU post-checks
+  ansible.builtin.include_tasks:
+    file: nova_verify.yaml

--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -1,15 +1,14 @@
-- name: set podified MariaDB copy shell vars
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.set_fact:
-    mariadb_copy_shell_vars: |
-      PODIFIED_DB_ROOT_PASSWORD="{{ podified_db_root_password }}"
+- name: get dst database service environment variables
+  ansible.builtin.include_role:
+    name: mariadb_copy
+    tasks_from: env_vars_dst.yaml
 
 - name: wait for cell1 Nova compute EDPM services version updated
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ mariadb_copy_shell_vars }}
-    oc rsh openstack-cell1-galera-0 mysql --user=root --password=${PODIFIED_DB_ROOT_PASSWORD} \
+    {{ mariadb_copy_shell_vars_dst }}
+    oc exec openstack-cell1-galera-0 -c galera -- mysql -rs -uroot -p$PODIFIED_DB_ROOT_PASSWORD \
       -e "select a.version from nova_cell1.services a join nova_cell1.services b where a.version!=b.version and a.binary='nova-compute';"
   register: records_check_results
   until: records_check_results.rc == 0 and records_check_results.stdout_lines | length == 0

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -1,0 +1,30 @@
+- name: set Nova services shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    nova_header: |
+      alias openstack="oc exec -t openstackclient -- openstack"
+      FIP={{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
+
+- name: verify if Nova services can stop the existing test VM instance
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ nova_header }}
+    ${BASH_ALIASES[openstack]} server list | grep -qF '| test | ACTIVE |' && ${BASH_ALIASES[openstack]} server stop test
+    ${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |'
+    ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test | grep "it is in power state shutdown" || echo PASS
+  register: nova_verify_stop_result
+  until: nova_verify_stop_result is success
+  retries: 10
+  delay: 6
+
+- name: verify if Nova services can start the existing test VM instance
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ nova_header }}
+    ${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |' && ${BASH_ALIASES[openstack]} server start test
+    ${BASH_ALIASES[openstack]} server list | grep -F '| test | ACTIVE |'
+    ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test --fit-width -f json | jq -r '.state' | grep running
+  register: nova_verify_start_result
+  until: nova_verify_start_result is success
+  retries: 60
+  delay: 6

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -1,0 +1,2 @@
+prelaunch_test_instance: true
+edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -1,0 +1,66 @@
+set -e
+
+# Create Image
+IMG=cirros-0.5.2-x86_64-disk.img
+URL=http://download.cirros-cloud.net/0.5.2/$IMG
+DISK_FORMAT=qcow2
+RAW=$IMG
+curl -L -# $URL > /tmp/$IMG
+if type qemu-img >/dev/null 2>&1; then
+    RAW=$(echo $IMG | sed s/img/raw/g)
+    qemu-img convert -f qcow2 -O raw /tmp/$IMG /tmp/$RAW
+    DISK_FORMAT=raw
+fi
+${BASH_ALIASES[openstack]} image show cirros || \
+    ${BASH_ALIASES[openstack]} image create --container-format bare --disk-format $DISK_FORMAT cirros < /tmp/$RAW
+
+# Create flavor
+${BASH_ALIASES[openstack]} flavor show m1.small || \
+    ${BASH_ALIASES[openstack]} flavor create --ram 512 --vcpus 1 --disk 1 --ephemeral 1 m1.small
+
+# Create networks
+${BASH_ALIASES[openstack]} network show private || ${BASH_ALIASES[openstack]} network create private --share
+${BASH_ALIASES[openstack]} subnet show priv_sub || ${BASH_ALIASES[openstack]} subnet create priv_sub --subnet-range 192.168.0.0/24 --network private
+${BASH_ALIASES[openstack]} network show public || ${BASH_ALIASES[openstack]} network create public --external --provider-network-type flat --provider-physical-network datacentre
+${BASH_ALIASES[openstack]} subnet show pub_sub || \
+    ${BASH_ALIASES[openstack]} subnet create pub_sub --subnet-range 192.168.122.0/24 --allocation-pool start=192.168.122.200,end=192.168.122.210 --gateway 192.168.122.1 --no-dhcp --network public
+${BASH_ALIASES[openstack]} router show priv_router || {
+    ${BASH_ALIASES[openstack]} router create priv_router
+    ${BASH_ALIASES[openstack]} router add subnet priv_router priv_sub
+    ${BASH_ALIASES[openstack]} router set priv_router --external-gateway public
+}
+
+# Create a floating IP
+${BASH_ALIASES[openstack]} floating ip show 192.168.122.20 || \
+    ${BASH_ALIASES[openstack]} floating ip create public --floating-ip-address 192.168.122.20
+
+# Create a test instance
+${BASH_ALIASES[openstack]} server show test || {
+    ${BASH_ALIASES[openstack]} server create --flavor m1.small --image cirros --nic net-id=private test --wait
+    ${BASH_ALIASES[openstack]} server add floating ip test 192.168.122.20
+}
+
+# Create security groups
+${BASH_ALIASES[openstack]} security group rule list --protocol icmp --ingress -f json | grep -q '"IP Range": "0.0.0.0/0"' || \
+    ${BASH_ALIASES[openstack]} security group rule create --protocol icmp --ingress --icmp-type -1 $(${BASH_ALIASES[openstack]} security group list --project admin -f value -c ID)
+${BASH_ALIASES[openstack]} security group rule list --protocol tcp --ingress -f json | grep '"Port Range": "22:22"' || \
+    ${BASH_ALIASES[openstack]} security group rule create --protocol tcp --ingress --dst-port 22 $(${BASH_ALIASES[openstack]} security group list --project admin -f value -c ID)
+
+# check connectivity via FIP
+# FIXME: defer __network_adoption__ - this doesn't work yet in the adoption procedure
+#ping -c4 192.168.122.20
+
+# FIXME: Invalid volume: Volume xxx status must be available, but current status is: backing-up
+# Create a Cinder volume, a backup from it, and snapshot it.
+#${BASH_ALIASES[openstack]} volume show disk || \
+#    ${BASH_ALIASES[openstack]} volume create --image cirros --bootable --size 1 disk
+#${BASH_ALIASES[openstack]} volume backup show backup || \
+#    ${BASH_ALIASES[openstack]} volume backup create --name backup disk
+#${BASH_ALIASES[openstack]} volume snapshot show snapshot || \
+#    ${BASH_ALIASES[openstack]} volume snapshot create --volume disk snapshot
+
+# TODO: Add volume to the test VM, after tripleo wallaby (osp 17) isolnet network adoption implemented for storage networks
+#${BASH_ALIASES[openstack]} volume show disk -f json | jq -r '.status' | grep -q available && \
+#    ${BASH_ALIASES[openstack]} server add volume test disk
+
+export FIP=192.168.122.20

--- a/tests/roles/development_environment/meta/main.yaml
+++ b/tests/roles/development_environment/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: pre-launch test VM instance
+  no_log: "{{ use_no_log }}"
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell:
+    cmd: |
+      alias openstack="ssh -i {{ edpm_privatekey_path }} root@{{ edpm_node_ip }} OS_CLOUD=standalone openstack"
+      {{ lookup('ansible.builtin.file', 'pre_launch.bash') }}

--- a/tests/roles/mariadb_copy/tasks/env_vars_dst.yaml
+++ b/tests/roles/mariadb_copy/tasks/env_vars_dst.yaml
@@ -1,0 +1,27 @@
+- name: get podified MariaDB service cluster IP
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc get svc --selector "mariadb/name=openstack" -ojsonpath='{.items[0].spec.clusterIP}'
+  register: podified_mariadb_ip_result
+
+- name: get podified cell1 MariaDB IP
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc get svc --selector "mariadb/name=openstack-cell1" -ojsonpath='{.items[0].spec.clusterIP}'
+  register: podified_cell1_mariadb_ip_result
+
+- name: set MariaDB copy shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    mariadb_copy_shell_vars_dst: |
+      PODIFIED_MARIADB_IP={{ podified_mariadb_ip_result.stdout }}
+      PODIFIED_CELL1_MARIADB_IP={{ podified_cell1_mariadb_ip_result.stdout }}
+      PODIFIED_DB_ROOT_PASSWORD="{{ podified_db_root_password }}"
+
+      # The CHARACTER_SET and collation should match the source DB
+      # if the do not then it will break foreign key relationships
+      # for any tables that are created in the future as part of db sync
+      CHARACTER_SET=utf8
+      COLLATION=utf8_general_ci

--- a/tests/roles/mariadb_copy/tasks/env_vars_src.yaml
+++ b/tests/roles/mariadb_copy/tasks/env_vars_src.yaml
@@ -1,0 +1,8 @@
+- name: set src MariaDB copy shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    mariadb_copy_shell_vars_src: |
+      MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+      # TODO: remove the default(external_...) when CI is transitioned to use 'source_...'
+      SOURCE_MARIADB_IP={{ source_mariadb_ip|default(external_mariadb_ip) }}
+      SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password|default(external_db_root_password) }}"

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -1,37 +1,18 @@
-- name: get podified MariaDB service cluster IP
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc get svc --selector "mariadb/name=openstack" -ojsonpath='{.items[0].spec.clusterIP}'
-  register: podified_mariadb_ip_result
+- name: get the source database service environment variables
+  ansible.builtin.include_tasks:
+    file: env_vars_src.yaml
 
-- name: get podified cell1 MariaDB IP
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc get svc --selector "mariadb/name=openstack-cell1" -ojsonpath='{.items[0].spec.clusterIP}'
-  register: podified_cell1_mariadb_ip_result
+- name: get the destination database service environment variables
+  ansible.builtin.include_tasks:
+    file: env_vars_dst.yaml
 
-- name: set MariaDB copy shell vars
+- name: Get the count of not-OK source databases
   no_log: "{{ use_no_log }}"
-  ansible.builtin.set_fact:
-    mariadb_copy_shell_vars: |
-      MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+  ansible.builtin.shell: |
+    {{ pulled_openstack_configuration_shell_headers }}
+    test -z "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"  || [ "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK" = " " ]
 
-      PODIFIED_MARIADB_IP={{ podified_mariadb_ip_result.stdout }}
-      PODIFIED_CELL1_MARIADB_IP={{ podified_cell1_mariadb_ip_result.stdout }}
-      PODIFIED_DB_ROOT_PASSWORD="{{ podified_db_root_password }}"
-
-      SOURCE_MARIADB_IP={{ source_mariadb_ip }}
-      SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password }}"
-
-      # The CHARACTER_SET and collation should match the source DB
-      # if the do not then it will break foreign key relationships
-      # for any tables that are created in the future as part of db sync
-      CHARACTER_SET=utf8
-      COLLATION=utf8_general_ci
-
-- name: MariaDB copy pre checks
+- name: test connection to podified DBs (show databases)
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell:
     cmd: "{{ lookup('ansible.builtin.template', 'pre_checks.bash') }}"

--- a/tests/roles/mariadb_copy/templates/dump_dbs.bash
+++ b/tests/roles/mariadb_copy/templates/dump_dbs.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{ shell_header }}
 {{ oc_header }}
-{{ mariadb_copy_shell_vars }}
+{{ mariadb_copy_shell_vars_src }}
 
 mkdir -p {{ mariadb_copy_tmp_dir }}
 cd {{ mariadb_copy_tmp_dir }}

--- a/tests/roles/mariadb_copy/templates/post_checks.bash
+++ b/tests/roles/mariadb_copy/templates/post_checks.bash
@@ -1,14 +1,36 @@
 {{ shell_header }}
 {{ oc_header }}
-{{ mariadb_copy_shell_vars }}
-oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-mysql -h "${PODIFIED_MARIADB_IP}" -uroot "-p${PODIFIED_DB_ROOT_PASSWORD}" -e 'SHOW databases;' \
-    | grep keystone
+{{ mariadb_copy_shell_vars_dst }}
+{{ pulled_openstack_configuration_shell_headers }}
+
+# use 'oc exec' and 'mysql -rs' to maintain formatting
+dbs=$(oc exec openstack-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+echo $dbs | grep -Eq '\bkeystone\b'
+
 # ensure neutron db is renamed from ovs_neutron
-oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-mysql -h "${PODIFIED_MARIADB_IP}" -uroot "-p${PODIFIED_DB_ROOT_PASSWORD}" -e 'SHOW databases;' \
-    | grep neutron
+echo $dbs | grep -Eq '\bneutron\b'
+echo $PULL_OPENSTACK_CONFIGURATION_DATABASES | grep -Eq '\bovs_neutron\b'
+
 # ensure nova cell1 db is extracted to a separate db server and renamed from nova to nova_cell1
-oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-mysql -h "${PODIFIED_CELL1_MARIADB_IP}" -uroot "-p${PODIFIED_DB_ROOT_PASSWORD}" -e 'SHOW databases;' \
-    | grep nova_cell1
+c1dbs=$(oc exec openstack-cell1-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+echo $c1dbs | grep -Eq '\bnova_cell1\b'
+
+# ensure default cell renamed to cell1, and the cell UUIDs retained intact
+novadb_mapped_cells=$(oc exec openstack-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" \
+  nova_api -e 'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')
+uuidf='\S{8,}-\S{4,}-\S{4,}-\S{4,}-\S{12,}'
+left_behind=$(comm -23 \
+  <(echo $PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS | grep -oE " $uuidf \S+") \
+  <(echo $novadb_mapped_cells | tr -s "| " " " | grep -oE " $uuidf \S+"))
+changed=$(comm -13 \
+  <(echo $PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS | grep -oE " $uuidf \S+") \
+  <(echo $novadb_mapped_cells | tr -s "| " " " | grep -oE " $uuidf \S+"))
+test $(grep -Ec ' \S+$' <<<$left_behind) -eq 1
+default=$(grep -E ' default$' <<<$left_behind)
+test $(grep -Ec ' \S+$' <<<$changed) -eq 1
+grep -qE " $(awk '{print $1}' <<<$default) cell1$" <<<$changed
+
+# ensure the registered Nova compute service name has not changed
+novadb_svc_records=$(oc exec openstack-cell1-galera-0 -c galera -- mysql -rs -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" \
+  nova_cell1 -e "select host from services where services.binary='nova-compute' order by host asc;")
+diff -Z <(echo $novadb_svc_records) <(echo $PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES)

--- a/tests/roles/mariadb_copy/templates/pre_checks.bash
+++ b/tests/roles/mariadb_copy/templates/pre_checks.bash
@@ -1,16 +1,11 @@
 #!/bin/bash
 {{ shell_header }}
 {{ oc_header }}
-{{ mariadb_copy_shell_vars }}
+{{ mariadb_copy_shell_vars_src }}
+{{ mariadb_copy_shell_vars_dst }}
 
-# Test connection to the original DB (show databases)
-podman run -i --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $MARIADB_IMAGE \
-    mysql -h "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;'
-# Run mysqlcheck on the original DB to look for things that are not OK
-podman run -i --rm --userns=keep-id -u $UID -v $PWD:$PWD:z,rw -w $PWD $MARIADB_IMAGE \
-    mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root "-p$SOURCE_DB_ROOT_PASSWORD"
 # Test connection to podified DBs (show databases)
 oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-    mysql -h "$PODIFIED_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
+    mysql -rsh "$PODIFIED_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
 oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
-    mysql -h "$PODIFIED_CELL1_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'
+    mysql -rsh "$PODIFIED_CELL1_MARIADB_IP" -uroot "-p$PODIFIED_DB_ROOT_PASSWORD" -e 'SHOW databases;'

--- a/tests/roles/mariadb_copy/templates/restore_dbs.bash
+++ b/tests/roles/mariadb_copy/templates/restore_dbs.bash
@@ -1,7 +1,8 @@
 #!/bin/bash
 {{ shell_header }}
 {{ oc_header }}
-{{ mariadb_copy_shell_vars }}
+{{ mariadb_copy_shell_vars_src }}
+{{ mariadb_copy_shell_vars_dst }}
 cd {{ mariadb_copy_tmp_dir }}
 
 # db schemas to rename on import
@@ -45,7 +46,7 @@ EOF
     oc run ${container_name} --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
         mysql -h "${db_server}" -uroot "-p${db_password}" "${db_name}" < "${db_file}"
 done
-oc exec -it openstack-galera-0 -- mysql --user=root --password=${db_server_password_map["default"]} -e \
+oc exec -it openstack-galera-0 -c galera -- mysql --user=root --password=${db_server_password_map["default"]} -e \
     "update nova_api.cell_mappings set name='cell1' where name='default';"
-oc exec -it openstack-cell1-galera-0 -- mysql --user=root --password=${db_server_password_map["default"]} -e \
+oc exec -it openstack-cell1-galera-0 -c galera -- mysql --user=root --password=${db_server_password_map["default"]} -e \
     "delete from nova_cell1.services where host not like '%nova-cell1-%' and services.binary != 'nova-compute';"

--- a/tests/roles/nova_adoption/tasks/main.yaml
+++ b/tests/roles/nova_adoption/tasks/main.yaml
@@ -69,12 +69,12 @@
                   disable_compute_service_check_for_ffu=true
     '
 
-- name: Wait for Nova control plane services' CRs to become ready
+- name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_tasks:
     file: wait.yaml
 
 # TODO(bogdando): implement podified FQDNs check for Nova endpoints
-- name: Check that Nova endpoints are defined and pointing to the podified FQDNs and that Nova API responds
+- name: check that Nova endpoints are defined and pointing to the podified FQDNs and that Nova API responds
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
@@ -86,3 +86,12 @@
   until: nova_responding_result is success
   retries: 60
   delay: 2
+
+# TODO(bogdando): provide automated checks for 'The expected changes to happen'
+- name: query the superconductor for cell1 existance and compare it to pre-adoption values
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ pulled_openstack_configuration_shell_headers }}
+    echo $PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS
+    oc rsh nova-cell0-conductor-0 nova-manage cell_v2 list_cells | grep -F '| cell1 |'

--- a/tests/roles/pull_openstack_configuration/tasks/main.yaml
+++ b/tests/roles/pull_openstack_configuration/tasks/main.yaml
@@ -1,0 +1,79 @@
+- name: set shell vars pull openstack configuration ssh commands
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    pull_openstack_configuration_ssh_shell_vars: |
+      CONTROLLER_SSH="{{ controller1_ssh }}"
+
+- name: get src database service environment variables
+  ansible.builtin.include_role:
+    name: mariadb_copy
+    tasks_from: env_vars_src.yaml
+
+# NOTE(bogdando): env variables must be used to keep this consistent with documentation,
+# where the stored values need to be compared with post-adoption ones w/o using ansible specifics
+- name: test connection to the original DB
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ mariadb_copy_shell_vars_src }}
+    export PULL_OPENSTACK_CONFIGURATION_DATABASES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+      mysql -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+    echo "$PULL_OPENSTACK_CONFIGURATION_DATABASES"
+  register: _databases_check
+
+- name: run mysqlcheck on the original DB to look for things that are not OK
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ mariadb_copy_shell_vars_src }}
+    export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+      mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root "-p$SOURCE_DB_ROOT_PASSWORD" | grep -v OK)
+    echo "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
+  failed_when: _mysqlnok_check.stdout != ''
+  register: _mysqlnok_check
+
+- name: get source Nova services topology specific configuration
+  no_log: "{{ use_no_log }}"
+  block:
+    - name: get Nova cells mappings from database
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        {{ mariadb_copy_shell_vars_src }}
+        export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+          -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+          'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')
+        echo "$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
+      register: _novadb_mapped_cells_check
+
+    - name: get the host names of the registered Nova compute services
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        {{ mariadb_copy_shell_vars_src }}
+        export PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+          -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+          "select host from nova.services where services.binary='nova-compute';")
+        echo "$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES"
+      register: _nova_compute_hostnames_check
+
+    - name: get the list of mapped Nova cells
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        {{ pull_openstack_configuration_ssh_shell_vars }}
+        export PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS=$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)
+        echo "$PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS"
+      register: _nova_cell_mappings_check
+
+- name: set cached fact for pulled openstack services configuration shell headers
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    pulled_openstack_configuration_shell_headers: |
+      PULL_OPENSTACK_CONFIGURATION_DATABASES="{{ _databases_check.stdout_lines | join(' ') }}"
+      PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="{{ _mysqlnok_check.stdout_lines | join(' ') }}"
+      PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="{{ _novadb_mapped_cells_check.stdout_lines | join(' ') }}"
+      PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="{{ _nova_compute_hostnames_check.stdout_lines | join(' ') }}"
+      PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="{{ _nova_cell_mappings_check.stdout_lines | join(' ') }}"

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -3,6 +3,9 @@ install_yamls_path: ~/install_yamls #CUSTOMIZE_THIS
 # Whether to use 'make crc_storage_cleanup; make crc_storage' before the test
 reset_crc_storage: true
 
+# Pre-launch test VM instance on the source cloud
+prelaunch_test_instance: false
+
 storage_class_name: crc-csi-hostpath-provisioner #CUSTOMIZE_THIS
 storage_reclaim_policy: delete # or retain
 


### PR DESCRIPTION
* MariaDB pre-/post-checks:

Get services topology specific configuration in
pull_openstack_configuration. Add missing role for that as well.

Split maridb source vs podified env vars shell headers to use it
in corresponding places.

Update and fix the composition of the services pre-check list to
execute it before stopping services.

Update and fix the composition of the list of the services to be
stopped (cannot pull data from stopped services).

Verify no dataplane disruptions during the FFU/adoption process.

Verify Nova services still control pre-created VM workload after
FFU/adotpion is done.

Replace oc run with oc exec in post checks. Fix 'oc rsh' which breaks
expected formatting for 'mysql -rs', when it is called from console vs
called by ansible shell module. Use instead 'oc exec' to keep post
checks working the same way in docs and executed via ansible tests.

* Pre-launch test VM instance in dev env role.

Add a test role for development environment and mention it
in the docs TOC as well.

Defer pingtest until the network adoption done.
Defer cinder volumes until workloads with volumes adoption done.
Defer Nova RBD backend until workloads adoption from ceph to ceph done.

Use a copy of the install_yaml shell script to bootstrap a VM.
We cannot use it via intall_yamls devsetup make target because:
* we need to wrap it with shell/ocp/etc headers
* we need to use bash aliases ref to openstack commands instead of
  direct openstack CLI syntax
* we should avoid SSH-ing to the source cloud VMs (standalone/computes)
  during EDPM adoption
* install_yaml is going to be deprecated anyway
* it's FIP ping test doesn't work and depends on the network adoption
  done
* it's cinder volume/backup/snapshot/attach test doesn't work yet,
  which is OK for this simpe workload adoption case. 

Jira: [OSPRH-3123](https://issues.redhat.com/browse/OSPRH-3123)
