### PR TITLE
Add bootstrap

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -162,6 +162,7 @@ EOF
     preProvisioned: true
     services:
       - download-cache
+      - bootstrap
       - configure-network
       - validate-network
       - install-os

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -118,6 +118,7 @@
       preProvisioned: true
       services:
         - download-cache
+        - bootstrap
         - configure-network
         - validate-network
         - install-os


### PR DESCRIPTION
In grienfield deployments and CI jobs, we always
ensure the bootstrap role is executed on EDPM nodes.

Add the missing role for the openstack dataplane CR
used for adoption docs and tests/CI as well