### PR TITLE
[glance_adoption] Ensure replicas is set for glance CR

### DIFF
--- a/docs_user/modules/openstack-glance_adoption.adoc
+++ b/docs_user/modules/openstack-glance_adoption.adoc
@@ -44,6 +44,7 @@ spec:
       storageRequest: 10G
       glanceAPIs:
         default:
+          replicas: 1
           type: single
           override:
             service:
@@ -169,6 +170,7 @@ spec:
       storageRequest: 10G
       glanceAPIs:
         default:
+          replicas: 1
           type: single
           override:
             service:
@@ -297,6 +299,7 @@ spec:
       storageRequest: 10G
       glanceAPIs:
         default:
+          replicas: 1
           override:
             service:
               internal:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -14,6 +14,7 @@
           storageRequest: 10G
           glanceAPIs:
             default:
+              replicas: 1
               override:
                 service:
                   internal:
@@ -53,6 +54,7 @@
           storageRequest: 10G
           glanceAPIs:
             default:
+              replicas: 1
               override:
                 service:
                   internal:


### PR DESCRIPTION
With [1] replicas needs to be explicitly set for glanceAPI instances while patching it along with backend configuration. This is needed for cases where empty spec for glanceAPIs is used during initial creation.

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/417