### PR TITLE
Modify the upstream dns server in the control plane

### DIFF
--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -100,6 +100,14 @@
   retries: 60
   delay: 2
 
+- name: Patch openstack upstream dns server to set the correct value for the environment
+  when: upstream_dns is defined
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    crname=$(oc get openstackcontrolplane -o name)
+    oc patch ${crname} --type json \
+      -p='[{"op": "replace", "path": "/spec/dns/template/options", "value": [{"key": "server", "values": ["{{ upstream_dns }}"]}]}]'
 
 - name: Patch rabbitmq resources for lower resource consumption
   changed_when: false


### PR DESCRIPTION
Patch the control plane dns upstream server to point to the
dns server address in the running environment.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/50590
