### PR TITLE
Adapt the data-plane-adoption doc/tests to the new GlanceAPI CRD

### DIFF
--- a/docs/openstack/backend_services_deployment.md
+++ b/docs/openstack/backend_services_deployment.md
@@ -150,7 +150,7 @@ podified OpenStack control plane services.
     glance:
       enabled: false
       template:
-        glanceAPI: {}
+        glanceAPIs: {}
 
     horizon:
       enabled: false

--- a/docs/openstack/glance_adoption.md
+++ b/docs/openstack/glance_adoption.md
@@ -42,18 +42,19 @@ spec:
       databaseInstance: openstack
       storageClass: "local-storage"
       storageRequest: 10G
-      glanceAPI:
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/allow-shared-ip: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-            spec:
-              type: LoadBalancer
-        networkAttachments:
-        - storage
+      glanceAPIs:
+        default:
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+          networkAttachments:
+          - storage
 '
 ```
 
@@ -87,18 +88,19 @@ spec:
         store_description=Ceph glance store backend.
       storageClass: "local-storage"
       storageRequest: 10G
-      glanceAPI:
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/allow-shared-ip: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-            spec:
-              type: LoadBalancer
-        networkAttachments:
-        - storage
+      glanceAPIs:
+        default:
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+          networkAttachments:
+          - storage
 EOF
 ```
 
@@ -134,7 +136,7 @@ oc patch openstackcontrolplane openstack --type=merge --patch-file glance_patch.
 Inspect the resulting glance pods:
 
 ```bash
-GLANCE_POD=`oc get pod |grep glance-external-api | cut -f 1 -d' '`
+GLANCE_POD=`oc get pod |grep glance-default-external-0 | cut -f 1 -d' '`
 oc exec -t $GLANCE_POD -c glance-api -- cat /etc/glance/glance.conf.d/02-config.conf
 
 [DEFAULT]

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -34,7 +34,7 @@ spec:
   glance:
     enabled: false
     template:
-      glanceAPI: {}
+      glanceAPIs: {}
 
   horizon:
     enabled: false

--- a/tests/config/base_rhev/openstack_control_plane_rhev.yaml
+++ b/tests/config/base_rhev/openstack_control_plane_rhev.yaml
@@ -34,7 +34,7 @@ spec:
   glance:
     enabled: false
     template:
-      glanceAPI: {}
+      glanceAPIs: {}
 
   horizon:
     enabled: false

--- a/tests/config/periodic_ci/container_image_overrides.yaml
+++ b/tests/config/periodic_ci/container_image_overrides.yaml
@@ -32,7 +32,7 @@ spec:
   glance:
     enabled: false
     template:
-      glanceAPI: {}
+      glanceAPIs: {}
 
   horizon:
     enabled: false

--- a/tests/roles/backend_services/templates/container_overrides.j2
+++ b/tests/roles/backend_services/templates/container_overrides.j2
@@ -17,8 +17,9 @@ spec:
 
   glance:
     template:
-      glanceAPI:
-        containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
+      glanceAPIs:
+        default:
+          containerImage: {{ container_registry }}/{{ container_namespace }}/openstack-glance-api:{{ container_tag }}
 
   horizon:
     template:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -12,18 +12,19 @@
           databaseInstance: openstack
           storageClass: "local-storage"
           storageRequest: 10G
-          glanceAPI:
-            override:
-              service:
-                metadata:
-                  annotations:
-                    metallb.universe.tf/address-pool: internalapi
-                    metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-                spec:
-                  type: LoadBalancer
-            networkAttachments:
-            - storage
+          glanceAPIs:
+            default:
+              override:
+                service:
+                  metadata:
+                    annotations:
+                      metallb.universe.tf/address-pool: internalapi
+                      metallb.universe.tf/allow-shared-ip: internalapi
+                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  spec:
+                    type: LoadBalancer
+              networkAttachments:
+              - storage
     '
   when: glance_backend == 'local'
 
@@ -49,18 +50,19 @@
             store_description=Ceph glance store backend.
           storageClass: "local-storage"
           storageRequest: 10G
-          glanceAPI:
-            override:
-              service:
-                metadata:
-                  annotations:
-                    metallb.universe.tf/address-pool: internalapi
-                    metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-                spec:
-                  type: LoadBalancer
-            networkAttachments:
-            - storage
+          glanceAPIs:
+            default:
+              override:
+                service:
+                  metadata:
+                    annotations:
+                      metallb.universe.tf/address-pool: internalapi
+                      metallb.universe.tf/allow-shared-ip: internalapi
+                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  spec:
+                    type: LoadBalancer
+              networkAttachments:
+              - storage
     '
   when: glance_backend == 'ceph'
 
@@ -68,8 +70,19 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get pod --selector=service=glance-external -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
-    oc get pod --selector=service=glance-internal -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+
+    STATUS=$(oc get pod --selector=service=glance -o jsonpath='{.items[*].status.phase}{"\n"}');
+    code=1
+    IFS=" " read -r -a STATUS <<< "$STATUS"
+    for i in "${STATUS[@]}"; do
+        if echo "$i" | grep -v Running; then
+            # if at least one instance is not Running, return
+            exit $code
+        else
+            code=0
+        fi
+    done
+    exit $code
   register: glance_running_result
   until: glance_running_result is success
   retries: 60


### PR DESCRIPTION
We recently introduced the ability to deploy a list of glanceAPI in the OpenStackControlPlane. This feature is not required in the adoption context, but it's critical to adapt the Glance deployment to the new api.
It might be relevant in the future as long as DCN environments will be adopted.