### PR TITLE
Change ssh migration key to ECDSA type

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -100,7 +100,7 @@ EOF
 
   ```bash
   cd "$(mktemp -d)"
-  ssh-keygen -f ./id -t ed25519 -N ''
+  ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
   oc get secret nova-migration-ssh-key || oc create secret generic nova-migration-ssh-key \
     -n openstack \
     --from-file=ssh-privatekey=id \

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -114,7 +114,7 @@
     {{ shell_header }}
     {{ oc_header }}
     cd "$(mktemp -d)"
-    ssh-keygen -f ./id -t ed25519 -N ''
+    ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
     oc get secret nova-migration-ssh-key || oc create secret generic nova-migration-ssh-key \
     -n openstack \
     --from-file=ssh-privatekey=id \


### PR DESCRIPTION
Even though the recent FIPS standard[1] allows ED25519 ssh keys, the current FIPS profile in centos9 stream does not allow it. So the current migration ssh key isn't usable. This PR changes the key type to ECDSA until the profile is updated.

[1] https://csrc.nist.gov/pubs/fips/186-5/final