### PR TITLE
Add support for running Adoption on RHEV deployed env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,7 @@ test-with-ceph: TEST_OUTFILE := tests/logs/test_with_ceph_out_$(shell date +%FT%
 test-with-ceph:
 	mkdir -p tests/logs
 	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_with_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
+test-minimal-rhev: TEST_OUTFILE := tests/logs/test_minimal_rhev_out_$(shell date +%FT%T%Z).log
+test-minimal-rhev:
+        mkdir -p tests/logs
+        ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_minimal_rhev.yaml 2>&1 | tee $(TEST_OUTFILE)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ test-with-ceph: TEST_OUTFILE := tests/logs/test_with_ceph_out_$(shell date +%FT%
 test-with-ceph:
 	mkdir -p tests/logs
 	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_with_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
+
 test-minimal-rhev: TEST_OUTFILE := tests/logs/test_minimal_rhev_out_$(shell date +%FT%T%Z).log
 test-minimal-rhev:
-        mkdir -p tests/logs
-        ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_minimal_rhev.yaml 2>&1 | tee $(TEST_OUTFILE)
+	mkdir -p tests/logs
+	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) tests/playbooks/test_minimal_rhev.yaml 2>&1 | tee $(TEST_OUTFILE)

--- a/tests/config/base_rhev/kustomization.yaml
+++ b/tests/config/base_rhev/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- openstack_control_plane_rhev.yaml

--- a/tests/config/base_rhev/openstack_control_plane_rhev.yaml
+++ b/tests/config/base_rhev/openstack_control_plane_rhev.yaml
@@ -1,0 +1,127 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+
+  cinder:
+    enabled: false
+    template:
+      cinderAPI: {}
+      cinderScheduler: {}
+      cinderBackup: {}
+      cinderVolumes: {}
+
+  dns:
+    template:
+      override:
+        service:
+          metadata:
+            annotations:
+              metallb.universe.tf/address-pool: ctlplane
+              metallb.universe.tf/allow-shared-ip: ctlplane
+              metallb.universe.tf/loadBalancerIPs: 192.168.23.80
+          spec:
+            type: LoadBalancer
+      options:
+      - key: server
+        values:
+        - 10.37.136.1
+      replicas: 1
+
+  glance:
+    enabled: false
+    template:
+      glanceAPI: {}
+
+  horizon:
+    enabled: false
+    template: {}
+
+  ironic:
+    enabled: false
+    template:
+      ironicConductors: []
+
+  keystone:
+    enabled: false
+    template: {}
+
+  manila:
+    enabled: false
+    template:
+      manilaAPI: {}
+      manilaScheduler: {}
+      manilaShares: {}
+
+  mariadb:
+    enabled: true
+    templates:
+      openstack:
+        storageRequest: 500M
+      openstack-cell1:
+        storageRequest: 500M
+
+  memcached:
+    enabled: true
+    templates:
+      memcached:
+        replicas: 1
+
+  neutron:
+    enabled: false
+    template: {}
+
+  nova:
+    enabled: false
+    template: {}
+
+  ovn:
+    enabled: false
+    template:
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+      ovnDBCluster:
+        ovndbcluster-nb:
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
+        ovndbcluster-sb:
+          containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
+
+  ovs:
+    enabled: false
+    template:
+      external-ids: {}
+
+  placement:
+    enabled: false
+    template: {}
+
+  rabbitmq:
+    templates:
+      rabbitmq:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.15.2.85
+            spec:
+              type: LoadBalancer
+      rabbitmq-cell1:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.15.2.86
+            spec:
+              type: LoadBalancer
+
+  telemetry:
+    enabled: false
+    template: {}

--- a/tests/playbooks/test_minimal_rhev.yaml
+++ b/tests/playbooks/test_minimal_rhev.yaml
@@ -1,0 +1,35 @@
+- name: Prelude
+  hosts: local
+  gather_facts: false
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
+  roles:
+    - prelude_local
+
+- name: Cleanup
+  hosts: local
+  gather_facts: false
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
+  roles:
+    - pcp_cleanup
+
+- name: Adoption
+  hosts: local
+  gather_facts: false
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
+  roles:
+    - backend_services
+    - stop_openstack_services
+    - mariadb_copy
+    - ovn_adoption
+    - keystone_adoption
+    - neutron_adoption
+    - glance_adoption
+    - placement_adoption
+    - cinder_adoption
+    - dataplane_rhev_adoption

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -46,13 +46,26 @@
     {% endif %}
 
 - name: when not a periodic CI job use the base deployment
-  when: not periodic|default(false)
+  when:
+    - not periodic|default(false)
+    - not platform_rhev|default(false)
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     mkdir -p tmp
     oc kustomize base > tmp/test_deployment.yaml
     oc apply -f tmp/test_deployment.yaml
+  args:
+    chdir: "../config"
+
+- name: For rhev deployed env, use RHEV customize base deployment
+  when: platform_rhev|default(false)
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    mkdir -p tmp
+    oc kustomize base_rhev > tmp/test_deployment_rhev.yaml
+    oc apply -f tmp/test_deployment_rhev.yaml
   args:
     chdir: "../config"
 

--- a/tests/roles/dataplane_rhev_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_rhev_adoption/defaults/main.yaml
@@ -1,0 +1,6 @@
+registry_name: "quay.io"
+registry_namespace: "podified-antelope-centos9"
+image_tag: "current-podified"
+ansible_ssh_private_key_secret: dataplane-adoption-secret
+default_edpm_chrony_ntp_servers:
+  - pool.ntp.org

--- a/tests/roles/dataplane_rhev_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_rhev_adoption/tasks/main.yaml
@@ -1,0 +1,328 @@
+- name: force latest ansible-runner image
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ oc_login_command }}
+    # openstack-operator catalog pins the sha256, which might differ from latest with time
+    oc patch csv -n openstack-operators openstack-ansibleee-operator.v0.0.1 \
+      --type='json' -p='[{
+      "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
+      "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"}}]'
+
+- name: ensure oc login
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc project openstack
+
+- name: ensure IPAM is configured
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: network.openstack.org/v1beta1
+    kind: NetConfig
+    metadata:
+      name: netconfig
+    spec:
+      networks:
+      - name: CtlPlane
+        dnsDomain: ctlplane.redhat.local
+        subnets:
+        - name: subnet1
+          allocationRanges:
+          - end: 192.168.23.15
+            start: 192.168.23.4
+          cidr: 192.168.23.0/24
+          gateway: 192.168.23.1
+      - name: InternalApi
+        dnsDomain: internalapi.redhat.local
+        subnets:
+        - name: subnet1
+          allocationRanges:
+          - end: 172.15.2.15
+            start: 172.15.2.4
+          cidr: 172.15.2.0/24
+          vlan: 20
+      - name: External
+        dnsDomain: external.redhat.local
+        subnets:
+        - name: subnet1
+          allocationRanges:
+          - end: 10.4.0.15
+            start: 10.4.0.4
+          cidr: 10.4.0.0/24
+          gateway: 10.4.0.1
+          vlan: 10
+      - name: Tenant
+        dnsDomain: tenant.redhat.local
+        subnets:
+        - name: subnet1
+          allocationRanges:
+          - end: 172.15.0.15
+            start: 172.15.0.4
+          cidr: 172.15.0.0/24
+          vlan: 50
+    EOF
+
+- name: Slurp the private key
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.slurp:
+    path: "{{ edpm_privatekey_path }}"
+  register: edpm_privatekey
+  when: edpm_encoded_privatekey is undefined
+
+- name: create dataplane-adoption-secret.yaml
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+        name: dataplane-adoption-secret
+    data:
+        ssh-privatekey: "{{ edpm_encoded_privatekey|default(edpm_privatekey.content) }}"
+    EOF
+
+- name: "[hack] create nova-metadata-neutron-config-secret.yaml"
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+        name: nova-metadata-neutron-config
+    data:
+        05-nova-metadata.conf: |
+    $(echo "[DEFAULT]\nnova_metadata_host = 1.2.3.4\nnova_metadata_port = 8775\nnova_metadata_protocol = http\nmetadata_proxy_shared_secret = 1234567842\n" | base64 | sed 's/^/        /')
+    EOF
+
+- name: set Nova copy shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    nova_shell_vars: |
+      CONTROLLER1_SSH="{{ controller1_ssh }}"
+      CONTROLLER2_SSH="{{ controller2_ssh }}"
+      CONTROLLER3_SSH="{{ controller3_ssh }}"
+      COMPUTE_SSH="{{ compute_ssh }}"
+
+- name: stop nova services on controllers
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ nova_shell_vars }}
+
+    ServicesToStop=("tripleo_nova_api_cron.service"
+                    "tripleo_nova_api.service"
+                    "tripleo_nova_conductor.service"
+                    "tripleo_nova_metadata.service"
+                    "tripleo_nova_vnc_proxy.service")
+
+    echo "Stopping nova services"
+
+    for service in ${ServicesToStop[*]}; do
+        echo "Stopping the service: $service in each controller node"
+        $CONTROLLER1_SSH sudo systemctl stop $service
+        $CONTROLLER2_SSH sudo systemctl stop $service
+        $CONTROLLER3_SSH sudo systemctl stop $service
+    done
+
+- name: stop nova services on compute
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ nova_shell_vars }}
+
+    ServicesToStop=("tripleo_nova_compute.service"
+                    "tripleo_nova_libvirt.target"
+                    "tripleo_nova_migration_target.service"
+                    "tripleo_nova_virtlogd_wrapper.service"
+                    "tripleo_nova_virtnodedevd.service"
+                    "tripleo_nova_virtproxyd.service"
+                    "tripleo_nova_virtqemud.service"
+                    "tripleo_nova_virtsecretd.service"
+                    "tripleo_nova_virtstoraged.service")
+
+    echo "Stopping nova services"
+
+    for service in ${ServicesToStop[*]}; do
+        echo "Stopping the service: $service in each controller node"
+        $COMPUTE_SSH sudo systemctl stop $service
+    done
+
+- name: deploy dataplane
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    metadata:
+      name: openstack
+    spec:
+      networkAttachments:
+        - ctlplane
+      preProvisioned: true
+      services:
+        - download-cache
+        - configure-network
+        - validate-network
+        - install-os
+        - configure-os
+        - run-os
+        - ovn
+      env:
+        - name: ANSIBLE_CALLBACKS_ENABLED
+          value: "profile_tasks"
+        - name: ANSIBLE_FORCE_COLOR
+          value: "True"
+        - name: ANSIBLE_ENABLE_TASK_DEBUGGER
+          value: "True"
+      nodes:
+        compute-0.redhat.local:
+          hostName: compute-0.redhat.local
+          ansible:
+            ansibleHost: {{ edpm_node_ip }}
+          networks:
+          - defaultRoute: true
+            fixedIP: {{ edpm_node_ip }}
+            name: CtlPlane
+            subnetName: subnet1
+          - name: InternalApi
+            fixedIP: 172.15.2.10
+            subnetName: subnet1
+          - name: Tenant
+            fixedIP: 172.15.0.10
+            subnetName: subnet1
+          - name: External
+            fixedIP: 10.4.0.10
+            subnetName: subnet1
+      nodeTemplate:
+        ansibleSSHPrivateKeySecret: {{ ansible_ssh_private_key_secret }}
+        managementNetwork: ctlplane
+        ansible:
+          ansiblePort: 22
+          ansibleUser: stack
+          ansibleVars:
+            service_net_map:
+              nova_api_network: internal_api
+              nova_libvirt_network: internal_api
+
+            # edpm_network_config
+            # Default nic config template for a EDPM compute node
+            # These vars are edpm_network_config role vars
+            edpm_network_config_override: ""
+            edpm_network_config_template: |
+              {%- raw %}
+              ---
+              {% set mtu_list = [ctlplane_mtu] %}
+              {% for network in role_networks %}
+              {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+              {%- endfor %}
+              {% set min_viable_mtu = mtu_list | max %}
+              network_config:
+              - type: interface
+                name: nic1
+                use_dhcp: true
+              - type: interface
+                name: nic2
+                use_dhcp: false
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                routes: {{ ctlplane_host_routes }}
+              - type: interface
+                name: nic3
+                use_dhcp: false
+                addresses:
+                - ip_netmask: {{ tenant_ip }}/{{ tenant_cidr }}
+                routes: {{ tenant_host_routes }}
+              - type: interface
+                name: nic4
+                use_dhcp: false
+                addresses:
+                - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
+                routes: {{ internal_api_host_routes }}
+              - type: ovs_bridge
+                name: {{ neutron_physical_bridge_name }}
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                use_dhcp: false
+                addresses:
+                - ip_netmask: {{ external_ip }}/{{ external_cidr }}
+                routes: []
+                members:
+                - type: interface
+                  name: nic5
+                  primary: true
+              {% endraw %}
+
+            edpm_network_config_hide_sensitive_logs: false
+            #
+            # These vars are for the network config templates themselves and are
+            # considered EDPM network defaults.
+            neutron_physical_bridge_name: br-ex
+            neutron_public_interface_name: eth4
+            role_networks:
+            - InternalApi
+            - Tenant
+            networks_lower:
+              External: external
+              InternalApi: internal_api
+              Tenant: tenant
+
+            # edpm_nodes_validation
+            edpm_nodes_validation_validate_controllers_icmp: false
+            edpm_nodes_validation_validate_gateway_icmp: false
+
+            edpm_chrony_ntp_servers: {{ edpm_chrony_ntp_servers|default(default_edpm_chrony_ntp_servers) }}
+
+            edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
+            edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
+            edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
+            edpm_nova_compute_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
+            edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
+            edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+
+            gather_facts: false
+            enable_debug: false
+            # edpm firewall, change the allowed CIDR if needed
+            edpm_sshd_configure_firewall: true
+            edpm_sshd_allowed_ranges: ['192.168.23.0/24']
+            # SELinux module
+            edpm_selinux_mode: enforcing
+            plan: overcloud
+    EOF
+
+- name: deploy the dataplane deployment
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneDeployment
+    metadata:
+      name: openstack
+    spec:
+      nodeSets:
+      - openstack
+    EOF
+
+- name: wait for dataplane node set to be ready
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc wait --for condition=Ready osdpns/openstack --timeout=40m
+  # TODO: work on network configuration for making possible to run this task on other IP ranges
+  when: "edpm_node_ip.startswith('192.168.23')"

--- a/tests/roles/dataplane_rhev_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_rhev_adoption/tasks/main.yaml
@@ -89,75 +89,51 @@
         ssh-privatekey: "{{ edpm_encoded_privatekey|default(edpm_privatekey.content) }}"
     EOF
 
-- name: "[hack] create nova-metadata-neutron-config-secret.yaml"
+- name: generate an ssh key-pair nova-migration-ssh-key secret
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cd "$(mktemp -d)"
+    ssh-keygen -f ./id -t ed25519 -N ''
+    oc get secret nova-migration-ssh-key || oc create secret generic nova-migration-ssh-key \
+    -n openstack \
+    --from-file=ssh-privatekey=id \
+    --from-file=ssh-publickey=id.pub \
+    --type kubernetes.io/ssh-auth
+    rm -f id*
+    cd -
+
+- name: create a Nova Compute Extra Config service
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     oc apply -f - <<EOF
     apiVersion: v1
-    kind: Secret
+    kind: ConfigMap
     metadata:
-        name: nova-metadata-neutron-config
+      name: nova-compute-extraconfig
+      namespace: openstack
     data:
-        05-nova-metadata.conf: |
-    $(echo "[DEFAULT]\nnova_metadata_host = 1.2.3.4\nnova_metadata_port = 8775\nnova_metadata_protocol = http\nmetadata_proxy_shared_secret = 1234567842\n" | base64 | sed 's/^/        /')
+      19-nova-compute-cell1-workarounds.conf: |
+        [workarounds]
+        disable_compute_service_check_for_ffu=true
+    ---
+    apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneService
+    metadata:
+      name: nova-compute-extraconfig
+      namespace: openstack
+    spec:
+      label: nova.compute.extraconfig
+      configMaps:
+        - nova-compute-extraconfig
+      secrets:
+        - nova-cell1-compute-config
+        - nova-migration-ssh-key
+      playbook: osp.edpm.nova
     EOF
-
-- name: set Nova copy shell vars
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.set_fact:
-    nova_shell_vars: |
-      CONTROLLER1_SSH="{{ controller1_ssh }}"
-      CONTROLLER2_SSH="{{ controller2_ssh }}"
-      CONTROLLER3_SSH="{{ controller3_ssh }}"
-      COMPUTE_SSH="{{ compute_ssh }}"
-
-- name: stop nova services on controllers
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    {{ nova_shell_vars }}
-
-    ServicesToStop=("tripleo_nova_api_cron.service"
-                    "tripleo_nova_api.service"
-                    "tripleo_nova_conductor.service"
-                    "tripleo_nova_metadata.service"
-                    "tripleo_nova_vnc_proxy.service")
-
-    echo "Stopping nova services"
-
-    for service in ${ServicesToStop[*]}; do
-        echo "Stopping the service: $service in each controller node"
-        $CONTROLLER1_SSH sudo systemctl stop $service
-        $CONTROLLER2_SSH sudo systemctl stop $service
-        $CONTROLLER3_SSH sudo systemctl stop $service
-    done
-
-- name: stop nova services on compute
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    {{ nova_shell_vars }}
-
-    ServicesToStop=("tripleo_nova_compute.service"
-                    "tripleo_nova_libvirt.target"
-                    "tripleo_nova_migration_target.service"
-                    "tripleo_nova_virtlogd_wrapper.service"
-                    "tripleo_nova_virtnodedevd.service"
-                    "tripleo_nova_virtproxyd.service"
-                    "tripleo_nova_virtqemud.service"
-                    "tripleo_nova_virtsecretd.service"
-                    "tripleo_nova_virtstoraged.service")
-
-    echo "Stopping nova services"
-
-    for service in ${ServicesToStop[*]}; do
-        echo "Stopping the service: $service in each controller node"
-        $COMPUTE_SSH sudo systemctl stop $service
-    done
 
 - name: deploy dataplane
   ansible.builtin.shell: |
@@ -179,13 +155,13 @@
         - install-os
         - configure-os
         - run-os
+        - libvirt
+        - nova-compute-extraconfig
         - ovn
       env:
         - name: ANSIBLE_CALLBACKS_ENABLED
           value: "profile_tasks"
         - name: ANSIBLE_FORCE_COLOR
-          value: "True"
-        - name: ANSIBLE_ENABLE_TASK_DEBUGGER
           value: "True"
       nodes:
         compute-0.redhat.local:


### PR DESCRIPTION
To support Dataplane adoption CI on RHEV, adding RHEV env specific template changes in the test suite.
source env: 3 controller and 1 compute
- Added new openstackcontrolplane CR base config for RHEV based on the different DNS and rabbitmq spec.
- Added a new dataplane_rhev_adoption role as the Netconfig, osdpns templates are totally different for RHEV env.
Ref: https://issues.redhat.com/browse/OSP-30525
