### PR TITLE
[DP3] Remove unneeded image URL references

### DIFF
--- a/docs_user/modules/openstack-autoscaling_adoption.adoc
+++ b/docs_user/modules/openstack-autoscaling_adoption.adoc
@@ -34,18 +34,6 @@ spec:
         [DEFAULT]
         debug=true
       secret: osp-secret
-ifeval::["{build}" == "upstream"]
-      apiImage: "quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified"
-      evaluatorImage: "quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified"
-      notifierImage: "quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified"
-      listenerImage: "quay.io/podified-antelope-centos9/openstack-aodh-listener:current-podified"
-endif::[]
-ifeval::["{build}" == "downstream"]
-      apiImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-api-rhel9:18.0"
-      evaluatorImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-evaluator-rhel9:18.0"
-      notifierImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-notifier-rhel9:18.0"
-      listenerImage: "registry.redhat.io/rhosp-dev-preview/openstack-aodh-listener-rhel9:18.0"
-endif::[]
       passwordSelectors:
       databaseUser: aodh
       databaseInstance: openstack

--- a/docs_user/modules/openstack-telemetry_adoption.adoc
+++ b/docs_user/modules/openstack-telemetry_adoption.adoc
@@ -21,38 +21,16 @@ This guide also assumes that:
 
 Patch OpenStackControlPlane to deploy Ceilometer services:
 
-// TODO(jistr): There are still some quay.io images in the downstream build.
-
 ----
 cat << EOF > ceilometer_patch.yaml
 spec:
   ceilometer:
     enabled: true
     template:
-ifeval::["{build}" == "upstream"]
-      centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
-      computeImage: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
       customServiceConfig: |
         [DEFAULT]
         debug=true
-      ipmiImage: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
-      nodeExporterImage: quay.io/prometheus/node-exporter:v1.5.0
-      notificationImage: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
       secret: osp-secret
-      sgCoreImage: quay.io/infrawatch/sg-core:v5.1.1
-endif::[]
-ifeval::["{build}" == "downstream"]
-      centralImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-central-rhel9:18.0
-      computeImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-compute-rhel9:18.0
-      customServiceConfig: |
-        [DEFAULT]
-        debug=true
-      ipmiImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-ipmi-rhel9:18.0
-      nodeExporterImage: quay.io/prometheus/node-exporter:v1.5.0
-      notificationImage: registry.redhat.io/rhosp-dev-preview/openstack-ceilometer-notification-rhel9:18.0
-      secret: osp-secret
-      sgCoreImage: quay.io/infrawatch/sg-core:v5.1.1
-endif::[]
 EOF
 ----
 


### PR DESCRIPTION
In the spirit of PR 290 [1] which is now heading into main branch, let's remove the image URLs from Autoscaling and Telemetry service adoption. This should make the docs downstream-ready.

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/290