### PR TITLE
Adopt Glance with Cinder backend

### DIFF
--- a/docs_user/modules/openstack-glance_adoption.adoc
+++ b/docs_user/modules/openstack-glance_adoption.adoc
@@ -120,6 +120,99 @@ command:
 oc patch openstackcontrolplane openstack --type=merge --patch-file=glance_swift.patch
 ----
 
+=== Using Cinder backend
+
+When Glance is deployed with Cinder as a backend in the source environment based
+on TripleO, the podified `glanceAPI` instance should be deployed with the following
+configuration:
+
+----
+..
+spec
+  glance:
+   ...
+      customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = default_backend:cinder
+          [glance_store]
+          default_backend = default_backend
+          [default_backend]
+          rootwrap_config = /etc/glance/rootwrap.conf
+          description = Default cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+----
+
+It is recommended to write the patch manifest into a file, for example `glance_cinder.patch`.
+For example, the Glance deployment with a Cinder backend would look like this:
+
+----
+spec:
+  glance:
+    enabled: true
+    apiOverride:
+      route: {}
+    template:
+      databaseInstance: openstack
+      storageClass: "local-storage"
+      storageRequest: 10G
+      customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = default_backend:cinder
+          [glance_store]
+          default_backend = default_backend
+          [default_backend]
+          rootwrap_config = /etc/glance/rootwrap.conf
+          description = Default cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+      glanceAPIs:
+        default:
+          replicas: 1
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+          networkAttachments:
+            - storage
+----
+
+Having `Cinder` as a backend establishes a dependency between the two services,
+and any deployed `GlanceAPI` instance would **not work** if `Glance` is
+configured with `Cinder` that is still not available in the `OpenStackControlPlane`.
+Once Cinder, and in particular `CinderVolume`, has been adopted through the
+procedure described in <<adopting-the-block-storage-service>>, it is possible
+to proceed with the `GlanceAPI` adoption.
+
+Verify that `CinderVolume` is available with the following command:
+
+----
+$ oc get pod -l component=cinder-volume | grep Running
+cinder-volume-75cb47f65-92rxq   3/3     Running   0
+----
+
+If the output is similar to the above, it is possible to move forward and patch
+the `GlanceAPI` service deployed in the podified context with the following
+command:
+
+----
+oc patch openstackcontrolplane openstack --type=merge --patch-file=glance_cinder.patch
+----
+
 === Using NFS backend
 
 When the source Cloud based on TripleO uses Glance with a NFS backend, before

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -39,6 +39,9 @@
     - role: swift_adoption
       tags:
         - swift_adoption
+    - role: cinder_adoption
+      tags:
+        - cinder_adoption
     - role: glance_adoption
       tags:
         - glance_adoption
@@ -48,9 +51,6 @@
     - role: nova_adoption
       tags:
         - nova_adoption
-    - role: cinder_adoption
-      tags:
-        - cinder_adoption
     - role: horizon_adoption
       tags:
         - horizon_adoption

--- a/tests/roles/glance_adoption/defaults/main.yaml
+++ b/tests/roles/glance_adoption/defaults/main.yaml
@@ -1,2 +1,2 @@
-# glance_backend can be 'local', 'ceph' or 'swift'
+# glance_backend can be 'local', 'ceph', 'swift' or 'cinder'
 glance_backend: swift

--- a/tests/roles/glance_adoption/files/glance_cinder.yaml
+++ b/tests/roles/glance_adoption/files/glance_cinder.yaml
@@ -1,0 +1,38 @@
+spec:
+  glance:
+    enabled: true
+    apiOverride:
+      route: {}
+    template:
+      databaseInstance: openstack
+      storageClass: "local-storage"
+      storageRequest: 10G
+      customServiceConfig: |
+          [DEFAULT]
+          enabled_backends = default_backend:cinder
+          [glance_store]
+          default_backend = default_backend
+          [default_backend]
+          rootwrap_config = /etc/glance/rootwrap.conf
+          description = Default cinder backend
+          cinder_store_auth_address = {{ .KeystoneInternalURL }}
+          cinder_store_user_name = {{ .ServiceUser }}
+          cinder_store_password = {{ .ServicePassword }}
+          cinder_store_project_name = service
+          cinder_catalog_info = volumev3::internalURL
+          cinder_use_multipath = true
+      glanceAPIs:
+        default:
+          replicas: 1
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+          networkAttachments:
+            - storage

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -19,5 +19,12 @@
     oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_swift.yaml
   when: glance_backend == 'swift'
 
+- name: deploy podified Glance with Cinder backend
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_cinder.yaml
+  when: glance_backend == 'cinder'
+
 - name: Check the adopted GlanceAPI
   ansible.builtin.include_tasks: check_glance.yaml


### PR DESCRIPTION
This patch describes the required steps to adopt the OpenStack Image Service (Glance) with a Cinder backend.

Implements: [OSPRH-783](https://issues.redhat.com/browse/OSPRH-783)