### PR TITLE
Also stop compute containers alongside services

### DIFF
--- a/docs_user/modules/openstack-stop_remaining_services.adoc
+++ b/docs_user/modules/openstack-stop_remaining_services.adoc
@@ -48,6 +48,9 @@ These steps can be automated with a simple script that relies on the previously
 defined environmental variables and function:
 
 ----
+ComputeContainersToStop=(
+                "nova_virtlogd"
+)
 
 ComputeServicesToStop=(
                 "tripleo_nova_compute.service"
@@ -74,6 +77,15 @@ for i in "${!computes[@]}"; do
             ${SSH_CMD} sudo systemctl disable --now $service
             ${SSH_CMD} test -f /etc/systemd/system/$service '||' sudo systemctl mask $service
         fi
+    done
+done
+
+echo "Forcing stop of compute containers not managed by service units"
+for i in "${!computes[@]}"; do
+    SSH_CMD="ssh -i $EDPM_PRIVATEKEY_PATH root@${computes[$i]}"
+    for container in ${ComputeContainersToStop[*]}; do
+        echo "Stopping the $container in compute $i"
+        ${SSH_CMD} sudo podman stop nova_virtlogd '||' true
     done
 done
 

--- a/tests/roles/stop_remaining_services/tasks/main.yaml
+++ b/tests/roles/stop_remaining_services/tasks/main.yaml
@@ -17,6 +17,10 @@
     {{ shell_header }}
     {{ stop_other_services_shell_vars }}
 
+    ComputeContainersToStop=(
+                    "nova_virtlogd"
+    )
+
     ComputeServicesToStop=(
                     "tripleo_nova_compute.service"
                     "tripleo_nova_libvirt.target"
@@ -42,6 +46,15 @@
                 ${SSH_CMD} sudo systemctl disable --now $service
                 ${SSH_CMD} test -f /etc/systemd/system/$service '||' sudo systemctl mask $service
             fi
+        done
+    done
+
+    echo "Forcing stop of compute containers not managed by service units"
+    for i in "${!computes[@]}"; do
+        SSH_CMD="ssh -i $EDPM_PRIVATEKEY_PATH root@${computes[$i]}"
+        for container in ${ComputeContainersToStop[*]}; do
+            echo "Stopping the $container in compute $i"
+            ${SSH_CMD} sudo podman stop nova_virtlogd '||' true
         done
     done
 


### PR DESCRIPTION
Some tripleo containers are not managed with systemd services, and need to be stopped.

Stop nova_virtlogd tripleo container on compute hosts to let decontainerized libvirt/virtlogd functioning during adoption process.

JIRA [OSPRH-5315](https://issues.redhat.com/browse/OSPRH-5315)