### PR TITLE
[ovn_adoption] start northd/ovn-controller after ovndbs adoption

### DIFF
--- a/docs_user/modules/openstack-backend_services_deployment.adoc
+++ b/docs_user/modules/openstack-backend_services_deployment.adoc
@@ -232,9 +232,11 @@ spec:
           networkAttachment: internalapi
       ovnNorthd:
         networkAttachment: internalapi
-        replicas: 1
+        replicas: 0
       ovnController:
         networkAttachment: tenant
+        nodeSelector:
+          node: non-existing-node-name
 
   placement:
     enabled: false

--- a/docs_user/modules/openstack-ovn_adoption.adoc
+++ b/docs_user/modules/openstack-ovn_adoption.adoc
@@ -116,7 +116,7 @@ oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6641 
 oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6642 > /backup/ovs-sb.db"
 ----
 
-* Start podified OVN database services prior to import.
+* Start podified OVN database services prior to import, keeping northd/ovn-controller stopped.
 
 [source,yaml]
 ----
@@ -134,6 +134,13 @@ spec:
           dbType: SB
           storageRequest: 10G
           networkAttachment: internalapi
+      ovnNorthd:
+        replicas: 0
+        networkAttachment: internalapi
+      ovnController:
+        networkAttachment: tenant
+        nodeSelector:
+          node: non-existing-node-name
 '
 ----
 
@@ -184,7 +191,15 @@ spec:
     template:
       ovnNorthd:
         networkAttachment: internalapi
+        replicas: 1
 '
+----
+
+* Also enable `ovn-controller`
+
+[source,yaml]
+----
+oc patch openstackcontrolplane openstack --type=json -p="[{'op': 'remove', 'path': '/spec/ovn/template/ovnController/nodeSelector'}]"
 ----
 
 * Delete the ovn-data pod and persistent volume claim with OVN databases backup (consider making a snapshot of it, before deleting)

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -95,9 +95,11 @@ spec:
     template:
       ovnController:
         networkAttachment: tenant
+        nodeSelector:
+          node: non-existing-node-name
       ovnNorthd:
         networkAttachment: internalapi
-        replicas: 1
+        replicas: 0
       ovnDBCluster:
         ovndbcluster-nb:
           dbType: NB
@@ -107,11 +109,6 @@ spec:
           dbType: SB
           networkAttachment: internalapi
           containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
-
-  ovs:
-    enabled: false
-    template:
-      external-ids: {}
 
   placement:
     enabled: false

--- a/tests/config/periodic_ci/container_image_overrides.yaml
+++ b/tests/config/periodic_ci/container_image_overrides.yaml
@@ -95,14 +95,11 @@ spec:
           networkAttachment: internalapi
       ovnNorthd:
         networkAttachment: internalapi
-        replicas: 1
+        replicas: 0
       ovnController:
         networkAttachment: tenant
-
-  ovs:
-    enabled: false
-    template:
-      external-ids: {}
+        nodeSelector:
+          node: non-existing-node-name
 
   placement:
     enabled: false

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -184,6 +184,12 @@
             replicas: 1
     '
 
+- name: Enable ovn controller
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=json -p="[{'op': 'remove', 'path': '/spec/ovn/template/ovnController/nodeSelector'}]"
+
 - name: list briefs from OVN NB and SB databases
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
ovn-controller and northd were started along with ovn dbs, instead these should be started after ovn dbs are adopted.

Currently enable ovnnorthd task was noop as it was already started.

Also remove references for ovs CR which no longer exists since [1].

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/315

Depends-On: https://github.com/openstack-k8s-operators/ovn-operator/pull/232
Related-Issue: OSPRH-2437