### PR TITLE
Rename adoption CI job to use all lowercase

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -3,4 +3,4 @@
     name: openstack-k8s-operators/data-plane-adoption
     github-check:
       jobs:
-        - data-plane-adoption-OSP-17-to-extracted-crc
+        - data-plane-adoption-osp-17-to-extracted-crc


### PR DESCRIPTION
Following the change in
https://review.rdoproject.org/r/c/rdo-jobs/+/51181, use a fully
lowercase job name for adoption.
