### PR TITLE
Add databaseAccount to some services

### DIFF
--- a/docs_user/modules/openstack-barbican_adoption.adoc
+++ b/docs_user/modules/openstack-barbican_adoption.adoc
@@ -49,6 +49,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
+      databaseAccount: barbican
       databaseUser: barbican
       rabbitMqClusterName: rabbitmq
       secret: osp-secret

--- a/docs_user/modules/openstack-cinder_adoption.adoc
+++ b/docs_user/modules/openstack-cinder_adoption.adoc
@@ -691,6 +691,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
+      databaseAccount: cinder
       secret: osp-secret
       cinderAPI:
         override:

--- a/docs_user/modules/openstack-glance_adoption.adoc
+++ b/docs_user/modules/openstack-glance_adoption.adoc
@@ -45,6 +45,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
+      databaseAccount: glance
       storageClass: "local-storage"
       storageRequest: 10G
       customServiceConfig: |

--- a/docs_user/modules/openstack-heat_adoption.adoc
+++ b/docs_user/modules/openstack-heat_adoption.adoc
@@ -71,6 +71,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
+      databaseAccount: heat
       secret: osp-secret
       memcachedInstance: memcached
       passwordSelectors:

--- a/docs_user/modules/openstack-manila_adoption.adoc
+++ b/docs_user/modules/openstack-manila_adoption.adoc
@@ -246,6 +246,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
+      databaseAccount: manila
       secret: osp-secret
       manilaAPI:
         replicas: 3

--- a/docs_user/modules/openstack-neutron_adoption.adoc
+++ b/docs_user/modules/openstack-neutron_adoption.adoc
@@ -50,6 +50,7 @@ spec:
             spec:
               type: LoadBalancer
       databaseInstance: openstack
+      databaseAccount: neutron
       secret: osp-secret
       networkAttachments:
       - internalapi

--- a/docs_user/modules/openstack-placement_adoption.adoc
+++ b/docs_user/modules/openstack-placement_adoption.adoc
@@ -32,6 +32,7 @@ spec:
       route: {}
     template:
       databaseInstance: openstack
+      databaseAccount: placement
       secret: osp-secret
       override:
         service:

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -18,6 +18,7 @@
         template:
           databaseInstance: openstack
           databaseUser: barbican
+          databaseAccount: barbican
           rabbitMqClusterName: rabbitmq
           secret: osp-secret
           simpleCryptoBackendSecret: osp-secret

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -10,6 +10,7 @@
           route: {}
         template:
           databaseInstance: openstack
+          databaseAccount: cinder
           secret: osp-secret
           cinderAPI:
             override:

--- a/tests/roles/glance_adoption/files/glance_ceph.yaml
+++ b/tests/roles/glance_adoption/files/glance_ceph.yaml
@@ -3,6 +3,7 @@ spec:
     enabled: true
     template:
       databaseInstance: openstack
+      databaseAccount: glance
       customServiceConfig: |
         [DEFAULT]
         enabled_backends=default_backend:rbd

--- a/tests/roles/glance_adoption/files/glance_local.yaml
+++ b/tests/roles/glance_adoption/files/glance_local.yaml
@@ -3,6 +3,7 @@ spec:
     enabled: true
     template:
       databaseInstance: openstack
+      databaseAccount: glance
       customServiceConfig: |
         [DEFAULT]
         enabled_backends = default_backend:file

--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -22,6 +22,7 @@
           route: {}
         template:
           databaseInstance: openstack
+          databaseAccount: heat
           secret: osp-secret
           memcachedInstance: memcached
           passwordSelectors:

--- a/tests/roles/manila_adoption/tasks/main.yaml
+++ b/tests/roles/manila_adoption/tasks/main.yaml
@@ -11,6 +11,7 @@
           route: {}
         template:
           databaseInstance: openstack
+          databaseAccount: manila
           manilaAPI:
             customServiceConfig: |
               [DEFAULT]

--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -20,6 +20,7 @@
                 spec:
                   type: LoadBalancer
           databaseInstance: openstack
+          databaseAccount: neutron
           secret: osp-secret
           networkAttachments:
           - internalapi

--- a/tests/roles/placement_adoption/tasks/main.yaml
+++ b/tests/roles/placement_adoption/tasks/main.yaml
@@ -10,6 +10,7 @@
           route: {}
         template:
           databaseInstance: openstack
+          databaseAccount: placement
           secret: osp-secret
           override:
             service:


### PR DESCRIPTION
This PR: https://github.com/openstack-k8s-operators/openstack-operator/pull/698 is failing:
  message: 'MariaDBAccount is not present: accountName is empty'

Adoption fails at Barbican step, but I belive the issue is alos there for other services.