### PR TITLE
Split OSP services stopping into different roles

### DIFF
--- a/docs_user/assemblies/openstack_adoption.adoc
+++ b/docs_user/assemblies/openstack_adoption.adoc
@@ -23,6 +23,7 @@ include::../modules/openstack-ironic_adoption.adoc[leveloffset=+1]
 include::../modules/openstack-heat_adoption.adoc[leveloffset=+1]
 include::../modules/openstack-telemetry_adoption.adoc[leveloffset=+1]
 include::../modules/openstack-autoscaling_adoption.adoc[leveloffset=+1]
+include::../modules/openstack-stop_remaining_services.[leveloffset=+1]
 include::../modules/openstack-edpm_adoption.adoc[leveloffset=+1]
 
 include::../modules/openstack-troubleshooting.adoc[leveloffset=+1]

--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -3,6 +3,14 @@
 == Prerequisites
 
 * Previous Adoption steps completed.
+* Remaining source cloud xref:stop_remaining_services.adoc[services are stopped] on compute hosts.
+
+____
+*WARNING* This step is a "point of no return" in the EDPM adoption
+procedure. The source control plane and data plane services must not
+be ever enabled back, after EDPM is deployed, and Podified control
+plane has taken control over it!
+____
 
 == Variables
 
@@ -156,31 +164,31 @@ cd -
 +
 [,yaml]
 ----
-  oc apply -f - <<EOF
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: nova-compute-extraconfig
-    namespace: openstack
-  data:
-    19-nova-compute-cell1-workarounds.conf: |
-      [workarounds]
-      disable_compute_service_check_for_ffu=true
-  ---
-  apiVersion: dataplane.openstack.org/v1beta1
-  kind: OpenStackDataPlaneService
-  metadata:
-    name: nova-compute-extraconfig
-    namespace: openstack
-  spec:
-    label: nova.compute.extraconfig
-    configMaps:
-      - nova-compute-extraconfig
-    secrets:
-      - nova-cell1-compute-config
-      - nova-migration-ssh-key
-    playbook: osp.edpm.nova
-  EOF
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nova-compute-extraconfig
+  namespace: openstack
+data:
+  19-nova-compute-cell1-workarounds.conf: |
+    [workarounds]
+    disable_compute_service_check_for_ffu=true
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: nova-compute-extraconfig
+  namespace: openstack
+spec:
+  label: nova.compute.extraconfig
+  configMaps:
+    - nova-compute-extraconfig
+  secrets:
+    - nova-cell1-compute-config
+    - nova-migration-ssh-key
+  playbook: osp.edpm.nova
+EOF
 ----
 +
 The secret `nova-cell<X>-compute-config` is auto-generated for each

--- a/docs_user/modules/openstack-stop_openstack_services.adoc
+++ b/docs_user/modules/openstack-stop_openstack_services.adoc
@@ -16,6 +16,10 @@ Since gracefully stopping all services is non-trivial and beyond the scope of
 this guide we'll proceed with the force method but present a couple of
 recommendations on how to check some things in the services.
 
+Note that we should not stop the infrastructure management services now, like
+database, RabbitMQ, and HAProxy Load Balancer. Nor should we stop yet the
+Nova compute service and containerized modular libvirt daemons.
+
 == Variables
 
 Define the shell variables used in the steps below. The values are
@@ -38,12 +42,6 @@ are in the right host, for example to stop a service:
 ----
 . stackrc ansible -i $(which tripleo-ansible-inventory) Controller -m shell -a "sudo systemctl stop tripleo_horizon.service" -b
 ----
-
-____
-*NOTE* Nova computpe services in this guide are running on the same controller hosts.
-Adjust `+CONTROLLER${i}_SSH+` commands and `ServicesToStop` given below to your
-source environment specific topology.
-____
 
 == Pre-checks
 
@@ -71,9 +69,8 @@ undesired state, so at the very least we should have a look to confirm that
 there are no ongoing  operations.
 
 1- Connect to all the controller nodes.
