### PR TITLE
Use galera VIP and verify all members synced

### DIFF
--- a/docs_user/modules/openstack-mariadb_copy.adoc
+++ b/docs_user/modules/openstack-mariadb_copy.adoc
@@ -30,7 +30,6 @@ control plane services are running.
 future. For example, you might require routability from the original MariaDB to
 podified MariaDB_.
 * Podman package is installed
-* `CONTROLLER1_SSH`, `CONTROLLER2_SSH`, and `CONTROLLER3_SSH` are configured.
 
 == Variables
 
@@ -49,12 +48,30 @@ CHARACTER_SET=utf8
 COLLATION=utf8_general_ci
 
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
-# Replace with your environment's MariaDB IP:
-SOURCE_MARIADB_IP=192.168.122.100
+# Replace with your environment's MariaDB Galera cluster VIP and backend IPs:
+SOURCE_MARIADB_IP=192.168.122.99
+declare -A SOURCE_GALERA_MEMBERS
+SOURCE_GALERA_MEMBERS=(
+  ["standalone.localdomain"]=192.168.122.100
+  # ...
+)
 SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
 ----
 
 == Pre-checks
+
+* Check that the Galera database cluster members are online and synced:
++
+[,bash]
+----
+for i in "${!SOURCE_GALERA_MEMBERS[@]}"; do
+  echo "Checking for the database node $i WSREP status Synced"
+  sudo podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+    -h "${SOURCE_GALERA_MEMBERS[$i]}" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" \
+    -e "show global status like 'wsrep_local_state_comment';" |\
+    grep -qE '\bSynced\b'
+done
+----
 
 * Get the count of not-OK source databases:
 +

--- a/tests/roles/mariadb_copy/tasks/env_vars_src.yaml
+++ b/tests/roles/mariadb_copy/tasks/env_vars_src.yaml
@@ -5,4 +5,9 @@
       MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
       # TODO: remove the default(external_...) when CI is transitioned to use 'source_...'
       SOURCE_MARIADB_IP={{ source_mariadb_ip|default(external_mariadb_ip) }}
+      declare -A SOURCE_GALERA_MEMBERS
+      SOURCE_GALERA_MEMBERS=(
+      ["standalone.localdomain"]={{ source_mariadb_ip|default(external_mariadb_ip) }}
+      # ...
+      )
       SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password|default(external_db_root_password) }}"

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -6,6 +6,18 @@
   ansible.builtin.include_tasks:
     file: env_vars_dst.yaml
 
+- name: check that the Galera database cluster members are online and synced
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    for i in "${!SOURCE_GALERA_MEMBERS[@]}"; do
+      echo "Checking for the database node $i WSREP status Synced"
+      sudo podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+        -h "${SOURCE_GALERA_MEMBERS[$i]}" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" \
+        -e "show global status like 'wsrep_local_state_comment';" |\
+        grep -qE '\bSynced\b'
+    done
+
 - name: Get the count of not-OK source databases
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -13,8 +13,8 @@ storage_reclaim_policy: delete # or retain
 oc_header: |
   eval $(crc oc-env)
 
-# Source MariaDB IP for DB exports.
-source_mariadb_ip: 192.168.122.100 #CUSTOMIZE_THIS
+# Source MariaDB Galera cluster VIP for DB exports.
+source_mariadb_ip: 192.168.122.99 #CUSTOMIZE_THIS
 
 # Source OVN DB IP for DB exports.
 source_ovndb_ip: 192.168.122.100 #CUSTOMIZE_THIS


### PR DESCRIPTION
When importing databases, access Galera cluster by a VIP.

Verify galera cluster members are synced, before starting the databases adoption. That is needed to make sure the DB cluster is not degraded, and there is no ongoing WSREP replications. That should also help to shut it down later gracefully.