### PR TITLE
Run edpm_pre_adoption_validation before dataplane adoption

### DIFF
--- a/docs_user/modules/openstack-dataplane_adoption.adoc
+++ b/docs_user/modules/openstack-dataplane_adoption.adoc
@@ -465,6 +465,57 @@ oc patch openstackdataplanenodeset openstack --type='json' --patch='[
   }]'
 ----
 
+* Run pre-adoption validation:
+
+** Create the validation service
++
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: pre-adoption-validation
+spec:
+  playbook: osp.edpm.pre_adoption_validation
+EOF
+----
+** Create a OpenStackDataPlaneDeployment that runs the validation only
++
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-pre-adoption
+spec:
+  nodeSets:
+  - openstack
+  servicesOverride:
+  - pre-adoption-validation
+EOF
+----
+** Wait for the validation to finish
++
+Check if all the Ansible EE pods reaches `Completed` status:
++
+----
+# watching the pods
+watch oc get pod -l app=openstackansibleee
+----
++
+----
+# following the ansible logs with:
+oc logs -l app=openstackansibleee -f --max-log-requests 20
+----
++
+Wait for the deployment to reach the Ready status:
++
+----
+oc wait --for condition=Ready osdpd/openstack-pre-adoption --timeout=10m
+----
+
 * Deploy OpenStackDataPlaneDeployment:
 +
 [source,yaml]

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -156,7 +156,7 @@
       playbook: osp.edpm.nova
     EOF
 
-- name: deploy dataplane
+- name: Create OpenStackDataPlaneNodeSet
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
@@ -306,6 +306,70 @@
         "value": "neutron-dhcp"
       }]'
   when: edpm_neutron_dhcp_agent_enabled|bool
+
+- name: Run pre-adoption validation
+  when: run_pre_adoption_validation|bool
+  block:
+    - name: Create OpenStackDataPlaneService/pre-adoption-validation
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc apply -f - <<EOF
+        apiVersion: dataplane.openstack.org/v1beta1
+        kind: OpenStackDataPlaneService
+        metadata:
+          name: pre-adoption-validation
+        spec:
+          playbook: osp.edpm.pre_adoption_validation
+        EOF
+
+    - name: Create OpenStackDataPlaneDeployment to run the validation only
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc apply -f - <<EOF
+        apiVersion: dataplane.openstack.org/v1beta1
+        kind: OpenStackDataPlaneDeployment
+        metadata:
+          name: openstack-pre-adoption
+        spec:
+          nodeSets:
+          - openstack
+          servicesOverride:
+          - pre-adoption-validation
+        EOF
+
+    - name: Wait for the validation deployment to finish
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+
+        DEPLOYMENT_NAME=openstack-pre-adoption
+        TRIES=180
+        DELAY=10
+        ALLOWED_JOB_RETRIES=1
+
+        for i in $(seq $TRIES)
+        do
+            ready=$(oc get osdpd/$DEPLOYMENT_NAME -o jsonpath='{.status.conditions[0].status}')
+            if [ "$ready" == "True" ]; then
+                echo "Pre adoption validation Deployment is Ready"
+                exit 0
+            else
+                failed=$(oc get jobs -l openstackdataplanedeployment=$DEPLOYMENT_NAME -o jsonpath="{.items[?(@.status.failed > $ALLOWED_JOB_RETRIES)].metadata.name}")
+                if [ ! -z "${failed}" ]; then
+                    echo "There are failed AnsibleEE jobs: $failed"
+                    exit 1
+                fi
+            fi
+
+        sleep $DELAY
+        done
+
+        echo "Run out of retries"
+        exit 2
 
 - name: deploy the dataplane deployment
   no_log: "{{ use_no_log }}"

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -1,3 +1,4 @@
 prelaunch_test_instance: true
 prelaunch_test_instance_script: pre_launch.bash
 edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
+run_pre_adoption_validation: true

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -17,7 +17,7 @@ oc_header: |
 source_mariadb_ip: 192.168.122.99 #CUSTOMIZE_THIS
 
 # Source OS diff config ip for Tripleo
-source_os_diff_config_ip: 192.168.122.100 
+source_os_diff_config_ip: 192.168.122.100
 
 # Source OVN DB IP for DB exports.
 source_ovndb_ip: 192.168.122.100 #CUSTOMIZE_THIS
@@ -35,3 +35,6 @@ auth_url: http://keystone-public-openstack.apps-crc.testing
 
 # Set this to true if adopting the ironic services (ironic + ironic-inspector + nova w/compute-ironic)
 ironic_adoption: false
+
+# Run pre-adoption validation before the deploying
+run_pre_adoption_validation: true


### PR DESCRIPTION
This commit runs the validation role in a separate DataPlaneDeployment on the same DataPlaneNodeSet to be used for the dataplane adoption but with a servicesOverride in the Deployment to only run a single service doing the validation.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/609 (merged)
Implements: OSPRH-5713