### PR TITLE
Tests: Cinder volume and backup support

### DIFF
--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -22,6 +22,8 @@
   vars:
     glance_backend: ceph
     manila_backend: cephfs
+    cinder_volume_backend: ceph
+    cinder_backup_backend: ceph
   module_defaults:
     ansible.builtin.shell:
       executable: /bin/bash

--- a/tests/playbooks/tests/roles/cinder_adoption/defaults/main.yam
+++ b/tests/playbooks/tests/roles/cinder_adoption/defaults/main.yam
@@ -1,0 +1,4 @@
+# Volume backends: ceph
+# Backup backends: ceph or swift
+cinder_volume_backend: ""
+cinder_backup_backend: ""

--- a/tests/roles/cinder_adoption/tasks/backup_backend.yaml
+++ b/tests/roles/cinder_adoption/tasks/backup_backend.yaml
@@ -1,0 +1,44 @@
+- name: deploy podified Cinder backup
+  when: cinder_backup_backend == 'ceph'
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '
+    spec:
+      cinder:
+        enabled: true
+        template:
+          cinderBackup:
+            networkAttachments:
+            - storage
+            replicas: 1
+            customServiceConfig: |
+              [DEFAULT]
+              backup_driver=cinder.backup.drivers.ceph.CephBackupDriver
+              backup_ceph_conf=/etc/ceph/ceph.conf
+              backup_ceph_user=openstack
+              backup_ceph_pool=backups
+    '
+
+- name: deploy podified Cinder backup
+  when: cinder_backup_backend == 'swift'
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '
+    spec:
+      cinder:
+        enabled: true
+        template:
+          cinderBackup:
+            networkAttachments:
+            - storage
+            replicas: 1
+            customServiceConfig: |
+              [DEFAULT]
+              backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver
+              # Below are defaults, explicit for illustration purposes
+              backup_swift_auth = per_user
+              keystone_catalog_info = identity:Identity Service:publicURL
+              swift_catalog_info = object-store:swift:publicURL
+    '

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -25,24 +25,41 @@
           cinderBackup:
             networkAttachments:
             - storage
-            replicas: 0 # backend needs to be configured
+            replicas: 0 # no backups by default
           cinderVolumes:
             volume1:
               networkAttachments:
               - storage
-              replicas: 0 # backend needs to be configured
+              replicas: 0 # no volumes by default
     '
 
-- name: wait for Cinder to start up
+- name: Deploy cinder-volume if necessary
+  when: cinder_volume_backend != ''
+  ansible.builtin.include_tasks: volume_backend.yaml
+
+- name: Deploy cinder-backup if necessary
+  when: cinder_backup_backend != ''
+  ansible.builtin.include_tasks: backup_backend.yaml
+
+- name: wait for Cinder pods to start up
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     oc get pod --selector=component=cinder-scheduler -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
     oc get pod --selector=component=cinder-api -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    [ -n "{{ cinder_volume_backend }}" ] && oc get pod --selector=component=cinder-volume -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    [ -n "{{ cinder_backup_backend }}" ] && oc get pod --selector=component=cinder-backup -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 180
   delay: 2
+
+# Give time for volume and backup services to initialize drivers, otherwise they
+# always looks ok (up) because that's the default at the start.
+- name: Pause to allow backend drivers to start
+  when: cinder_volume_backend != '' or cinder_backup_backend != ''
+  ansible.builtin.pause:
+     seconds: 90
 
 - name: check that Cinder is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -55,6 +72,28 @@
   register: cinder_responding_result
   until: cinder_responding_result is success
   retries: 60
+  delay: 2
+
+- name: wait for Cinder volume to be up and ready
+  when: cinder_volume_backend != ''
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t openstackclient -- openstack volume service list --service cinder-volume | grep ' up '
+  register: cinder_running_result
+  until: cinder_running_result is success
+  retries: 5
+  delay: 2
+
+- name: wait for Cinder backup to be up and ready
+  when: cinder_backup_backend != ''
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t openstackclient -- openstack volume service list --service cinder-backup | grep ' up '
+  register: cinder_running_result
+  until: cinder_running_result is success
+  retries: 5
   delay: 2
 
 - name: Cinder online data migrations

--- a/tests/roles/cinder_adoption/tasks/volume_backend.yaml
+++ b/tests/roles/cinder_adoption/tasks/volume_backend.yaml
@@ -1,0 +1,26 @@
+- name: deploy podified Cinder volume
+  when: cinder_volume_backend == 'ceph'
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '
+    spec:
+      cinder:
+        enabled: true
+        template:
+          cinderVolumes:
+            volume1:
+              networkAttachments:
+              - storage
+              replicas: 1
+              customServiceConfig: |
+                [tripleo_ceph]
+                backend_host=hostgroup
+                volume_backend_name=tripleo_ceph
+                volume_driver=cinder.volume.drivers.rbd.RBDDriver
+                rbd_ceph_conf=/etc/ceph/ceph.conf
+                rbd_user=openstack
+                rbd_pool=volumes
+                rbd_flatten_volume_from_snapshot=False
+                report_discard_supported=True
+    '

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -18,6 +18,7 @@
                     "tripleo_cinder_api.service"
                     "tripleo_cinder_api_cron.service"
                     "tripleo_cinder_scheduler.service"
+                    "tripleo_cinder_volume.service"
                     "tripleo_cinder_backup.service"
                     "tripleo_glance_api.service"
                     "tripleo_manila_api.service"


### PR DESCRIPTION
This patch adds the cinder volume and backup services to the tests.

For now only Ceph is supported in both services, and the backup can also be deployed with swift.

By default none of these cinder services are deployed and we must use `cinder_volume_backend` and `cinder_backup_backend` to deploy them, as illustrated in `tests/playbooks/test_with_ceph.yaml`.

For cinder volume and backup services we'll not only confirm that the pods are running, but also that the services are reporting as being `up`.

Jira: OSPRH-2442