### PR TITLE
Downstream docs variant

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,8 +30,11 @@ jobs:
 
       - name: Install Asciidoc
         run: make docs-dependencies
-      - name: Build user docs
+
+      - name: Build upstream user docs
         run: make docs-user
+      - name: Build downstream preview of user docs
+        run: BUILD=downstream make docs-user
       - name: Build dev docs
         run: make docs-dev
 
@@ -63,6 +66,7 @@ jobs:
           mv -T docs_build/adoption-dev dev
 
           mv user/index-upstream.html user/index.html
+          mv user/index-downstream.html user/downstream.html
           mv dev/index-upstream.html dev/index.html
 
           git add user

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ docs-dependencies: .bundle
 
 	bundle config set --local path 'local/bundle'; bundle install
 
-docs: docs-dependencies docs-user docs-dev
+docs: docs-dependencies docs-user-all-variants docs-dev
+
+docs-user-all-variants:
+	cd docs_user; BUILD=upstream $(MAKE) html
+	cd docs_user; BUILD=downstream $(MAKE) html
 
 docs-user:
 	cd docs_user; $(MAKE) html

--- a/docs_user/Makefile
+++ b/docs_user/Makefile
@@ -1,4 +1,4 @@
-BUILD = upstream
+BUILD ?= upstream
 BUILD_DIR = ../docs_build
 ROOTDIR = $(realpath .)
 NAME = adoption-user
@@ -30,6 +30,7 @@ html-latest: prepare $(IMAGES_TS) $(DEST_HTML)
 pdf: prepare $(DEST_PDF)
 
 prepare:
+	@if [ "$(BUILD)" != upstream -a "$(BUILD)" != downstream ]; then echo "BUILD must be 'upstream' or 'downstream'."; exit 1; fi
 	@mkdir -p $(BUILD_DIR)
 	@mkdir -p $(DEST_DIR) $(IMAGES_DIR)
 

--- a/docs_user/modules/openstack-autoscaling_adoption.adoc
+++ b/docs_user/modules/openstack-autoscaling_adoption.adoc
@@ -34,16 +34,25 @@ spec:
         [DEFAULT]
         debug=true
       secret: osp-secret
+ifeval::["{build}" == "upstream"]
       apiImage: "quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified"
       evaluatorImage: "quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified"
       notifierImage: "quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified"
       listenerImage: "quay.io/podified-antelope-centos9/openstack-aodh-listener:current-podified"
+endif::[]
+ifeval::["{build}" == "downstream"]
+      apiImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-api-rhel9:18.0"
+      evaluatorImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-evaluator-rhel9:18.0"
+      notifierImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-notifier-rhel9:18.0"
+      listenerImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-listener-rhel9:18.0"
+endif::[]
       passwordSelectors:
       databaseUser: aodh
       databaseInstance: openstack
       memcachedInstance: memcached
 EOF
 ----
+
 
 ____
 If you have previously backed up your OpenStack services configuration file from the old environment, you can use os-diff to compare and make sure the configuration is correct. For more information, see xref:pulling-the-openstack-configuration_{context}[Pulling the OpenStack configuration].

--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -355,12 +355,22 @@ spec:
         - hostname: clock.redhat.com
         - hostname: clock2.redhat.com
 
+ifeval::["{build}" == "upstream"]
         edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
         edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
         edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
         edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
         edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
         edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
+endif::[]
+ifeval::["{build}" == "downstream"]
+        edpm_ovn_controller_agent_image: registry.redhat.io/rhosp-dev-preview/openstack-ovn-controller-rhel9:18.0
+        edpm_iscsid_image: registry.redhat.io/rhosp-dev-preview/openstack-iscsid-rhel9:18.0
+        edpm_logrotate_crond_image: registry.redhat.io/rhosp-dev-preview/openstack-cron-rhel9:18.0
+        edpm_nova_compute_container_image: registry.redhat.io/rhosp-dev-preview/openstack-nova-compute-rhel9:18.0
+        edpm_nova_libvirt_container_image: registry.redhat.io/rhosp-dev-preview/openstack-nova-libvirt-rhel9:18.0
+        edpm_ovn_metadata_agent_image: registry.redhat.io/rhosp-dev-preview/openstack-neutron-metadata-agent-ovn-rhel9:18.0
+endif::[]
 
         gather_facts: false
         enable_debug: false

