### PR TITLE
Use oc run instead of podman

### DIFF
--- a/docs_user/modules/openstack-pull_openstack_configuration.adoc
+++ b/docs_user/modules/openstack-pull_openstack_configuration.adoc
@@ -111,8 +111,8 @@ Export shell variables for the following outputs to compare it with post-adoptio
 +
 [,bash]
 ----
-export PULL_OPENSTACK_CONFIGURATION_DATABASES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
-    mysql -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+export PULL_OPENSTACK_CONFIGURATION_DATABASES=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+    mysql -rsh "$SOURCE_MARIADB_IP" -uroot -p"$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;')
 echo "$PULL_OPENSTACK_CONFIGURATION_DATABASES"
 ----
 +
@@ -122,8 +122,8 @@ Note the `nova`, `nova_api`, `nova_cell0` databases residing in the same DB host
 +
 [,bash]
 ----
-export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
-    mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root "-p$SOURCE_DB_ROOT_PASSWORD" | grep -v OK)
+export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+    mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root -p"$SOURCE_DB_ROOT_PASSWORD" | grep -v OK)
 echo "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
 ----
 
@@ -131,8 +131,8 @@ echo "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
 +
 [,bash]
 ----
-export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-    -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+    mysql -rsh "${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" nova_api -e \
     'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')
 echo "$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
 ----
@@ -141,8 +141,9 @@ echo "$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
 +
 [,bash]
 ----
-export PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-    -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+
+export PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+    mysql -rsh "$SOURCE_MARIADB_IP" -uroot -p"$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
     "select host from nova.services where services.binary='nova-compute';")
 echo "$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES"
 ----
@@ -164,15 +165,15 @@ values in an env file should protect you from such a situation:
 [,bash]
 ----
 cat > ~/.source_cloud_exported_variables << EOF
-PULL_OPENSTACK_CONFIGURATION_DATABASES="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+PULL_OPENSTACK_CONFIGURATION_DATABASES="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
     mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD -e 'SHOW databases;')"
-PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
     mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root -p$SOURCE_DB_ROOT_PASSWORD | grep -v OK)"
-PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-    -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
+PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+    mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
     'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')"
-PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-    -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
+PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+    mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
     "select host from nova.services where services.binary='nova-compute';")"
 PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)"
 EOF
@@ -184,7 +185,7 @@ chmod 0600 ~/.source_cloud_exported_variables
 [,bash]
 ----
 podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-    -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" ovs_neutron -e \
+    -rsh "$SOURCE_MARIADB_IP" -uroot -p"$SOURCE_DB_ROOT_PASSWORD" ovs_neutron -e \
     "select host, configurations from agents where agents.binary='neutron-sriov-nic-agent';"
 ----
 

--- a/tests/roles/mariadb_copy/templates/restore_dbs.bash
+++ b/tests/roles/mariadb_copy/templates/restore_dbs.bash
@@ -37,11 +37,11 @@ oc rsh mariadb-copy-data << EOF
       db_password=\${db_server_password_map[\${db_name}]}
     fi
     echo "creating \${db_name} in \${db_server}"
-    mysql -h"\${db_server}" -uroot "-p\${db_password}" -e \
+    mysql -h"\${db_server}" -uroot -p"\${db_password}" -e \
       "CREATE DATABASE IF NOT EXISTS \${db_name} DEFAULT \
       CHARACTER SET ${CHARACTER_SET} DEFAULT COLLATE ${COLLATION};"
     echo "importing \${db_name} into \${db_server}"
-    mysql -h "\${db_server}" -uroot "-p\${db_password}" "\${db_name}" < "\${db_file}"
+    mysql -h "\${db_server}" -uroot -p"\${db_password}" "\${db_name}" < "\${db_file}"
   done
 
   mysql -h "\${db_server_map['default']}" -uroot -p"\${db_server_password_map['default']}" -e \

--- a/tests/roles/pull_openstack_configuration/tasks/main.yaml
+++ b/tests/roles/pull_openstack_configuration/tasks/main.yaml
@@ -19,9 +19,10 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
-    export PULL_OPENSTACK_CONFIGURATION_DATABASES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
-      mysql -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;')
+    export PULL_OPENSTACK_CONFIGURATION_DATABASES=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+      mysql -rsh "$SOURCE_MARIADB_IP" -uroot -p"$SOURCE_DB_ROOT_PASSWORD" -e 'SHOW databases;')
     echo "$PULL_OPENSTACK_CONFIGURATION_DATABASES"
   register: _databases_check
 
@@ -29,9 +30,10 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
-    export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
-      mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root "-p$SOURCE_DB_ROOT_PASSWORD" | grep -v OK)
+    export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+      mysqlcheck --all-databases -h "${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" | grep -v OK)
     echo "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
   failed_when: _mysqlnok_check.stdout != ''
   register: _mysqlnok_check
@@ -42,9 +44,10 @@
     - name: get Nova cells mappings from database
       ansible.builtin.shell: |
         {{ shell_header }}
+        {{ oc_header }}
         {{ mariadb_copy_shell_vars_src }}
-        export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-          -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+        export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+        mysql -rsh "${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" nova_api -e \
           'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')
         echo "$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
       register: _novadb_mapped_cells_check
@@ -52,9 +55,10 @@
     - name: get the host names of the registered Nova compute services
       ansible.builtin.shell: |
         {{ shell_header }}
+        {{ oc_header }}
         {{ mariadb_copy_shell_vars_src }}
-        export PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES=$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-          -rsh "$SOURCE_MARIADB_IP" -uroot "-p$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
+        export PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES=$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+        mysql -rsh "$SOURCE_MARIADB_IP" -uroot -p"$SOURCE_DB_ROOT_PASSWORD" nova_api -e \
           "select host from nova.services where services.binary='nova-compute';")
         echo "$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES"
       register: _nova_compute_hostnames_check
@@ -81,17 +85,18 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     cat > ~/.source_cloud_exported_variables << EOF
-    PULL_OPENSTACK_CONFIGURATION_DATABASES="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+    PULL_OPENSTACK_CONFIGURATION_DATABASES="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
         mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD -e 'SHOW databases;')"
-    PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE \
+    PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
         mysqlcheck --all-databases -h $SOURCE_MARIADB_IP -u root -p$SOURCE_DB_ROOT_PASSWORD | grep -v OK)"
-    PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-        -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
+    PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+        mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
         'select uuid,name,transport_url,database_connection,disabled from cell_mappings;')"
-    PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$(podman run -i --rm --userns=keep-id -u $UID $MARIADB_IMAGE mysql \
-        -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
+    PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$(oc run mariadb-client -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+        mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
         "select host from nova.services where services.binary='nova-compute';")"
     PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)"
     EOF


### PR DESCRIPTION
pull_openstack_configuration role uses podman to get environment variables. This patch changes behavior to use oc run instead on destination environment.