### PR TITLE
Add type: single to glance local backend

### DIFF
--- a/tests/roles/glance_adoption/files/glance_local.yaml
+++ b/tests/roles/glance_adoption/files/glance_local.yaml
@@ -14,6 +14,7 @@ spec:
       storageRequest: 10G
       glanceAPIs:
         default:
+          type: single
           replicas: 1
           override:
             service:


### PR DESCRIPTION
While we're waiting to land swift as a default backend for glance, we should maintain the local backend deployment that simulates the deployment using file. When file is used, there's no need to split the api. This patch updates the glance_local file to avoid splitting the api.