-2- Stop the services.
-3- Make sure all the services are stopped.
-4- Repeat steps 1-3 for compute hosts (workloads running on dataplane will not be affected)
+2- Stop the control plane services.
+3- Verify the control plane services are stopped.
 
 The cinder-backup service on OSP 17.1 could be running as Active-Passive under
 pacemaker or as Active-Active, so we'll have to check how it's running and
@@ -105,16 +102,6 @@ ServicesToStop=("tripleo_horizon.service"
                 "tripleo_nova_metadata.service"
                 "tripleo_nova_scheduler.service"
                 "tripleo_nova_vnc_proxy.service"
-                # Compute services on dataplane
-                "tripleo_nova_compute.service"
-                "tripleo_nova_libvirt.target"
-                "tripleo_nova_migration_target.service"
-                "tripleo_nova_virtlogd_wrapper.service"
-                "tripleo_nova_virtnodedevd.service"
-                "tripleo_nova_virtproxyd.service"
-                "tripleo_nova_virtqemud.service"
-                "tripleo_nova_virtsecretd.service"
-                "tripleo_nova_virtstoraged.service"
                 "tripleo_aodh_api.service"
                 "tripleo_aodh_api_cron.service"
                 "tripleo_aodh_evaluator.service"
@@ -149,7 +136,7 @@ for service in ${ServicesToStop[*]}; do
         if [ ! -z "${!SSH_CMD}" ]; then
             echo "Checking status of $service in controller $i"
             if ! ${!SSH_CMD} systemctl show $service | grep ActiveState=inactive >/dev/null; then
-               echo "ERROR: Service $service still running on controller $i"
+                echo "ERROR: Service $service still running on controller $i"
             fi
         fi
     done

--- a/docs_user/modules/openstack-stop_remaining_services.adoc
+++ b/docs_user/modules/openstack-stop_remaining_services.adoc
@@ -1,0 +1,95 @@
+= Stop other infrastructure management and compute services
+
+Before we can start with the EDPM adoption we need to make sure that compute,
+libvirt, load balancing, messaging and database services have been stopped on
+the source cloud. Also, we need to disable repositories for
+modular libvirt daemons on compute hosts.
+
+After this step, the source cloud's control plane can be decomissioned,
+which is taking down only cloud controllers, database and messaging nodes.
+Nodes that must remain functional are those running the compute, storage,
+or networker roles (in terms of composable roles covered by Tripleo Heat
+Templates).
+
+== Variables
+
+Define the shell variables used in the steps below. The values are
+just illustrative and refer to a single node standalone director deployment,
+use values that are correct for your environment:
+
+[,bash]
+----
+EDPM_PRIVATEKEY_PATH="~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa"
+declare -A computes
+computes=(
+["standalone.localdomain"]="192.168.122.100"
+# ...
+)
+----
+
+We chose to use these ssh variables with the ssh commands instead of using
+ansible to try to create instructions that are independent on where they are
+running, but ansible commands could be used to achieve the same result if we
+are in the right host, for example to stop a service:
+
+----
+. stackrc
+ansible -i $(which tripleo-ansible-inventory) Compute -m shell -a "sudo systemctl stop tripleo_virtqemud.service" -b
+----
+
+== Stopping remaining services
+
+Remove the conflicting repositories and packages (in case of a devsetup that
+uses Standalone TripleO) from all compute hosts. That is required to install
+libvirt packages, when these hosts become adopted as External DataPlane Managed
+(EDPM) nodes, where modular libvirt daemons are no longer running in podman
+containers.
+
+These steps can be automated with a simple script that relies on the previously
+defined environmental variables and function:
+
+[,bash]
+----
+
+ComputeServicesToStop=(
+                "tripleo_nova_compute.service"
+                "tripleo_nova_libvirt.target"
+                "tripleo_nova_migration_target.service"
+                "tripleo_nova_virtlogd_wrapper.service"
+                "tripleo_nova_virtnodedevd.service"
+                "tripleo_nova_virtproxyd.service"
+                "tripleo_nova_virtqemud.service"
+                "tripleo_nova_virtsecretd.service"
+                "tripleo_nova_virtstoraged.service")
+
+PacemakerResourcesToStop=(
+                "galera-bundle"
+                "haproxy-bundle"
+                "rabbitmq-bundle")
+
+echo "Disabling systemd units and cleaning up for compute services"
+for i in "${!computes[@]}"; do
+    SSH_CMD="ssh -i $EDPM_PRIVATEKEY_PATH root@${computes[$i]}"
+    for service in ${ComputeServicesToStop[*]}; do
+        echo "Stopping the $service in compute $i"
+        if ${SSH_CMD} sudo systemctl is-active $service; then
+            ${SSH_CMD} sudo systemctl disable --now $service
+            ${SSH_CMD} test -f /etc/systemd/system/$service '||' sudo systemctl mask $service
+        fi
+    done
+done
+
+echo "Stopping pacemaker services"
+for i in {1..3}; do
+    SSH_CMD=CONTROLLER${i}_SSH
+    if [ ! -z "${!SSH_CMD}" ]; then
+        echo "Using controller $i to run pacemaker commands"
+        for resource in ${PacemakerResourcesToStop[*]}; do
+            if ${!SSH_CMD} sudo pcs resource config $resource; then
+                ${!SSH_CMD} sudo pcs resource disable $resource
+            fi
+        done
+        break
+    fi
+done
+----

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - openstack/cinder_adoption.md
     - openstack/horizon_adoption.md
     - openstack/manila_adoption.md
+    - openstack/stop_remaining_services.md
     - openstack/edpm_adoption.md
     - openstack/ironic_adoption.md
     - openstack/heat_adoption.md

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -35,5 +35,6 @@
     - nova_adoption
     - cinder_adoption
     - horizon_adoption
+    - stop_remaining_services
     - dataplane_adoption
     - heat_adoption

--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -40,4 +40,5 @@
     - horizon_adoption
     - heat_adoption
     - manila_adoption
+    - stop_remaining_services
     - dataplane_adoption

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -6,7 +6,6 @@
       CONTROLLER2_SSH="{{ controller2_ssh }}"
       CONTROLLER3_SSH="{{ controller3_ssh }}"
 
-# TODO(bogdando): split Compute services on dataplane after the multi-node/multi-cells adoption supported
 - name: stop control plane services
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
@@ -32,16 +31,7 @@
                     "tripleo_nova_conductor.service"
                     "tripleo_nova_metadata.service"
                     "tripleo_nova_scheduler.service"
-                    "tripleo_nova_vnc_proxy.service"
-                    "tripleo_nova_compute.service"
-                    "tripleo_nova_libvirt.target"
-                    "tripleo_nova_migration_target.service"
-                    "tripleo_nova_virtlogd_wrapper.service"
-                    "tripleo_nova_virtnodedevd.service"
-                    "tripleo_nova_virtproxyd.service"
-                    "tripleo_nova_virtqemud.service"
-                    "tripleo_nova_virtsecretd.service"
-                    "tripleo_nova_virtstoraged.service")
+                    "tripleo_nova_vnc_proxy.service")
 
     PacemakerResourcesToStop=("openstack-cinder-volume"
                               "openstack-cinder-backup"
@@ -67,7 +57,7 @@
             if [ ! -z "${!SSH_CMD}" ]; then
                 echo "Checking status of $service in controller $i"
                 if ! ${!SSH_CMD} systemctl show $service | grep ActiveState=inactive >/dev/null; then
-                   echo "ERROR: Service $service still running on controller $i"
+                    echo "ERROR: Service $service still running on controller $i"
                 fi
             fi
         done

--- a/tests/roles/stop_remaining_services/defaults/main.yaml
+++ b/tests/roles/stop_remaining_services/defaults/main.yaml
@@ -1,0 +1,2 @@
+install_yamls_path: /home/zuul/src/github.com/openstack-k8s-operators/install_yamls/
+edpm_privatekey_path: "{{ install_yamls_path }}/out/edpm/ansibleee-ssh-key-id_rsa"

--- a/tests/roles/stop_remaining_services/meta/main.yaml
+++ b/tests/roles/stop_remaining_services/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/stop_remaining_services/tasks/main.yaml
+++ b/tests/roles/stop_remaining_services/tasks/main.yaml
@@ -1,0 +1,60 @@
+- name: set shell vars for stopping other services
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    stop_other_services_shell_vars: |
+      CONTROLLER1_SSH="{{ controller1_ssh }}"
+      CONTROLLER2_SSH="{{ controller2_ssh }}"
+      CONTROLLER3_SSH="{{ controller3_ssh }}"
+      EDPM_PRIVATEKEY_PATH="{{ edpm_privatekey_path }}"
+      declare -A computes
+      computes=(
+      ["standalone.localdomain"]="{{ edpm_node_ip }}"
+      )
+
+- name: stop compute services
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ stop_other_services_shell_vars }}
+
+    ComputeServicesToStop=(
+                    "tripleo_nova_compute.service"
+                    "tripleo_nova_libvirt.target"
+                    "tripleo_nova_migration_target.service"
+                    "tripleo_nova_virtlogd_wrapper.service"
+                    "tripleo_nova_virtnodedevd.service"
+                    "tripleo_nova_virtproxyd.service"
+                    "tripleo_nova_virtqemud.service"
+                    "tripleo_nova_virtsecretd.service"
+                    "tripleo_nova_virtstoraged.service")
+
+    PacemakerResourcesToStop=(
+                    "galera-bundle"
+                    "haproxy-bundle"
+                    "rabbitmq-bundle")
+
+    echo "Disabling systemd units and cleaning up for compute services"
+    for i in "${!computes[@]}"; do
+        SSH_CMD="ssh -i $EDPM_PRIVATEKEY_PATH root@${computes[$i]}"
+        for service in ${ComputeServicesToStop[*]}; do
+            echo "Stopping the $service in compute $i"
+            if ${SSH_CMD} sudo systemctl is-active $service; then
+                ${SSH_CMD} sudo systemctl disable --now $service
+                ${SSH_CMD} test -f /etc/systemd/system/$service '||' sudo systemctl mask $service
+            fi
+        done
+    done
+
+    echo "Stopping pacemaker services"
+    for i in {1..3}; do
+        SSH_CMD=CONTROLLER${i}_SSH
+        if [ ! -z "${!SSH_CMD}" ]; then
+            echo "Using controller $i to run pacemaker commands"
+            for resource in ${PacemakerResourcesToStop[*]}; do
+                if ${!SSH_CMD} sudo pcs resource config $resource; then
+                    ${!SSH_CMD} sudo pcs resource disable $resource
+                fi
+            done
+            break
+        fi
+    done


### PR DESCRIPTION
1) Split the osp services stopping role into a role that stops the
   control plane services, and another role to stop the remaining
   services.  Add up stopping Galera, RabbitMQ and HAProxy services
   into the latter, because stopping those for the former appears to
   be too early (we need to pull OSP configuration firstly).
   Both roles to be integrated into EDPM roles in follow-ups.

2) Disable service units and do dev envs clean up for computes.

3) Document that additional requirement for libvirt repositories
   reconfig in real adoption scenarios that will be using RHEL and
   subscritption manager. The exact commands to be added later.

4) Related changes:                                                                                                                                                      
  * Document that EDPM adoption is "the point of no return"
  * Document that at the time we are stopping the OSP control plane
    services, we must not stop the remaining infrastructure management,
    and compute services yet.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/540
Partial: [OSPRH-3123](https://issues.redhat.com/browse/OSPRH-3123)