### PR TITLE
Check pull requests that docs rendering works

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,8 +4,17 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docs*
+      - docs_dev/**
+      - docs_user/**
+      - Gemfile
+      - Makefile
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -62,5 +71,6 @@ jobs:
           git commit -m "Rendered docs"
 
       - name: Push rendered docs to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git push --force origin gh-pages


### PR DESCRIPTION
Until now we ran docs build & push only after a push to the main branch. Newly we'll run the docs build workflow both on a push to the main branch and on pull requests. We'll only run the last task (acutal push to Github Pages) on a push to the main branch, not on pull requests.