### PR TITLE
Introduce Manila native cephfs adoption process

### DIFF
--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -21,6 +21,7 @@
   gather_facts: false
   vars:
     glance_backend: ceph
+    manila_backend: cephfs
   module_defaults:
     ansible.builtin.shell:
       executable: /bin/bash
@@ -37,4 +38,5 @@
     - cinder_adoption
     - horizon_adoption
     - heat_adoption
+    - manila_adoption
     - dataplane_adoption

--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -1,6 +1,7 @@
 # Service account passwords (not service DB passwords) from the
 # original deployment.
 cinder_password: ''
+manila_password: ''
 glance_password: ''
 ironic_password: ''
 neutron_password: ''

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -41,6 +41,9 @@
         oc set data secret/osp-secret "HeatPassword={{ heat_password }}"
         oc set data secret/osp-secret "HeatAuthEncryptionKey={{ heat_auth_encryption_key }}"
     {% endif %}
+    {% if manila_password %}
+        oc set data secret/osp-secret "ManilaPassword={{ manila_password }}"
+    {% endif %}
 
 - name: when not a periodic CI job use the base deployment
   when: not periodic|default(false)

--- a/tests/roles/ceph_backend_configuration/tasks/main.yaml
+++ b/tests/roles/ceph_backend_configuration/tasks/main.yaml
@@ -6,6 +6,16 @@
       CEPH_KEY=$($CEPH_SSH "cat /etc/ceph/ceph.client.openstack.keyring | base64 -w 0")
       CEPH_CONF=$($CEPH_SSH "cat /etc/ceph/ceph.conf | base64 -w 0")
 
+- name: update the openstack keyring caps for Manila
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    CEPH_SSH="{{ controller1_ssh }}"
+    CEPH_CAPS="mgr 'allow *' mon 'allow r, profile rbd' osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, allow rw pool manila_data'"
+    OSP_KEYRING="client.openstack"
+    CEPH_ADM=$($CEPH_SSH "cephadm shell -- ceph auth caps $OSP_KEYRING $CEPH_CAPS")
+
 - name: create ceph-conf-files secret
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
@@ -40,6 +50,7 @@
               - CinderVolume
               - CinderBackup
               - GlanceAPI
+              - ManilaShare
               extraVolType: Ceph
               volumes:
               - name: ceph

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -105,7 +105,7 @@
     metadata:
         name: dataplane-adoption-secret
     data:
-        ssh-privatekey: "{{ edpm_encoded_privatekey|default(edpm_privatekey.content) }}"
+        ssh-privatekey: "{{ edpm_encoded_privatekey | default(edpm_privatekey.content) }}"
     EOF
 
 - name: "[hack] create nova-metadata-neutron-config-secret.yaml"
@@ -222,8 +222,7 @@
             # Default nic config template for a EDPM compute node
             # These vars are edpm_network_config role vars
             edpm_network_config_override: ""
-            edpm_network_config_template: |
-              {%- raw %}
+            edpm_network_config_template: |{%- raw %}
               ---
               {% set mtu_list = [ctlplane_mtu] %}
               {% for network in role_networks %}
@@ -277,7 +276,7 @@
             edpm_nodes_validation_validate_controllers_icmp: false
             edpm_nodes_validation_validate_gateway_icmp: false
 
-            edpm_chrony_ntp_servers: {{ edpm_chrony_ntp_servers|default(default_edpm_chrony_ntp_servers) }}
+            edpm_chrony_ntp_servers: {{ edpm_chrony_ntp_servers | default(default_edpm_chrony_ntp_servers) }}
 
             edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
             edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"

--- a/tests/roles/manila_adoption/defaults/main.yaml
+++ b/tests/roles/manila_adoption/defaults/main.yaml
@@ -1,0 +1,2 @@
+# manila_backend can be 'cephfs' or 'ceph_nfs'
+manila_backend: cephfs

