### PR TITLE
Add internalapi network to ovn helper pod

### DIFF
--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -93,6 +93,7 @@
       name: ovn-copy-data
       annotations:
         openshift.io/scc: anyuid
+        k8s.v1.cni.cncf.io/networks: internalapi
       labels:
         app: adoption
     spec:


### PR DESCRIPTION
For source osp env on RHEV, during adoption while dumping the ovn databases from source ovsdb the helper pod is not able to make connectivity to the source ovsdb IP. Adding the internalapi network to helper pod would help to build the connectivity to source ovsdb.
Ref: OSPRH-2793