### PR TITLE
Adoption of the ovn-controller and neutron-ovn-metadata-agent

### DIFF
--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -422,6 +422,13 @@ spec:
 EOF
 ----
 
+* Adoption of the neutron-ovn-metadata-agent:
++
+Neutron-ovn-metadata-agent running on the EDPM nodes don't require any
+additional actions nor config adjustments to do during the adoption process.
+When OpenStackDataPlaneDeployment and OpenStackDataPlaneNodeSet will be ready,
+neutron-ovn-metadata-agent should be up and running on the EDPM nodes.
+
 == Post-checks
 
 * Check if all the Ansible EE pods reaches `Completed` status:
@@ -440,6 +447,18 @@ EOF
 +
 ----
   oc wait --for condition=Ready osdpns/openstack --timeout=30m
+----
+
+* Verify that neutron agents are alive:
++
+----
+oc exec openstackclient -- openstack network agent list
++--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
+| ID                                   | Agent Type                   | Host                   | Availability Zone | Alive | State | Binary                     |
++--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
+| 10482583-2130-5b0d-958f-3430da21b929 | OVN Metadata agent           | standalone.localdomain |                   | :-)   | UP    | neutron-ovn-metadata-agent |
+| a4f1b584-16f1-4937-b2b0-28102a3f6eaa | OVN Controller agent         | standalone.localdomain |                   | :-)   | UP    | ovn-controller             |
++--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
 ----
 
 == Nova compute services fast-forward upgrade from Wallaby to Antelope

--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -236,6 +236,17 @@ EOF
 
 * Deploy OpenStackDataPlaneNodeSet:
 +
+Make sure that ovn-controller settings configured in the OpenStackDataPlaneNodeSet are the same as were set in the compute nodes before adoption.
+This configuration is stored in the "external_ids" colum in the "Open_vSwitch" table in ovsdb and can be checked with command:
++
+----
+ovs-vsctl list Open .
+...
+external_ids        : {hostname=standalone.localdomain, ovn-bridge=br-int, ovn-bridge-mappings="datacentre:br-ctlplane", ovn-chassis-mac-mappings="datacentre:1e:0a:bb:e6:7c:ad", ovn-encap-ip="172.19.0.100", ovn-encap-tos="0", ovn-encap-type=geneve, ovn-match-northd-version=False, ovn-monitor-all=True, ovn-ofctrl-wait-before-clear="8000", ovn-openflow-probe-interval="60", ovn-remote="tcp:ovsdbserver-sb.openstack.svc:6642", ovn-remote-probe-interval="60000", rundir="/var/run/openvswitch", system-id="2eec68e6-aa21-4c95-a868-31aeafc11736"}
+...
+----
+In above example bridge mappings are set as "datacentre:br-ctlplane" and it has to be set in the OpenStackDataPlaneNodeSet CR also.
++
 [source,yaml]
 ----
 oc apply -f - <<EOF
@@ -350,6 +361,15 @@ spec:
         # edpm_nodes_validation
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
+
+        # edpm ovn-controller configuration
+        edpm_ovn_bridge_mappings: ['datacentre:br-ctlplane']
+        edpm_ovn_bridge: br-int
+        edpm_ovn_encap_type: geneve
+        ovn_match_northd_version: false
+        ovn_monitor_all: true
+        edpm_ovn_remote_probe_interval: 60000
+        edpm_ovn_ofctrl_wait_before_clear: 8000
 
         timesync_ntp_servers:
         - hostname: clock.redhat.com

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -267,6 +267,15 @@
             # Do not attempt OVS 3.2 major upgrades here
             edpm_ovs_packages:
             - openvswitch3.1
+
+            # ovn-controller settings
+            edpm_ovn_bridge_mappings: ['datacentre:br-ctlplane']
+            edpm_ovn_bridge: br-int
+            edpm_ovn_encap_type: geneve
+            ovn_match_northd_version: false
+            ovn_monitor_all: true
+            edpm_ovn_remote_probe_interval: 60000
+            edpm_ovn_ofctrl_wait_before_clear: 8000
     EOF
 
 - name: deploy the dataplane deployment
@@ -323,3 +332,7 @@
 - name: Adopted Nova FFU post-checks
   ansible.builtin.include_tasks:
     file: nova_verify.yaml
+
+- name: Adopted Neutron and OVN agents post-checks
+  ansible.builtin.include_tasks:
+    file: neutron_verify.yaml

--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -1,0 +1,4 @@
+---
+- name: verify connectivity to the existing test VM instance using Floating IP
+  ansible.builtin.shell: |
+      ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}

--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -1,4 +1,23 @@
 ---
+- name: set Neutron services shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    neutron_header: |
+      alias openstack="oc exec -t openstackclient -- openstack"
+      FIP={{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
+
+- name: verify that neutron-ovn-metadata-agent is alive
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ neutron_header }}
+    ${BASH_ALIASES[openstack]} network agent list | grep -F 'neutron-ovn-metadata-agent' | grep -qF 'XXX' || echo PASS
+  register: neutron_verify_metadata_agent_result
+  until: neutron_verify_metadata_agent_result.stdout == 'PASS'
+  # NOTE(slaweq): retries should not be needed but it seems there is some minor
+  # bug in Neutron which causes reporting ovn-metadata-agent as DOWN in every first API request after deploying it on host.
+  retries: 2
+  delay: 1
+
 - name: verify connectivity to the existing test VM instance using Floating IP
   ansible.builtin.shell: |
       ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -46,9 +46,9 @@ ${BASH_ALIASES[openstack]} security group rule list --protocol icmp --ingress -f
 ${BASH_ALIASES[openstack]} security group rule list --protocol tcp --ingress -f json | grep '"Port Range": "22:22"' || \
     ${BASH_ALIASES[openstack]} security group rule create --protocol tcp --ingress --dst-port 22 $(${BASH_ALIASES[openstack]} security group list --project admin -f value -c ID)
 
+export FIP=192.168.122.20
 # check connectivity via FIP
-# FIXME: defer __network_adoption__ - this doesn't work yet in the adoption procedure
-#ping -c4 192.168.122.20
+ping -c4 ${FIP}
 
 # FIXME: Invalid volume: Volume xxx status must be available, but current status is: backing-up
 # Create a Cinder volume, a backup from it, and snapshot it.
@@ -62,5 +62,3 @@ ${BASH_ALIASES[openstack]} security group rule list --protocol tcp --ingress -f 
 # TODO: Add volume to the test VM, after tripleo wallaby (osp 17) isolnet network adoption implemented for storage networks
 #${BASH_ALIASES[openstack]} volume show disk -f json | jq -r '.status' | grep -q available && \
 #    ${BASH_ALIASES[openstack]} server add volume test disk
-
-export FIP=192.168.122.20


### PR DESCRIPTION
This PR contains two commits related to adoption of the ovn-controller and neutron-ovn-metadata-agent on the EDPM nodes.

Closes: issue/OSPRH-2438
Closes: issue/OSPRH-5015