### PR TITLE
[edpm]Temporary fix for stable compute UUID

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -86,6 +86,35 @@ EOF
 
 ## Procedure - EDPM adoption
 
+* *Temporary fix* until the OSP 17 [backport of the stable compute UUID feature
+](https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid)
+lands.
+
+  Define the map of compute node name, IP pairs:
+  ```bash
+  declare -A computes
+  computes=(
+    ["standalone.localdomain"]="192.168.122.100"
+    # ...
+  )
+  ```
+  For each compute node grab the UUID of the compute service and write it too
+  the stable `compute_id` file in `/var/lib/nova/` directory.
+  ```bash
+  for name in "${!computes[@]}";
+  do
+    uuid=$(\
+      openstack hypervisor show $name \
+      -f value -c 'id'\
+    )
+    echo "Writing $uuid to /var/lib/nova/compute_id on $name"
+    ssh \
+      -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
+      root@"${computes[$name]}" \
+      "echo $uuid > /var/lib/nova/compute_id"
+  done
+  ```
+
 * Create a [ssh authentication secret](https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets) for the EDPM nodes:
 
   ```bash

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -43,6 +43,42 @@
   register: edpm_privatekey
   when: edpm_encoded_privatekey is undefined
 
+# Remove this when https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid
+# is released in 17.x
+- name: Temporary fix to ensure stable compute UUID
+  block:
+    - name: ensure SSH key
+      ansible.builtin.copy:
+        dest: /tmp/ansible_private_key
+        content: "{{ edpm_encoded_privatekey | default(edpm_privatekey.content) | b64decode }}"
+        mode: "0600"
+      when: edpm_privatekey_path is undefined
+
+    - name: populate compute_id file
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        declare -A computes
+        computes=(
+          ["{{ edpm_node_hostname }}.localdomain"]="{{ edpm_node_ip }}"
+        )
+
+        for name in "${!computes[@]}";
+        do
+          uuid=$(\
+            oc exec -t openstackclient -- \
+              openstack hypervisor show $name \
+              -f value -c 'id'\
+          )
+
+          echo "Writing $uuid to /var/lib/nova/compute_id on $name"
+          ssh \
+            -i {{ edpm_privatekey_path | default("/tmp/ansible_private_key") }} \
+            {{ edpm_user }}@"${computes[$name]}" \
+            "echo $uuid > /var/lib/nova/compute_id"
+
+        done
+
 - name: create dataplane-adoption-secret.yaml
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
The temporary compute UUID feature exits in Antelope but the backport of it[1] to OSP 17.x hasn't been landed yet. When we start pre-generating the compute UUID during greenfield deployment as part of https://github.com/openstack-k8s-operators/edpm-ansible/pull/498 the adoption will break if there is no compute UUID file exists on each compute node. When [1] is released in 17.x the compute UUID file will be created by the nova-compute on the 17.x side. Until that we create the file right at the start of the EDPM adoption.

[1] https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid

Implements: https://issues.redhat.com/browse/OSPRH-117