--- a/docs_user/modules/openstack-mariadb_copy.adoc
+++ b/docs_user/modules/openstack-mariadb_copy.adoc
@@ -49,7 +49,12 @@ PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRoo
 CHARACTER_SET=utf8
 COLLATION=utf8_general_ci
 
+ifeval::["{build}" == "upstream"]
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+endif::[]
+ifeval::["{build}" == "downstream"]
+MARIADB_IMAGE=registry.redhat.io/rhosp-dev-preview/openstack-mariadb-rhel9:18.0
+endif::[]
 # Replace with your environment's MariaDB Galera cluster VIP and backend IPs:
 SOURCE_MARIADB_IP=192.168.122.99
 declare -A SOURCE_GALERA_MEMBERS

--- a/docs_user/modules/openstack-ovn_adoption.adoc
+++ b/docs_user/modules/openstack-ovn_adoption.adoc
@@ -38,7 +38,12 @@ just illustrative, use values that are correct for your environment:
 
 ----
 STORAGE_CLASS_NAME=crc-csi-hostpath-provisioner
+ifeval::["{build}" == "upstream"]
 OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
+endif::[]
+ifeval::["{build}" == "downstream"]
+OVSDB_IMAGE=registry.redhat.io/rhosp-dev-preview/openstack-ovn-base-rhel9:18.0
+endif::[]
 SOURCE_OVSDB_IP=172.17.1.49
 ----
 

--- a/docs_user/modules/openstack-pull_openstack_configuration.adoc
+++ b/docs_user/modules/openstack-pull_openstack_configuration.adoc
@@ -95,7 +95,12 @@ just illustrative, use values that are correct for your environment:
 [,bash]
 ----
 CONTROLLER_SSH="ssh -F ~/director_standalone/vagrant_ssh_config vagrant@standalone"
+ifeval::["{build}" == "upstream"]
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
+endif::[]
+ifeval::["{build}" == "downstream"]
+MARIADB_IMAGE=registry.redhat.io/rhosp-dev-preview/openstack-mariadb-rhel9:18.0
+endif::[]
 SOURCE_MARIADB_IP=192.168.122.100
 SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')
 ----

--- a/docs_user/modules/openstack-telemetry_adoption.adoc
+++ b/docs_user/modules/openstack-telemetry_adoption.adoc
@@ -21,12 +21,15 @@ This guide also assumes that:
 
 Patch OpenStackControlPlane to deploy Ceilometer services:
 
+// TODO(jistr): There are still some quay.io images in the downstream build.
+
 ----
 cat << EOF > ceilometer_patch.yaml
 spec:
   ceilometer:
     enabled: true
     template:
+ifeval::["{build}" == "upstream"]
       centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
       computeImage: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
       customServiceConfig: |
@@ -37,6 +40,19 @@ spec:
       notificationImage: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
       secret: osp-secret
       sgCoreImage: quay.io/infrawatch/sg-core:v5.1.1
+endif::[]
+ifeval::["{build}" == "downstream"]
+      centralImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-central-rhel9:18.0
+      computeImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-compute-rhel9:18.0
+      customServiceConfig: |
+        [DEFAULT]
+        debug=true
+      ipmiImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-ipmi-rhel9:18.0
+      nodeExporterImage: quay.io/prometheus/node-exporter:v1.5.0
+      notificationImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-notification-rhel9:18.0
+      secret: osp-secret
+      sgCoreImage: quay.io/infrawatch/sg-core:v5.1.1
+endif::[]
 EOF
 ----
 


### PR DESCRIPTION
Downstream docs preview can be built with:

```
BUILD=downstream make docs-user
```

(and analogously for the `docs-user-open` and `docs-user-watch` make targets).
