### PR TITLE
Write uuid to /var/lib/nova/compute_id only if needed

### DIFF
--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -127,7 +127,7 @@ do
   ssh \
     -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
     root@"${computes[$name]}" \
-                "echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id"
+      "grep -qF $uuid /var/lib/nova/compute_id || (echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id)"
 done
 ----
 

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -76,7 +76,7 @@
           ssh \
             -i {{ edpm_privatekey_path | default("/tmp/ansible_private_key") }} \
             {{ edpm_user }}@"${computes[$name]}" \
-            "echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id"
+            "grep -qF $uuid /var/lib/nova/compute_id || (echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id)"
         done
 
 - name: create dataplane-adoption-secret.yaml


### PR DESCRIPTION
File /var/lib/nova/compute_id may be existing and locked with chattr -x. Fix idempotency of writing uuid into it, only when its stored uuid contents doesn't match the one needs to be written there.