### PR TITLE
Patch glanceAPI using per-backend files

### DIFF
--- a/tests/roles/glance_adoption/files/glance_ceph.yaml
+++ b/tests/roles/glance_adoption/files/glance_ceph.yaml
@@ -1,0 +1,32 @@
+spec:
+  glance:
+    enabled: true
+    template:
+      databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends=default_backend:rbd
+        [glance_store]
+        default_backend=default_backend
+        [default_backend]
+        rbd_store_ceph_conf=/etc/ceph/ceph.conf
+        rbd_store_user=openstack
+        rbd_store_pool=images
+        store_description=Ceph glance store backend.
+      storageClass: "local-storage"
+      storageRequest: 10G
+      glanceAPIs:
+        default:
+          replicas: 1
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                spec:
+                  type: LoadBalancer
+          networkAttachments:
+            - storage

--- a/tests/roles/glance_adoption/files/glance_local.yaml
+++ b/tests/roles/glance_adoption/files/glance_local.yaml
@@ -1,0 +1,29 @@
+spec:
+  glance:
+    enabled: true
+    template:
+      databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:file
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        filesystem_store_datadir = /var/lib/glance/images/
+      storageClass: "local-storage"
+      storageRequest: 10G
+      glanceAPIs:
+        default:
+          replicas: 1
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                spec:
+                  type: LoadBalancer
+          networkAttachments:
+            - storage

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -2,78 +2,14 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch '
-    spec:
-      glance:
-        enabled: true
-        template:
-          customServiceConfig: |
-            [DEFAULT]
-            enabled_backends = default_backend:file
-            [glance_store]
-            default_backend = default_backend
-            [default_backend]
-            filesystem_store_datadir = /var/lib/glance/images/
-          databaseInstance: openstack
-          storageClass: "local-storage"
-          storageRequest: 10G
-          glanceAPIs:
-            default:
-              type: single
-              replicas: 1
-              override:
-                service:
-                  internal:
-                    metadata:
-                      annotations:
-                        metallb.universe.tf/address-pool: internalapi
-                        metallb.universe.tf/allow-shared-ip: internalapi
-                        metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-                  spec:
-                    type: LoadBalancer
-              networkAttachments:
-              - storage
-    '
+    oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_local.yaml
   when: glance_backend == 'local'
 
 - name: deploy podified Glance with Ceph backend
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch '
-    spec:
-      glance:
-        enabled: true
-        template:
-          databaseInstance: openstack
-          customServiceConfig: |
-            [DEFAULT]
-            enabled_backends=default_backend:rbd
-            [glance_store]
-            default_backend=default_backend
-            [default_backend]
-            rbd_store_ceph_conf=/etc/ceph/ceph.conf
-            rbd_store_user=openstack
-            rbd_store_pool=images
-            store_description=Ceph glance store backend.
-          storageClass: "local-storage"
-          storageRequest: 10G
-          glanceAPIs:
-            default:
-              replicas: 1
-              override:
-                service:
-                  internal:
-                    metadata:
-                      annotations:
-                        metallb.universe.tf/address-pool: internalapi
-                        metallb.universe.tf/allow-shared-ip: internalapi
-                        metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-                  spec:
-                    type: LoadBalancer
-              networkAttachments:
-              - storage
-    '
+     oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_ceph.yaml
   when: glance_backend == 'ceph'
 
 - name: wait for Glance to start up


### PR DESCRIPTION
Instead of passing an inline string to patch the controlplane, rely on
per-backend files (because the config is pretty much static) that can
be called from the role. This allows to improve readability and it helps
in terms of maintenance, and it also avoid conflicts in case we use
golang templating within the customServiceConfig option.

Related: [OSPRH-784](https://issues.redhat.com/browse/OSPRH-784)