### PR TITLE
Fix curl command in placement adoption

### DIFF
--- a/docs/openstack/placement_adoption.md
+++ b/docs/openstack/placement_adoption.md
@@ -49,7 +49,7 @@
 
   # Without OpenStack CLI placement plugin installed:
   PLACEMENT_PUBLIC_URL=$(openstack endpoint list -c 'Service Name' -c 'Service Type' -c URL | grep placement | grep public | awk '{ print $6; }')
-  curl "$PLACEMENT_PUBLIC_URL"
+  oc exec -t openstackclient -- curl "$PLACEMENT_PUBLIC_URL"
 
   # With OpenStack CLI placement plugin installed:
   openstack resource class list

--- a/tests/roles/placement_adoption/tasks/main.yaml
+++ b/tests/roles/placement_adoption/tasks/main.yaml
@@ -46,7 +46,7 @@
 
     ${BASH_ALIASES[openstack]} endpoint list | grep placement | grep public
     PLACEMENT_PUBLIC_URL=$(${BASH_ALIASES[openstack]} endpoint list -c 'Service Name' -c 'Service Type' -c URL | grep placement | grep public | awk '{ print $6; }')
-    curl "$PLACEMENT_PUBLIC_URL" | grep '"versions"'
+    oc exec -t openstackclient -- curl "$PLACEMENT_PUBLIC_URL" | grep '"versions"'
   register: placement_responding_result
   until: placement_responding_result is success
   retries: 15


### PR DESCRIPTION
When curl <placement_endpoint> is executed on the ansible control host, there is no CA cert installed, and the curl command fails because of untrusted self-signed certificate.

Issue the curl check in the openstackclient pod, which has required certs installed.