### PR TITLE
[DNM] testing ci-framework logging change

### DIFF
--- a/tests/roles/nova_adoption/tasks/main.yaml
+++ b/tests/roles/nova_adoption/tasks/main.yaml
@@ -1,3 +1,5 @@
+# this is just something to trigger the job so i can test the ci framework change
+
 - name: deploy podified Nova conductors, scheduler, metadata, and API
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
this change is testing
https://github.com/openstack-k8s-operators/ci-framework/pull/1266
which shoudl adjust the ciframework artifact role to
include collection fo edpm node logs from the standalone host

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1266
