### PR TITLE
Remove reboot-os role during edpm adoption

### DIFF
--- a/docs_user/modules/openstack-edpm_adoption.adoc
+++ b/docs_user/modules/openstack-edpm_adoption.adoc
@@ -260,7 +260,6 @@ spec:
     - configure-os
     - ssh-known-hosts
     - run-os
-    - reboot-os
     - install-certs
     - libvirt
     - nova-compute-extraconfig

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -161,7 +161,6 @@
         - configure-os
         - ssh-known-hosts
         - run-os
-        - reboot-os
         - install-certs
         - libvirt
         - nova-compute-extraconfig


### PR DESCRIPTION
Rebooting of dataplane nods shuold be avoided at all costs during adoption.

Remove reboot-os role to recover the basic VMs adoption case with local storage.

JIRA [OSPRH-3123](https://issues.redhat.com/browse/OSPRH-3123)