### PR TITLE
Fix OVN template for isolnet scenarios

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -197,11 +197,20 @@ podified OpenStack control plane services.
     ovn:
       enabled: false
       template:
+        ovnDBCluster:
+          ovndbcluster-nb:
+            dbType: NB
+            storageRequest: 10G
+            networkAttachment: internalapi
+          ovndbcluster-sb:
+            dbType: SB
+            storageRequest: 10G
+            networkAttachment: internalapi
+        ovnNorthd:
+          networkAttachment: internalapi
+          replicas: 1
         ovnController:
-          external-ids:
-            system-id: "random"
-            ovn-bridge: "br-int"
-            ovn-encap-type: "geneve"
+          networkAttachment: tenant
 
     placement:
       enabled: false

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -83,14 +83,18 @@ spec:
     enabled: false
     template:
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
+        networkAttachment: tenant
+      ovnNorthd:
+        networkAttachment: internalapi
+        replicas: 1
       ovnDBCluster:
         ovndbcluster-nb:
+          dbType: NB
+          networkAttachment: internalapi
           containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
         ovndbcluster-sb:
+          dbType: SB
+          networkAttachment: internalapi
           containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
 
   ovs:

--- a/tests/config/periodic_ci/container_image_overrides.yaml
+++ b/tests/config/periodic_ci/container_image_overrides.yaml
@@ -76,11 +76,20 @@ spec:
   ovn:
     enabled: false
     template:
+      ovnDBCluster:
+        ovndbcluster-nb:
+          dbType: NB
+          storageRequest: 10G
+          networkAttachment: internalapi
+        ovndbcluster-sb:
+          dbType: SB
+          storageRequest: 10G
+          networkAttachment: internalapi
+      ovnNorthd:
+        networkAttachment: internalapi
+        replicas: 1
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
+        networkAttachment: tenant
 
   ovs:
     enabled: false


### PR DESCRIPTION
Align CR for OVN adoption with its isolnet CR sample in openstack operator.

Fix communication between OSP control plane pods on OCP and standalone OSP 17.1 host.