### PR TITLE
Explicitly add the File backend for local storage

### DIFF
--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -6,14 +6,20 @@
     spec:
       glance:
         enabled: true
-        apiOverride:
-          route: {}
         template:
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_backends = default_backend:file
+            [glance_store]
+            default_backend = default_backend
+            [default_backend]
+            filesystem_store_datadir = /var/lib/glance/images/
           databaseInstance: openstack
           storageClass: "local-storage"
           storageRequest: 10G
           glanceAPIs:
             default:
+              type: single
               replicas: 1
               override:
                 service:


### PR DESCRIPTION
Local storage is an example where glance is adopted with a dummy backend.
While we decide what should be used as base use case, this patch fixes the local backend adoption by adding type:single, otherwise the webhook will deny the deployment, and we explicitly add the file config to avoid unexpected parsing behaviors.