### PR TITLE
Remove explicit params from Heat CR

### DIFF
--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -36,6 +36,10 @@ spec:
     template:
       glanceAPIs: {}
 
+  heat:
+    enabled: false
+    template: {}
+
   horizon:
     enabled: false
     template: {}

--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -22,9 +22,6 @@
           route: {}
         template:
           databaseInstance: openstack
-          databaseUser: heat
-          rabbitMqClusterName: rabbitmq
-          serviceUser: heat
           secret: osp-secret
           memcachedInstance: memcached
           passwordSelectors:


### PR DESCRIPTION
Heat seems to be the only operator explicitly defining rabbitMqClusterName, databaseUser and serviceUser. This change removes them from the test to ensure default values can be applied when Heat is enabeld.