### PR TITLE
Fix how the TripleO variables are rendered for Glance

### DIFF
--- a/docs_user/modules/openstack-glance_adoption.adoc
+++ b/docs_user/modules/openstack-glance_adoption.adoc
@@ -69,13 +69,14 @@ In the source cloud, verify the NFS parameters used by the overcloud to configur
 the Glance backend.
 In particular, find among the TripleO heat templates the following variables:
 
-
-[,bash]
 ---
-GlanceBackend : file
-GlanceNfsEnabled: true
-GlanceNfsShare: '192.168.24.1:/var/nfs
-'
+
+**GlanceBackend**: file
+
+**GlanceNfsEnabled**: true
+
+**GlanceNfsShare**: 192.168.24.1:/var/nfs
+
 ---
 
 that are usually an override of the default content provided by


### PR DESCRIPTION
This patch just fixes how the TripleO variables are rendered in the NFS section for Glance adoption.