### PR TITLE
Fix resetting storage dependency on PCP

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -306,12 +306,21 @@ against your environment.
 
 The development environment must be rolled back in case we want to execute another Adoption run.
 
-Delete the data-plane and control-plane resources from the CRC vm
+Delete the data-plane and control-plane resources
 
 [,bash]
 ----
-oc delete osdp openstack
-oc delete oscp openstack
+oc delete --ignore-not-found=true openstackdataplanedeployment/openstack
+oc delete --ignore-not-found=true openstackdataplanenodeset/openstack
+oc delete --ignore-not-found=true openstackcontrolplane/openstack
+oc delete --ignore-not-found=true secret osp-secret
+
+# FIXME: remove once oscp deletion properly cleans this up
+oc delete --wait=false keystoneapi keystone || true
+oc patch keystoneapi keystone --type=merge --patch '
+metadata:
+  finalizers: []
+' || true
 ----
 
 Revert the standalone vm to the snapshotted state
@@ -322,16 +331,37 @@ cd ~/install_yamls/devsetup
 make standalone_revert
 ----
 
-Clean up and initialize the storage PVs in CRC vm
+Clean up and initialize the storage PVs (for each Nova cell DB instance):
 
 [,bash]
 ----
+GALERA_OPERATOR_VERSION=mariadb-operator.v0.0.1
+
+oc delete --ignore-not-found=true pod ovn-copy-data
 oc delete --ignore-not-found=true pvc ovn-data
-oc delete --ignore-not-found=true pvc ansible-ee-logs
+
+oc patch csv $GALERA_OPERATOR_VERSION -n openstack-operators \
+  --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
+
+oc scale statefulsets openstack-galera --replicas=0 || true
+oc scale statefulsets openstack-cell1-galera --replicas=0 || true
+
+
+while oc get pod | grep rabbitmq-server-0; do
+    sleep 2
+done
+while oc get pod | grep openstack-galera-0; do
+    sleep 2
+done
+while oc get pod | grep openstack-cell1-galera-0; do
+    sleep 2
+done
+
 oc delete --ignore-not-found=true pvc mysql-db-openstack-galera-0
 oc delete --ignore-not-found=true pvc mysql-db-openstack-cell1-galera-0
-oc delete --ignore-not-found=true pvc glance-glance-default-external-0
-oc delete --ignore-not-found=true pvc glance-glance-default-internal-0
+
+oc patch csv $GALERA_OPERATOR_VERSION -n openstack-operators \
+  --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 1}]"
 ----
 
 == Experimenting with an additional compute node

--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -3,34 +3,17 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc delete --wait=false openstackdataplanedeployment/openstack || true
-    oc delete --wait=false openstackcontrolplane/openstack || true
-    oc patch openstackcontrolplane openstack --type=merge --patch '
-    metadata:
-      finalizers: []
-    ' || true
+    oc delete --ignore-not-found=true openstackdataplanedeployment/openstack
+    oc delete --ignore-not-found=true openstackdataplanenodeset/openstack
+    oc delete --ignore-not-found=true openstackcontrolplane/openstack
+    oc delete --ignore-not-found=true secret osp-secret
 
-    oc delete --wait=false galera openstack || true
-    oc patch galera openstack --type=merge --patch '
-    metadata:
-      finalizers: []
-    ' || true
-
+    # FIXME: remove once oscp deletion properly cleans this up
     oc delete --wait=false keystoneapi keystone || true
     oc patch keystoneapi keystone --type=merge --patch '
     metadata:
       finalizers: []
     ' || true
-
-    while oc get pod | grep rabbitmq-server-0; do
-        sleep 2
-    done
-    while oc get pod | grep openstack-galera-0; do
-        sleep 2
-    done
-
-    oc delete --wait=false pod ovn-copy-data || true
-    oc delete secret osp-secret || true
   when: pcp_cleanup_enabled|bool
 
 - name: revert standalone VM to snapshotted state
@@ -45,10 +28,32 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
+    GALERA_OPERATOR_VERSION=mariadb-operator.v0.0.1
+
+    oc delete --ignore-not-found=true pod ovn-copy-data
     oc delete --ignore-not-found=true pvc ovn-data
-    oc delete --ignore-not-found=true pvc ansible-ee-logs
+
+    oc patch csv $GALERA_OPERATOR_VERSION -n openstack-operators \
+      --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
+
+    oc scale statefulsets openstack-galera --replicas=0 || true
+    oc scale statefulsets openstack-cell1-galera --replicas=0 || true
+
+    while oc get pod | grep rabbitmq-server-0; do
+        sleep 2
+    done
+    while oc get pod | grep openstack-galera-0; do
+        sleep 2
+    done
+    while oc get pod | grep openstack-cell1-galera-0; do
+        sleep 2
+    done
+
     oc delete --ignore-not-found=true pvc mysql-db-openstack-galera-0
     oc delete --ignore-not-found=true pvc mysql-db-openstack-cell1-galera-0
-    oc delete --ignore-not-found=true pvc glance-glance-default-external-0
-    oc delete --ignore-not-found=true pvc glance-glance-default-internal-0
-  when: reset_crc_storage|bool
+
+    oc patch csv $GALERA_OPERATOR_VERSION -n openstack-operators \
+      --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 1}]"
+  when:
+    - reset_crc_storage|bool
+    - pcp_cleanup_enabled|bool


### PR DESCRIPTION
This is an attempt to fix the storage cleanup regression after https://github.com/openstack-k8s-operators/data-plane-adoption/pull/227

Storage cannot be reset until podified openstack control plane CRs
deleted, because of finalizers.

Fix condition to allow resetting storage only when resetting PCP
as well. Remove hacks to erase finalizers (but one for keystoneapis,
which should normally be deleted during oscp CR deletion).

Add removal of osp-secret, and osdpns steps.

Fix the ordering and waiting of events when resetting storage and PCP:

* Disable galera operator by scaling-in its operator deployment to 0
  (this is the only way as openstack controller webhook prohibits
  disabling/scaling-in galera replicas to 0, because this would
  break all openstack components under normal circumstances)
* Fully scale-in statefull sets for galera instances of all cells
* Remove galera databases pvcs, for all Nova cells
* Enable galera operator back to start DB instances back with cleaned
  up storage PVs. (It will recreate PVCs back, after the oscp CR applied)