--- a/tests/roles/manila_adoption/meta/main.yaml
+++ b/tests/roles/manila_adoption/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/manila_adoption/tasks/main.yaml
+++ b/tests/roles/manila_adoption/tasks/main.yaml
@@ -1,0 +1,75 @@
+- name: deploy podified Manila with cephfs backend
+  when: manila_backend == "cephfs"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '
+    spec:
+      manila:
+        enabled: true
+        apiOverride:
+          route: {}
+        template:
+          databaseInstance: openstack
+          manilaAPI:
+            customServiceConfig: |
+              [DEFAULT]
+              enabled_share_protocols=cephfs
+            replicas: 1
+            networkAttachments:
+            - internalapi
+            override:
+              service:
+                internal:
+                  metadata:
+                    annotations:
+                      metallb.universe.tf/address-pool: internalapi
+                      metallb.universe.tf/allow-shared-ip: internalapi
+                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  spec:
+                    type: LoadBalancer
+          manilaScheduler:
+            replicas: 1
+          manilaShares:
+            share1:
+              customServiceConfig: |
+                [DEFAULT]
+                enabled_share_backends=cephfs
+                enabled_share_protocols=cephfs
+                [cephfs]
+                driver_handles_share_servers=False
+                share_backend_name=cephfs
+                share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+                cephfs_conf_path=/etc/ceph/ceph.conf
+                cephfs_auth_id=openstack
+                cephfs_cluster_name=ceph
+                cephfs_volume_mode=0755
+                cephfs_protocol_helper_type=CEPHFS
+              replicas: 1
+              networkAttachments:
+              - storage
+    '
+
+- name: wait for Manila to start up
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc get pod --selector=component=manila-api -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    oc get pod --selector=component=manila-scheduler -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    oc get pod --selector=component=manila-share -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+  register: manila_running_result
+  until: manila_running_result is success
+  retries: 60
+  delay: 2
+
+- name: check that Manila is reachable and its endpoints are defined
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    alias openstack="oc exec -t openstackclient -- openstack"
+
+    ${BASH_ALIASES[openstack]} endpoint list | grep -i share
+    ${BASH_ALIASES[openstack]} share pool list
+  register: manila_responding_result
+  until: manila_responding_result is success
+  retries: 15

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -19,12 +19,12 @@
       MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 
       PODIFIED_MARIADB_IP={{ podified_mariadb_ip_result.stdout }}
-      PODIFIED_CELL1_MARIADB_IP={{podified_cell1_mariadb_ip_result.stdout}}
+      PODIFIED_CELL1_MARIADB_IP={{ podified_cell1_mariadb_ip_result.stdout }}
       PODIFIED_DB_ROOT_PASSWORD="{{ podified_db_root_password }}"
 
       # TODO: remove the default(external_...) when CI is transitioned to use 'source_...'
-      SOURCE_MARIADB_IP={{ source_mariadb_ip|default(external_mariadb_ip) }}
-      SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password|default(external_db_root_password) }}"
+      SOURCE_MARIADB_IP={{ source_mariadb_ip | default(external_mariadb_ip) }}
+      SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password | default(external_db_root_password) }}"
 
       # The CHARACTER_SET and collation should match the source DB
       # if the do not then it will break foreign key relationships

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -56,7 +56,7 @@
       OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
 
       # TODO: remove the default(external_...) when CI is transitioned to use 'source_...'
-      SOURCE_OVSDB_IP={{ source_ovndb_ip|default(external_ovndb_ip) }}
+      SOURCE_OVSDB_IP={{ source_ovndb_ip | default(external_ovndb_ip) }}
 
       CONTROLLER1_SSH="{{ controller1_ssh }}"
       CONTROLLER2_SSH="{{ controller2_ssh }}"

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -20,12 +20,16 @@
                     "tripleo_cinder_scheduler.service"
                     "tripleo_cinder_backup.service"
                     "tripleo_glance_api.service"
+                    "tripleo_manila_api.service"
+                    "tripleo_manila_api_cron.service"
+                    "tripleo_manila_scheduler.service"
                     "tripleo_neutron_api.service"
                     "tripleo_nova_api.service"
                     "tripleo_placement_api.service")
 
     PacemakerResourcesToStop=("openstack-cinder-volume"
-                              "openstack-cinder-backup")
+                              "openstack-cinder-backup"
+                              "openstack-manila-share")
 
     echo "Stopping systemd OpenStack services"
     for service in ${ServicesToStop[*]}; do

--- a/tests/secrets.sample.yaml
+++ b/tests/secrets.sample.yaml
@@ -18,6 +18,7 @@ podified_db_root_password: 12345678
 cinder_password: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.CinderPassword') | first }}"
 glance_password: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.GlancePassword') | first }}"
 ironic_password: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.IronicPassword') | first }}"
+manila_password: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.ManilaPassword') | first }}"
 neutron_password: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.NeutronPassword') | first }}"
 heat_password: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.HeatPassword') | first }}"
 heat_auth_encryption_key: "{{ lookup('file', tripleo_passwords) | from_yaml | community.general.json_query('*.HeatAuthEncryptionKey') | first }}"


### PR DESCRIPTION
This patch is supposed to update the existing testsuite and add the `manila-adoption` role.
 At the moment `native_cephfs` only is supported, but the idea is to extend the `manila_adoption` role to cover `ceph-nfs`.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/50743