### PR TITLE
Provide more info when waiting the dataplane

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -209,7 +209,20 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc wait --for condition=Ready osdpns/openstack --timeout=40m
+    NODESET_NAME=openstack
+    DEPLOYMENT_NAME=openstack
+    echo "========= AEE Pods ========="
+    oc get pod -l osdpd=${DEPLOYMENT_NAME}
+    LAST_SERVICE_NAME=$(oc get osdpns ${NODESET_NAME} -o jsonpath='{.spec.services}' | jq -r last)
+    echo "========= Last service name: ${LAST_SERVICE_NAME} ========="
+    LAST_SERVICE_POD=$(oc get pod -l job-name=${LAST_SERVICE_NAME}-${DEPLOYMENT_NAME} -o name)
+    echo "========= Last service POD name: ${LAST_SERVICE_POD} ========="
+    oc get ${LAST_SERVICE_POD} -o jsonpath='{.status.phase}{"\n"}' | grep Succeeded
+    oc get osdpd openstack -o jsonpath='{.status.deployed}{"\n"}' | grep true
+  register: osdpd_running_result
+  until: osdpd_running_result is success
+  retries: 25
+  delay: 60
 
 - name: Complete Nova services Wallaby->Antelope FFU
   ansible.builtin.include_tasks:


### PR DESCRIPTION
output:
https://logserver.rdoproject.org/14/214/4279db322a48ef29101e03c12727b72c4b56afa4/github-check/data-plane-adoption-github-rdo-centos-9-extracted-crc/79ac2da/controller/data-plane-adoption-tests-repo/data-plane-adoption/tests/logs/test_with_ceph_out_2023-12-05T18:26:46EST.log

the idea is to show all the AEE pods, so that when it fails it will be clear which service failed