### PR TITLE
Tests: Fix Cinder test with no volume or backup

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -47,8 +47,8 @@
     {{ oc_header }}
     oc get pod --selector=component=cinder-scheduler -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
     oc get pod --selector=component=cinder-api -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
-    [ -n "{{ cinder_volume_backend }}" ] && oc get pod --selector=component=cinder-volume -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
-    [ -n "{{ cinder_backup_backend }}" ] && oc get pod --selector=component=cinder-backup -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    [ -z "{{ cinder_volume_backend }}" ] || oc get pod --selector=component=cinder-volume -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    [ -z "{{ cinder_backup_backend }}" ] || oc get pod --selector=component=cinder-backup -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 180


### PR DESCRIPTION
The logic to detect when cinder volume and cinder backups are running in the "wait for Cinder pods to start up" task of the cinder_adoption role fails when there is no volume or backend, because the logic is faulty.

This patch changes the logic so that either the variable that specifies the backup and volume backend is empty or the `oc` command to check for the status of the pod succeeds.