### PR TITLE
Support custom EDPM node IPs during adoption

### DIFF
--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -15,11 +15,17 @@ ____
 == Variables
 
 Define the shell variables used in the Fast-forward upgrade steps below.
+Define the map of compute node name, IP pairs.
 The values are just illustrative, use values that are correct for your environment:
 
 [,bash]
 ----
 PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
+declare -A computes
+export computes=(
+  ["standalone.localdomain"]="192.168.122.100"
+  # ...
+)
 ----
 
 == Pre-checks
@@ -98,17 +104,6 @@ EOF
 
 * _Temporary fix_ until the OSP 17 https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid[backport of the stable compute UUID feature]
 lands.
-+
-Define the map of compute node name, IP pairs:
-+
-[,bash]
-----
-declare -A computes
-computes=(
-  ["standalone.localdomain"]="192.168.122.100"
-  # ...
-)
-----
 +
 For each compute node grab the UUID of the compute service and write it too
 the stable `compute_id` file in `/var/lib/nova/` directory.
@@ -268,10 +263,10 @@ spec:
     standalone:
       hostName: standalone
       ansible:
-        ansibleHost: 192.168.122.100
+        ansibleHost: ${computes[standalone.localdomain]}
       networks:
       - defaultRoute: true
-        fixedIP: 192.168.122.100
+        fixedIP: ${computes[standalone.localdomain]}
         name: CtlPlane
         subnetName: subnet1
       - name: InternalApi

--- a/docs_user/modules/openstack-stop_remaining_services.adoc
+++ b/docs_user/modules/openstack-stop_remaining_services.adoc
@@ -13,8 +13,9 @@ Templates).
 
 == Variables
 
-Define the shell variables used in the steps below. The values are
-just illustrative and refer to a single node standalone director deployment,
+Define the shell variables used in the steps below.
+Define the map of compute node name, IP pairs.
+The values are just illustrative and refer to a single node standalone director deployment,
 use values that are correct for your environment:
 
 [,bash]
@@ -22,8 +23,8 @@ use values that are correct for your environment:
 EDPM_PRIVATEKEY_PATH="~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa"
 declare -A computes
 computes=(
-["standalone.localdomain"]="192.168.122.100"
-# ...
+  ["standalone.localdomain"]="192.168.122.100"
+  # ...
 )
 ----
 

--- a/tests/roles/stop_remaining_services/tasks/main.yaml
+++ b/tests/roles/stop_remaining_services/tasks/main.yaml
@@ -8,7 +8,7 @@
       EDPM_PRIVATEKEY_PATH="{{ edpm_privatekey_path }}"
       declare -A computes
       computes=(
-      ["standalone.localdomain"]="{{ edpm_node_ip }}"
+        ["standalone.localdomain"]="{{ edpm_node_ip }}"
       )
 
 - name: stop compute services


### PR DESCRIPTION
When a node IP changes, hardcoded values fail EDPM adoption. Use the declared computes hashmap to properly populate the standalone host IP value. This approach allows deploying edpm and standalone hosts on custom IPs and enables multi-cell adoption future work.