### PR TITLE
Show upstream version in github preview

### DIFF
--- a/docs_user/modules/ceph-monitoring_migration.adoc
+++ b/docs_user/modules/ceph-monitoring_migration.adoc
@@ -90,7 +90,7 @@ shipped by cephadm, remove the following config options from the Ceph cluster.
 $ ceph config dump
 ...
 ...
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 mgr   advanced  mgr/cephadm/container_image_alertmanager    undercloud-0.ctlplane.redhat.local:8787/ceph/alertmanager:v0.25.0
 mgr   advanced  mgr/cephadm/container_image_base            undercloud-0.ctlplane.redhat.local:8787/ceph/ceph:v18
 mgr   advanced  mgr/cephadm/container_image_grafana         undercloud-0.ctlplane.redhat.local:8787/ceph/ceph-grafana:9.4.7
@@ -173,7 +173,7 @@ is not supported for an external Ceph cluster.
 [source,bash]
 ----
 for item in $(sudo cephadm shell --  ceph orch host ls --format json | jq -r '.[].hostname'); do
-    sudo cephadm shell -- ceph orch host label add  $item monitoring; 
+    sudo cephadm shell -- ceph orch host label add  $item monitoring;
 done
 ----
 
@@ -373,7 +373,7 @@ prometheus.cephstorage-2    cephstorage-2.redhat.local  172.17.3.144:9092
 
 [source,bash]
 ----
-[ceph: root@controller-0 /]# ceph config dump 
+[ceph: root@controller-0 /]# ceph config dump
 ...
 ...
 mgr  advanced  mgr/dashboard/ALERTMANAGER_API_HOST   http://172.17.3.83:9093

--- a/docs_user/modules/ceph-rbd_migration.adoc
+++ b/docs_user/modules/ceph-rbd_migration.adoc
@@ -216,7 +216,7 @@ force-purge the containers in the node:
 ----
 [root@oc0-controller-1 ~]# sudo podman ps
 CONTAINER ID  IMAGE                                                                                        COMMAND               CREATED         STATUS             PORTS       NAMES
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 5c1ad36472bc  quay.io/ceph/daemon@sha256:320c364dcc8fc8120e2a42f54eb39ecdba12401a2546763b7bef15b02ce93bc4  -n mon.oc0-contro...  35 minutes ago  Up 35 minutes ago              ceph-f6ec3ebe-26f7-56c8-985d-eb974e8e08e3-mon-oc0-controller-1
 3b14cc7bf4dd  quay.io/ceph/daemon@sha256:320c364dcc8fc8120e2a42f54eb39ecdba12401a2546763b7bef15b02ce93bc4  -n mgr.oc0-contro...  35 minutes ago  Up 35 minutes ago              ceph-f6ec3ebe-26f7-56c8-985d-eb974e8e08e3-mgr-oc0-controller-1-mtxohd
 endif::[]
@@ -283,7 +283,7 @@ Deployed mon.oc0-ceph-0 on host 'oc0-ceph-0'
 Check the new container in the oc0-ceph-0 node:
 
 ----
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 b581dc8bbb78  quay.io/ceph/daemon@sha256:320c364dcc8fc8120e2a42f54eb39ecdba12401a2546763b7bef15b02ce93bc4  -n mon.oc0-ceph-0...  24 seconds ago  Up 24 seconds ago              ceph-f6ec3ebe-26f7-56c8-985d-eb974e8e08e3-mon-oc0-ceph-0
 endif::[]
 ifeval::["{build}" == "downstream"]

--- a/docs_user/modules/ceph-rgw_migration.adoc
+++ b/docs_user/modules/ceph-rgw_migration.adoc
@@ -1,5 +1,6 @@
 [id="migrating-ceph-rgw_{context}"]
 
+
 //:context: migrating-ceph-rgw
 //kgilliga: This module might be converted to an assembly.
 
@@ -504,7 +505,7 @@ You can start deploying the Ceph IngressDaemon on the CephStorage nodes.
 Set the required images for both HaProxy and Keepalived
 
 ----
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 [ceph: root@controller-0 /]# ceph config set mgr mgr/cephadm/container_image_haproxy quay.io/ceph/haproxy:2.3
 [ceph: root@controller-0 /]# ceph config set mgr mgr/cephadm/container_image_keepalived quay.io/ceph/keepalived:2.1.5
 endif::[]

--- a/docs_user/modules/openstack-autoscaling_adoption.adoc
+++ b/docs_user/modules/openstack-autoscaling_adoption.adoc
@@ -34,7 +34,7 @@ spec:
         [DEFAULT]
         debug=true
       secret: osp-secret
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
       apiImage: "quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified"
       evaluatorImage: "quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified"
       notifierImage: "quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified"

--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -373,7 +373,7 @@ endif::[]
         edpm_ovn_ofctrl_wait_before_clear: 8000
 
         timesync_ntp_servers:
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
         - hostname: pool.ntp.org
 endif::[]
 ifeval::["{build}" == "downstream"]
@@ -381,7 +381,7 @@ ifeval::["{build}" == "downstream"]
         - hostname: clock2.redhat.com
 endif::[]
 
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
         edpm_bootstrap_command: |
           # This is a hack to deploy RDO Delorean repos to RHEL as if it were Centos 9 Stream
           set -euxo pipefail

--- a/docs_user/modules/openstack-mariadb_copy.adoc
+++ b/docs_user/modules/openstack-mariadb_copy.adoc
@@ -44,7 +44,7 @@ PODIFIED_DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRoo
 CHARACTER_SET=utf8
 COLLATION=utf8_general_ci
 
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 endif::[]
 ifeval::["{build}" == "downstream"]

--- a/docs_user/modules/openstack-ovn_adoption.adoc
+++ b/docs_user/modules/openstack-ovn_adoption.adoc
@@ -38,7 +38,7 @@ just illustrative, use values that are correct for your environment:
 
 ----
 STORAGE_CLASS_NAME=crc-csi-hostpath-provisioner
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 OVSDB_IMAGE=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
 endif::[]
 ifeval::["{build}" == "downstream"]

--- a/docs_user/modules/openstack-pull_openstack_configuration.adoc
+++ b/docs_user/modules/openstack-pull_openstack_configuration.adoc
@@ -94,7 +94,7 @@ just illustrative, use values that are correct for your environment:
 
 ----
 CONTROLLER_SSH="ssh -F ~/director_standalone/vagrant_ssh_config vagrant@standalone"
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 endif::[]
 ifeval::["{build}" == "downstream"]

--- a/docs_user/modules/openstack-telemetry_adoption.adoc
+++ b/docs_user/modules/openstack-telemetry_adoption.adoc
@@ -29,7 +29,7 @@ spec:
   ceilometer:
     enabled: true
     template:
-ifeval::["{build}" == "upstream"]
+ifeval::["{build}" != "downstream"]
       centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
       computeImage: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
       customServiceConfig: |


### PR DESCRIPTION
The github doc preview is missing sections of the doc as the build
variable is not defined in that env and therefore all our conditional
upstream/downstream ifeval blocks are hidden.

This patch changes the upstream conditions from:
```    ifeval::["{build}" == "upstream"]```
to
```    ifeval::["{build}" != "downstream"]```
so the upsteam blocks are visible even if the build variable is not
defined.
