### PR TITLE
Neutron SR-IOV agent adoption

### DIFF
--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -108,6 +108,12 @@ spec:
 EOF
 ----
 
+* In case when neutron-sriov-nic-agent is running on the existing compute nodes,
+  physical device mappings needs to be checked and set the same in the
+  OpenStackDataPlaneNodeSet CR. Those options will need to be set in the
+  OpenStackDataPlaneNodeSet CR.
+  For more information, see xref:pulling-the-openstack-configuration_{context}[Pulling the OpenStack configuration].
+
 == Procedure - EDPM adoption
 
 * _Temporary fix_ until the OSP 17 https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid[backport of the stable compute UUID feature]
@@ -394,6 +400,31 @@ endif::[]
         edpm_ovs_packages:
         - openvswitch3.1
 EOF
+----
+
+* Optionally enable neutron-sriov-nic-agent in the OpenStackDataPlaneNodeSet CR
++
+[source,yaml]
+----
+oc patch openstackdataplanenodeset openstack --type='json' --patch='[
+  {
+    "op": "add",
+    "path": "/spec/services/-",
+    "value": "neutron-sriov"
+  }, {
+    "op": "add",
+    "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings",
+    "value": "dummy_sriov_net:dummy-dev"
+  }, {
+    "op": "add",
+    "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_bandwidths",
+    "value": "dummy-dev:40000000:40000000"
+  }, {
+    "op": "add",
+    "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors",
+    "value": "dummy-dev:standalone.localdomain"
+  }
+]'
 ----
 
 * Deploy OpenStackDataPlaneDeployment:

--- a/docs_user/modules/openstack-pull_openstack_configuration.adoc
+++ b/docs_user/modules/openstack-pull_openstack_configuration.adoc
@@ -179,3 +179,13 @@ EOF
 chmod 0600 ~/.source_cloud_exported_variables
 ----
 
+* Optionally, if there are neutron-sriov-nic-agent agents running in the deployment, get its configuration:
++
+[,bash]
+----
+podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
+    -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" ovs_neutron -e \
+    "select host, configurations from agents where agents.binary='neutron-sriov-nic-agent';"
+----
+
+This configuration will be required later, during the xref:adopting-edpm_{context}[EDPM Adoption].

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -130,3 +130,4 @@ networks_lower:
   Storage: storage
   Tenant: tenant
 edpm_sshd_allowed_ranges: "{{ ['192.168.122.0/24'] if dataplane_os_net_config_set_route|default(true)|bool else ['0.0.0.0/0'] }}"
+edpm_neutron_sriov_agent_enabled: true

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -256,6 +256,31 @@
             edpm_ovn_ofctrl_wait_before_clear: 8000
     EOF
 
+- name: set neutron-sriov-nic-agent configuration in the OpenStackDataPlaneNodeSet CR
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackdataplanenodeset openstack --type='json' --patch='[
+      {
+        "op": "add",
+        "path": "/spec/services/-",
+        "value": "neutron-sriov"
+      }, {
+        "op": "add",
+        "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_physical_device_mappings",
+        "value": "dummy_sriov_net:dummy-dev"
+      }, {
+        "op": "add",
+        "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_bandwidths",
+        "value": ""
+      }, {
+        "op": "add",
+        "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors",
+        "value": ""
+      }]'
+  when: edpm_neutron_sriov_agent_enabled|bool
+
 - name: deploy the dataplane deployment
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |

--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -18,6 +18,20 @@
   retries: 2
   delay: 1
 
+- name: get neutron-sriov-nic-agent alive state
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ neutron_header }}
+    ${BASH_ALIASES[openstack]} network agent list | grep -F 'neutron-sriov-nic-agent' | grep -qF 'XXX' || echo ALIVE
+  register: neutron_verify_sriov_nic_agent_result
+
+- name: verify that neutron-sriov-nic-agent is alive
+  ansible.builtin.assert:
+    that:
+      - neutron_verify_sriov_nic_agent_result.stdout == 'ALIVE'
+    fail_msg: "neutron-sriov-nic-agent is DEAD after adoption"
+    success_msg: "neutron-sriov-nic-agent is ALIVE after adoption"
+
 - name: verify connectivity to the existing test VM instance using Floating IP
   ansible.builtin.shell: |
       ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}


### PR DESCRIPTION
This patch adds adoption of the neutron-sriov-nic-agent on the edpm nodes.
As we run our tests on the virtualized environment, there is no really way to spawn VM which uses SR-IOV port and test if this VM works after adoption. This will need to be tested in some other layer of our CI. This patch adds documentation about adoption of the SR-IOV agent and simple test which will make sure that neutron-sriov-nic-agent is ALIVE after adoption.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/755

Closes: OSPRH-2433