### PR TITLE
Add ironic service to stop_openstack_services role

### DIFF
--- a/docs_user/modules/openstack-stop_openstack_services.adoc
+++ b/docs_user/modules/openstack-stop_openstack_services.adoc
@@ -93,7 +93,11 @@ ServicesToStop=("tripleo_horizon.service"
                 "tripleo_ceilometer_agent_compute.service"
                 "tripleo_ceilometer_agent_ipmi.service"
                 "tripleo_ceilometer_agent_notification.service"
-                "tripleo_ovn_cluster_northd.service")
+                "tripleo_ovn_cluster_northd.service"
+                "tripleo_ironic_neutron_agent.service"
+                "tripleo_ironic_api.service"
+                "tripleo_ironic_inspector.service"
+                "tripleo_ironic_conductor.service")
 
 PacemakerResourcesToStop=("openstack-cinder-volume"
                           "openstack-cinder-backup"

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -45,7 +45,11 @@
                     "tripleo_ceilometer_agent_compute.service"
                     "tripleo_ceilometer_agent_ipmi.service"
                     "tripleo_ceilometer_agent_notification.service"
-                    "tripleo_ovn_cluster_northd.service")
+                    "tripleo_ovn_cluster_northd.service"
+                    "tripleo_ironic_neutron_agent.service"
+                    "tripleo_ironic_api.service"
+                    "tripleo_ironic_inspector.service"
+                    "tripleo_ironic_conductor.service")
 
     PacemakerResourcesToStop=("openstack-cinder-volume"
                               "openstack-cinder-backup"


### PR DESCRIPTION
Add stop for for following services:
-   "tripleo_ironic_neutron_agent.service"
-   "tripleo_ironic_api.service"
-   "tripleo_ironic_inspector.service"
-   "tripleo_ironic_conductor.service"