### PR TITLE
Drop container image ansible vars from samples

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -258,13 +258,6 @@ EOF
           - clock.redhat.com
           - clock2.redhat.com
 
-          edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
-          edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
-          edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
-          edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
-          edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
-          edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
-
           gather_facts: false
           enable_debug: false
           # edpm firewall, change the allowed CIDR if needed

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -1,6 +1,3 @@
-registry_name: "quay.io"
-registry_namespace: "podified-antelope-centos9"
-image_tag: "current-podified"
 ansible_ssh_private_key_secret: dataplane-adoption-secret
 default_edpm_chrony_ntp_servers:
   - pool.ntp.org

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -269,13 +269,6 @@
 
             edpm_chrony_ntp_servers: {{ edpm_chrony_ntp_servers | default(default_edpm_chrony_ntp_servers) }}
 
-            edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
-            edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
-            edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
-            edpm_nova_compute_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
-            edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
-            edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
-
             gather_facts: false
             enable_debug: false
             # edpm firewall, change the allowed CIDR if needed


### PR DESCRIPTION
These image vars are not needed in the samples. There are defaults already set in the corresponding roles in edpm-ansible. ref:  https://github.com/openstack-k8s-operators/dataplane-operator/pull/522