### PR TITLE
Simplify repo-setup to get RDO Antelope repos

### DIFF
--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -221,7 +221,6 @@ spec:
             # here we only ensuring that decontainerized libvirt can start
             ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
             dnf -y upgrade openstack-selinux
-            rpm -q python3-tripleoclient && dnf -y erase python3-tripleoclient --exclude=openvswitch3.1 --exclude=openvswitch-selinux-extra-policy --exclude=openstack-network-scripts-openvswitch3.1 --exclude=python3-openvswitch3.1 --exclude=python3-rdo-openvswitch --exclude=rdo-openvswitch --exclude=rhosp-openvswitch-3.1 --exclude=python3-rhosp-openvswitch
             rm -f /run/virtlogd.pid
             rm -rf repo-setup-main
 EOF

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -174,7 +174,6 @@
                 # here we only ensuring that decontainerized libvirt can start
                 ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
                 dnf -y upgrade openstack-selinux
-                rpm -q python3-tripleoclient && dnf -y erase python3-tripleoclient --exclude=openvswitch3.1 --exclude=openvswitch-selinux-extra-policy --exclude=openstack-network-scripts-openvswitch3.1 --exclude=python3-openvswitch3.1 --exclude=python3-rdo-openvswitch --exclude=rdo-openvswitch --exclude=rhosp-openvswitch-3.1 --exclude=python3-rhosp-openvswitch
                 rm -f /run/virtlogd.pid
                 rm -rf repo-setup-main
     EOF


### PR DESCRIPTION
Remove unrelated commands to erase tripleoclient.
It used to required with RPMs auto-upgrade policy set in
EDPM bootstrap/download_cache, which is no longer a thing.