### PR TITLE
Fix decontainerized libvirt adoption

### DIFF
--- a/docs/openstack/edpm_adoption.md
+++ b/docs/openstack/edpm_adoption.md
@@ -177,6 +177,45 @@ lands.
   ``cell<X>``. That secret, alongside ``nova-migration-ssh-key``, should
   always be specified for each custom `OpenStackDataPlaneService` related to Nova.
 
+* Create a repo-setup service to configure Antelope repositories
+
+  ```yaml
+  oc apply -f - <<EOF
+  apiVersion: dataplane.openstack.org/v1beta1
+  kind: OpenStackDataPlaneService
+  metadata:
+    name: repo-setup
+    namespace: openstack
+  spec:
+    label: dataplane.deployment.repo.setup
+    play: |
+      - hosts: all
+        strategy: linear
+        tasks:
+          - name: Enable podified-repos
+            become: true
+            ansible.builtin.shell: |
+              # TODO: Use subscription-manager and a valid OSP18 repos instead
+              # This is a hack to deploy RDO Delorean repos to RHEL as if it were Centos 9 Stream
+              set -euxo pipefail
+              curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
+              python3 -m venv ./venv
+              PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
+              # This is required for FIPS enabled until trunk.rdoproject.org
+              # is not being served from a centos7 host, tracked by
+              # https://issues.redhat.com/browse/RHOSZUUL-1517
+              dnf -y install crypto-policies
+              update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+              # FIXME: perform dnf upgrade for other packages in EDPM ansible
+              # here we only ensuring that decontainerized libvirt can start
+              ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
+              dnf -y upgrade openstack-selinux
+              rpm -q python3-tripleoclient && dnf -y erase python3-tripleoclient --exclude=openvswitch3.1 --exclude=openvswitch-selinux-extra-policy --exclude=openstack-network-scripts-openvswitch3.1 --exclude=python3-openvswitch3.1 --exclude=python3-rdo-openvswitch --exclude=rdo-openvswitch --exclude=rhosp-openvswitch-3.1 --exclude=python3-rhosp-openvswitch
+              rm -f /run/virtlogd.pid
+              rm -rf repo-setup-main
+  EOF
+  ```
+
 * Deploy OpenStackDataPlaneNodeSet:
 
   ```yaml
@@ -190,6 +229,7 @@ lands.
         - ctlplane
     preProvisioned: true
     services:
+      - repo-setup
       - download-cache
       - bootstrap
       - configure-network
@@ -308,6 +348,10 @@ lands.
           # SELinux module
           edpm_selinux_mode: enforcing
           plan: overcloud
+
+          # Do not attempt OVS 3.2 major upgrades here
+          edpm_ovs_packages:
+          - openvswitch3.1
   EOF
   ```
 

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -139,6 +139,46 @@
       playbook: osp.edpm.nova
     EOF
 
+- name: create a repo-setup service to configure Antelope repositories
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneService
+    metadata:
+      name: repo-setup
+      namespace: openstack
+    spec:
+      label: dataplane.deployment.repo.setup
+      play: |
+        - hosts: all
+          strategy: linear
+          tasks:
+            - name: Enable podified-repos
+              become: true
+              ansible.builtin.shell: |
+                # TODO: Use subscription-manager and a valid OSP18 repos instead
+                # This is a hack to deploy RDO Delorean repos to RHEL as if it were Centos 9 Stream
+                set -euxo pipefail
+                curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
+                python3 -m venv ./venv
+                PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
+                # This is required for FIPS enabled until trunk.rdoproject.org
+                # is not being served from a centos7 host, tracked by
+                # https://issues.redhat.com/browse/RHOSZUUL-1517
+                dnf -y install crypto-policies
+                update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+                # FIXME: perform dnf upgrade for other packages in EDPM ansible
+                # here we only ensuring that decontainerized libvirt can start
+                ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
+                dnf -y upgrade openstack-selinux
+                rpm -q python3-tripleoclient && dnf -y erase python3-tripleoclient --exclude=openvswitch3.1 --exclude=openvswitch-selinux-extra-policy --exclude=openstack-network-scripts-openvswitch3.1 --exclude=python3-openvswitch3.1 --exclude=python3-rdo-openvswitch --exclude=rdo-openvswitch --exclude=rhosp-openvswitch-3.1 --exclude=python3-rhosp-openvswitch
+                rm -f /run/virtlogd.pid
+                rm -rf repo-setup-main
+    EOF
+
 - name: deploy dataplane
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -153,6 +193,7 @@
         - ctlplane
       preProvisioned: true
       services:
+        - repo-setup
         - download-cache
         - bootstrap
         - configure-network
@@ -225,6 +266,10 @@
             # SELinux module
             edpm_selinux_mode: enforcing
             plan: overcloud
+
+            # Do not attempt OVS 3.2 major upgrades here
+            edpm_ovs_packages:
+            - openvswitch3.1
     EOF
 
 - name: deploy the dataplane deployment


### PR DESCRIPTION
After decontainerization, libvirt can no longer be started during adoption procedure. Workaround this by upgrading openstack-selinux during repo-setup osdpservice created during adoption.

Provide extra dataplane deployment service on EDPM computes to install RDO Antelope DLRN repos as a hack, until we figure a better source of OSP18 repos for rhel9 hosts used in the Adoption CI. Do not attempt OVS 3.2 or other host system components major upgrades here.

A complete solution should be to perform dnf caching and upgrading for other packages in EDPM ansible, including OVS upgrades.

Here we only ensuring that decontainerized libvirt can start to solve the regression.

This is also required for a simple VM adoption testing for Nova adoption

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/539

Enables [OSPRH-3123](https://issues.redhat.com/browse/OSPRH-3123)
Ublocks [OSPRH-813](https://issues.redhat.com/browse/OSPRH-813)
Ublocks [OSPRH-84](https://issues.redhat.com/browse/OSPRH-84)