### PR TITLE
Adds the github-check layout to the data-plane-adoption repo

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -1,0 +1,6 @@
+---
+- project:
+    name: openstack-k8s-operators/data-plane-adoption
+    github-check:
+      jobs:
+        - data-plane-adoption-OSP-17-to-extracted-crc


### PR DESCRIPTION
The github-check for this repo is currently defined at [1]. Instead we should move this in repo.

https://issues.redhat.com/browse/OSPRH-2997

[1] https://github.com/rdo-infra/review.rdoproject.org-config/blob/b13c3f957d6c4352c3cf976a732364074752c768/zuul.d/projects.yaml#L139