### PR TITLE
Remove variables with external prefix

### DIFF
--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -22,9 +22,8 @@
       PODIFIED_CELL1_MARIADB_IP={{ podified_cell1_mariadb_ip_result.stdout }}
       PODIFIED_DB_ROOT_PASSWORD="{{ podified_db_root_password }}"
 
-      # TODO: remove the default(external_...) when CI is transitioned to use 'source_...'
-      SOURCE_MARIADB_IP={{ source_mariadb_ip | default(external_mariadb_ip) }}
-      SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password | default(external_db_root_password) }}"
+      SOURCE_MARIADB_IP={{ source_mariadb_ip }}
+      SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password }}"
 
       # The CHARACTER_SET and collation should match the source DB
       # if the do not then it will break foreign key relationships

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -55,8 +55,7 @@
       PODIFIED_OVSDB_SB_IP={{ podified_ovn_sb_ip_result.stdout }}
       OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
 
-      # TODO: remove the default(external_...) when CI is transitioned to use 'source_...'
-      SOURCE_OVSDB_IP={{ source_ovndb_ip | default(external_ovndb_ip) }}
+      SOURCE_OVSDB_IP={{ source_ovndb_ip }}
 
       CONTROLLER1_SSH="{{ controller1_ssh }}"
       CONTROLLER2_SSH="{{ controller2_ssh }}"


### PR DESCRIPTION
In order to make them clearer, variables that point to the source
(standalone) environment begin by "source" and not "external". After
removing the old "external" vars from CI, removing the remainig ones as
workaround here.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/50752
