### PR TITLE
Add ironic pre_launch script

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -1,2 +1,3 @@
 prelaunch_test_instance: true
+prelaunch_test_instance_script: pre_launch.bash
 edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa

--- a/tests/roles/development_environment/files/pre_launch_ironic.bash
+++ b/tests/roles/development_environment/files/pre_launch_ironic.bash
@@ -1,0 +1,70 @@
+set -e
+
+# If the snapshot was reverted, and time is way off we get SSL issues in agent<->ironic connection
+# Workaround by restarting chronyd.service
+ssh -i $EDPM_PRIVATEKEY_PATH root@192.168.122.100 systemctl restart chronyd.service
+ssh -i $EDPM_PRIVATEKEY_PATH root@192.168.122.100 chronyc -a makestep
+
+# Enroll baremetal nodes
+pushd ${INSTALL_YAMLS_PATH}/devsetup
+make --silent bmaas_generate_nodes_yaml | tail -n +2 | tee /tmp/ironic_nodes.yaml
+popd
+
+scp -i $EDPM_PRIVATEKEY_PATH /tmp/ironic_nodes.yaml root@192.168.122.100:/root/ironic_nodes.yaml
+ssh -i $EDPM_PRIVATEKEY_PATH root@192.168.122.100 OS_CLOUD=standalone openstack baremetal create /root/ironic_nodes.yaml
+
+export IRONIC_PYTHON_AGENT_RAMDISK_ID=$(${BASH_ALIASES[openstack]} image show deploy-ramdisk -c id -f value)
+export IRONIC_PYTHON_AGENT_KERNEL_ID=$(${BASH_ALIASES[openstack]} image show deploy-kernel -c id -f value)
+for node in $(${BASH_ALIASES[openstack]} baremetal node list -c UUID -f value); do
+  ${BASH_ALIASES[openstack]} baremetal node set $node \
+    --driver-info deploy_ramdisk=${IRONIC_PYTHON_AGENT_RAMDISK_ID} \
+    --driver-info deploy_kernel=${IRONIC_PYTHON_AGENT_KERNEL_ID} \
+    --resource-class baremetal \
+    --property capabilities='boot_mode:uefi'
+done
+
+# Create a baremetal flavor
+${BASH_ALIASES[openstack]} flavor create baremetal --ram 1024 --vcpus 1 --disk 15 \
+  --property resources:VCPU=0 \
+  --property resources:MEMORY_MB=0 \
+  --property resources:DISK_GB=0 \
+  --property resources:CUSTOM_BAREMETAL=1 \
+  --property capabilities:boot_mode="uefi"
+
+# Create image
+IMG=Fedora-Cloud-Base-38-1.6.x86_64.qcow2
+URL=https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/$IMG
+curl --silent --show-error -o /tmp/${IMG} -L $URL
+DISK_FORMAT=$(qemu-img info /tmp/${IMG} | grep "file format:" | awk '{print $NF}')
+${BASH_ALIASES[openstack]} image create --container-format bare --disk-format ${DISK_FORMAT} Fedora-Cloud-Base-38 < /tmp/${IMG}
+
+export BAREMETAL_NODES=$(${BASH_ALIASES[openstack]} baremetal node list -c UUID -f value)
+# Manage nodes
+for node in $BAREMETAL_NODES; do
+  ${BASH_ALIASES[openstack]} baremetal node manage $node --wait 120
+done
+
+# Inspect baremetal nodes
+for node in $BAREMETAL_NODES; do
+  ${BASH_ALIASES[openstack]} baremetal node inspect $node --wait 300
+done
+
+# Provide nodes
+for node in $BAREMETAL_NODES; do
+  ${BASH_ALIASES[openstack]} baremetal node provide $node --wait 300
+done
+
+# Wait for nova to be aware of the node
+sleep 60
+
+# Create an instance on baremetal
+${BASH_ALIASES[openstack]} server show baremetal-test || {
+    ${BASH_ALIASES[openstack]} server create baremetal-test --flavor baremetal --image Fedora-Cloud-Base-38 --nic net-id=provisioning --wait
+}
+
+# Wait for node to boot
+sleep 60
+
+# Check instance status and network connectivity
+${BASH_ALIASES[openstack]} server show baremetal-test
+ping -c 4 $(${BASH_ALIASES[openstack]} server show baremetal-test -f json -c addresses | jq -r .addresses.provisioning[0])

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -1,7 +1,10 @@
 - name: pre-launch test VM instance
   no_log: "{{ use_no_log }}"
   when: prelaunch_test_instance|bool
+  environment:
+    INSTALL_YAMLS_PATH: "{{ install_yamls_path }}"
+    EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
   ansible.builtin.shell:
     cmd: |
       alias openstack="ssh -i {{ edpm_privatekey_path }} root@{{ edpm_node_ip }} OS_CLOUD=standalone openstack"
-      {{ lookup('ansible.builtin.file', 'pre_launch.bash') }}
+      {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}


### PR DESCRIPTION
Adds `pre_launch_ironic.bash`, this can be used to launch a workload in ironic when the source cloud has ironic enabled.