### PR TITLE
keystone service cleanup add ironic services

### DIFF
--- a/docs_user/modules/openstack-keystone_adoption.adoc
+++ b/docs_user/modules/openstack-keystone_adoption.adoc
@@ -79,7 +79,7 @@ control plane (everything except Keystone service and endpoints):
 ----
 openstack endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
 
-for service in aodh heat heat-cfn barbican cinderv3 glance manila manilav2 neutron nova placement swift; do
+for service in aodh heat heat-cfn barbican cinderv3 glance manila manilav2 neutron nova placement swift ironic-inspector ironic; do
   openstack service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
 done
 ----

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -84,6 +84,6 @@
 
     ${BASH_ALIASES[openstack]} endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
 
-    for service in aodh heat heat-cfn barbican cinderv3 glance manila manilav2 neutron nova placement swift; do
+    for service in aodh heat heat-cfn barbican cinderv3 glance manila manilav2 neutron nova placement swift ironic-inspector ironic; do
       ${BASH_ALIASES[openstack]} service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
     done


### PR DESCRIPTION
Add keystone service cleanup for ironic and ironic-inspector to the docs and tests.

In tests introduce the boolean variable `ironic_adoption`, only run keystone service cleanup for ironic services if this is set to true.