### PR TITLE
Optionally deploy cinder-volume with a Ceph backend

### DIFF
--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -22,6 +22,7 @@
   vars:
     glance_backend: ceph
     manila_backend: cephfs
+    cinder_backend: ceph
   module_defaults:
     ansible.builtin.shell:
       executable: /bin/bash

--- a/tests/roles/cinder_adoption/defaults/main.yaml
+++ b/tests/roles/cinder_adoption/defaults/main.yaml
@@ -1,0 +1,4 @@
+# cinder_backend is an empty string by default. When the OpenStackControlPlane
+# is deployed, no CinderVolumer replicas are present.
+# We currently support only Ceph in the testsuite role.
+cinder_backend: ""

--- a/tests/roles/cinder_adoption/tasks/backend.yaml
+++ b/tests/roles/cinder_adoption/tasks/backend.yaml
@@ -1,0 +1,37 @@
+- name: Deploy podified cinder-volume and configure the backend
+  when: cinder_backend | default('') == 'ceph'
+  block:
+    - name: deploy podified Cinder Volume with a Ceph backend
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc patch openstackcontrolplane openstack --type=merge --patch '
+          spec:
+            cinder:
+              template:
+                cinderVolumes:
+                  volume1:
+                    networkAttachments:
+                    - storage
+                    replicas: 1
+                    customServiceConfig: |
+                      [DEFAULT]
+                      enabled_backends=ceph
+                      [ceph]
+                      volume_backend_name=ceph
+                      volume_driver=cinder.volume.drivers.rbd.RBDDriver
+                      rbd_ceph_conf=/etc/ceph/ceph.conf
+                      rbd_user=openstack
+                      rbd_pool=volumes
+                      rbd_flatten_volume_from_snapshot=False
+          '
+
+    - name: wait for Cinder Volume to start up - Ceph
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc get pod --selector=component=cinder-volume -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+      register: cinder_volume_running_result
+      until: cinder_volume_running_result is success
+      retries: 180
+      delay: 2

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -44,6 +44,11 @@
   retries: 180
   delay: 2
 
+# cinder-api and cinder-scheduler are up and running at this point: configure
+# the cinder-volume backend if it's part of the job
+- name: Deploy cinder-volume and configure the backend
+  ansible.builtin.include_tasks: backend.yaml
+
 - name: check that Cinder is reachable and its endpoints are defined
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
This patch patch the ctlplane to deploy cinder-volume with a ceph backend. If cinder_backend is not defined or is empty, no cinder-volume is deployed, preserving the current behavior.

Fixes: [OSPRH-2442](https://issues.redhat.com/browse/OSPRH-2442)