### PR TITLE
Glance with NFS backend adoption process

### DIFF
--- a/docs_user/modules/openstack-glance_adoption.adoc
+++ b/docs_user/modules/openstack-glance_adoption.adoc
@@ -44,19 +44,224 @@ spec:
       storageRequest: 10G
       glanceAPIs:
         default:
+          type: single
           override:
             service:
-              metadata:
-                annotations:
-                  metallb.universe.tf/address-pool: internalapi
-                  metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
           networkAttachments:
           - storage
 '
 ----
+
+=== Using NFS backend
+
+When the source Cloud based on TripleO uses Glance with a NFS backend, before
+patching the OpenStackControlPlane to deploy Glance it's important to validate
+a few networking related prerequisites.
+In the source cloud, verify the NFS parameters used by the overcloud to configure
+the Glance backend.
+In particular, find among the TripleO heat templates the following variables:
+
+
+[,bash]
+---
+GlanceBackend : file
+GlanceNfsEnabled: true
+GlanceNfsShare: '192.168.24.1:/var/nfs
+'
+---
+
+that are usually an override of the default content provided by
+`/usr/share/openstack-tripleo-heat-templates/environments/storage/glance-nfs.yaml`[glance-nfs.yaml].
+In the example above, as the first variable shows, unlike Cinder, Glance has no
+notion of NFS backend: the `File` driver is used in this scenario, and behind the
+scenes, the `filesystem_store_datadir` which usually points to `/var/lib/glance/images/`
+is mapped to the export value provided by the `GlanceNfsShare` variable.
+If the `GlanceNfsShare` is not exported through a network that is supposed to be
+propagated to the adopted `OpenStack` control plane, an extra action is required
+by the human administrator, who must stop the `nfs-server` and remap the export
+to the `storage` network. This action usually happens when the Glance service is
+stopped in the source controller nodes.
+In the podified control plane, as per the
+(https://github.com/openstack-k8s-operators/docs/blob/main/images/network_diagram.jpg)[network isolation diagram],
+Glance is attached to the Storage network, propagated via the associated
+`NetworkAttachmentsDefinition` CR, and the resulting Pods have already the right
+permissions to handle the Image Service traffic through this network.
+In a deployed OpenStack control plane, you can verify that the network mapping
+matches with what has been deployed in the TripleO based environment by checking
+both the `NodeNetworkConfigPolicy` (`nncp`) and the `NetworkAttachmentDefinition`
+(`net-attach-def`) with the following commands:
+
+```
+$ oc get nncp
+NAME                        STATUS      REASON
+enp6s0-crc-8cf2w-master-0   Available   SuccessfullyConfigured
+
+$ oc get net-attach-def
+NAME
+ctlplane
+internalapi
+storage
+tenant
+
+$ oc get ipaddresspool -n metallb-system
+NAME          AUTO ASSIGN   AVOID BUGGY IPS   ADDRESSES
+ctlplane      true          false             ["192.168.122.80-192.168.122.90"]
+internalapi   true          false             ["172.17.0.80-172.17.0.90"]
+storage       true          false             ["172.18.0.80-172.18.0.90"]
+tenant        true          false             ["172.19.0.80-172.19.0.90"]
+```
+
+The above represents an example of the output that should be checked in the
+openshift environment to make sure there are no issues with the propagated
+networks.
+
+The following steps assume that:
+
+1. the Storage network has been propagated to the openstack control plane
+2. Glance is able to reach the Storage network and connect to the nfs-server
+   through the port `2049`.
+
+If the above conditions are met, it is possible to adopt the `Glance` service
+and create a new `default` `GlanceAPI` instance connected with the existing
+NFS share.
+
+[,bash]
+----
+cat << EOF > glance_nfs_patch.yaml
+
+spec:
+  extraMounts:
+  - extraVol:
+    - extraVolType: Nfs
+      mounts:
+      - mountPath: /var/lib/glance/images
+        name: nfs
+      propagation:
+      - Glance
+      volumes:
+      - name: nfs
+        nfs:
+          path: /var/nfs
+          server: 172.17.3.20
+    name: r1
+    region: r1
+  glance:
+    enabled: true
+    template:
+      databaseInstance: openstack
+      customServiceConfig: |
+         [DEFAULT]
+         enabled_backends = default_backend:file
+         [glance_store]
+         default_backend = default_backend
+         [default_backend]
+         filesystem_store_datadir = /var/lib/glance/images/
+      storageClass: "local-storage"
+      storageRequest: 10G
+      glanceAPIs:
+        default:
+          type: single
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+          networkAttachments:
+          - storage
+EOF
+----
+
+*Note*:
+
+Replace in `glance_nfs_patch.yaml` the `nfs/server` ip address with the IP used
+to reach the `nfs-server` and make sure the `nfs/path` points to the exported
+path in the `nfs-server`.
+
+Patch OpenStackControlPlane to deploy Glance with a NFS backend:
+
+[,bash]
+----
+oc patch openstackcontrolplane openstack --type=merge --patch-file glance_nfs_patch.yaml
+----
+
+When GlanceAPI is active, you can see a single API instance:
+
+```
+$ oc get pods -l service=glance
+NAME                      READY   STATUS    RESTARTS
+glance-default-single-0   3/3     Running   0
+```
+
+and the description of the pod must report:
+
+```
+Mounts:
+...
+  nfs:
+    Type:      NFS (an NFS mount that lasts the lifetime of a pod)
+    Server:    {{ server ip address }}
+    Path:      {{ nfs export path }}
+    ReadOnly:  false
+...
+```
+
+It is also possible to double check the mountpoint by running the following:
+
+```
+oc rsh -c glance-api glance-default-single-0
+
+sh-5.1# mount
+...
+...
+{{ ip address }}:/var/nfs on /var/lib/glance/images type nfs4 (rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=172.18.0.5,local_lock=none,addr=172.18.0.5)
+...
+...
+```
+
+You can run an `openstack image create` command and double check, on the NFS
+node, the uuid has been created in the exported directory.
+
+For example:
+
+```
+$ oc rsh openstackclient
+$ openstack image list
+
+sh-5.1$  curl -L -o /tmp/cirros-0.5.2-x86_64-disk.img http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
+...
+...
+
+sh-5.1$ openstack image create --container-format bare --disk-format raw --file /tmp/cirros-0.5.2-x86_64-disk.img cirros
+...
+...
+
+sh-5.1$ openstack image list
++--------------------------------------+--------+--------+
+| ID                                   | Name   | Status |
++--------------------------------------+--------+--------+
+| 634482ca-4002-4a6d-b1d5-64502ad02630 | cirros | active |
++--------------------------------------+--------+--------+
+```
+
+On the nfs-server node, we can see the same `uuid` in the exported `/var/nfs`:
+
+```
+$ ls /var/nfs/
+634482ca-4002-4a6d-b1d5-64502ad02630
+```
 
 === Using Ceph storage backend
 
@@ -93,11 +298,12 @@ spec:
         default:
           override:
             service:
-              metadata:
-                annotations:
-                  metallb.universe.tf/address-pool: internalapi
-                  metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
           networkAttachments:
@@ -118,7 +324,7 @@ pushd os-diff
 ----
 
 ____
-This will producre the difference between both ini configuration files.
+This will produce the difference between both ini configuration files.
 ____
 
 Patch OpenStackControlPlane to deploy Glance with Ceph backend:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -16,11 +16,12 @@
             default:
               override:
                 service:
-                  metadata:
-                    annotations:
-                      metallb.universe.tf/address-pool: internalapi
-                      metallb.universe.tf/allow-shared-ip: internalapi
-                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  internal:
+                    metadata:
+                      annotations:
+                        metallb.universe.tf/address-pool: internalapi
+                        metallb.universe.tf/allow-shared-ip: internalapi
+                        metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                   spec:
                     type: LoadBalancer
               networkAttachments:
@@ -54,11 +55,12 @@
             default:
               override:
                 service:
-                  metadata:
-                    annotations:
-                      metallb.universe.tf/address-pool: internalapi
-                      metallb.universe.tf/allow-shared-ip: internalapi
-                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  internal:
+                    metadata:
+                      annotations:
+                        metallb.universe.tf/address-pool: internalapi
+                        metallb.universe.tf/allow-shared-ip: internalapi
+                        metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                   spec:
                     type: LoadBalancer
               networkAttachments:


### PR DESCRIPTION
This patch improves the documentation describing how we can adopt the `OpenStack Image Service` deployed in `TripleO` with the `NFS` backend.
It also provides a syntax fix for the test suite when network isolation annotations are defined.

Fixes: [OSPRH-1395](https://issues.redhat.com/browse/OSPRH-1395)