### PR TITLE
[edpm]Do not run discover_hosts after adoption

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -311,12 +311,6 @@
         {{ oc_header }}
         oc wait --for condition=Ready osdpns/openstack --timeout=40m
 
-    - name: trigger manual compute host discovery in nova
-      ansible.builtin.shell: |
-        {{ shell_header }}
-        {{ oc_header }}
-        oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
-
     - name: run make edpm_deploy_instance
       ansible.builtin.shell: |
         {{ shell_header }}


### PR DESCRIPTION
The compute nodes being adopted has already been discovered in the 17.1 side so and that information is adopted via the DB adoption. So we should not run discovery again as it might mask an error in adoption.