### PR TITLE
Fix dev docs rendering

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -326,6 +326,7 @@ make standalone_revert
 Clean up and initialize the storage PVs in CRC vm
 
 [,bash]
+----
 cd ..
 make crc_storage_cleanup
 make crc_storage


### PR DESCRIPTION
Recently a change introduced invalid AsciiDoc syntax into the contributor docs and they failed to render:

asciidoctor: WARNING: assemblies/tests.adoc: line 48: unterminated listing block

This patch fixes the above issue.