### PR TITLE
sudo rights required to access swift.conf file

### DIFF
--- a/docs_user/modules/openstack-swift_adoption.adoc
+++ b/docs_user/modules/openstack-swift_adoption.adoc
@@ -37,7 +37,7 @@ metadata:
   namespace: openstack
 type: Opaque
 data:
-  swift.conf: $($CONTROLLER1_SSH cat /var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf | base64 -w0)
+  swift.conf: $($CONTROLLER1_SSH sudo cat /var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf | base64 -w0)
 EOF
 ----
 

--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -11,7 +11,7 @@
       namespace: openstack
     type: Opaque
     data:
-      swift.conf: $($CONTROLLER1_SSH cat /var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf | base64 -w0)
+      swift.conf: $($CONTROLLER1_SSH sudo cat /var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf | base64 -w0)
     EOF
 
 - name: Add swift ring files configmap


### PR DESCRIPTION
When ssh command is using user other than root, sudo rights required to access the swift.conf and feeding data in swift secret.