### PR TITLE
ironic standalone - disable neutron-sriov-nic-agent

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -104,6 +104,7 @@ export EDPM_COMPUTE_ADDITIONAL_NETWORKS=$(jq -c . /tmp/addtional_nets.json)
 export STANDALONE_COMPUTE_DRIVER=ironic
 export NTP_SERVER=pool.ntp.org  # Only neccecary if not on the RedHat network ...
 export EDPM_COMPUTE_CEPH_ENABLED=false  # Optional
+export EDPM_COMPUTE_SRIOV_ENABLED=false # Without this the standalone deploy fails when compute driver is ironic.
 ----
 
 '''


### PR DESCRIPTION
The standalone deployment fails when EDPM_COMPUTE_SRIOV_ENABLED is `true` in combination with `STANDALONE_COMPUTE_DRIVER`.

Update the developer docs with instructions to disable it.

!! This might be a bug in tripleo?
We should possibly set `nova::compute::pci::passthrough` to an empty list in [1] or possibly return an empty list at the end of the user_passthrough_config() in [2].

The error seen is:
```
2024-03-25 05:27:39.364941 | 52540055-1ba6-877d-ff3a-0000000008b9 |      FATAL | run derive_pci_passthrough_whitelist.py | standalone | error={"changed": true, "cmd": ["/var/lib/pci_passthrough_whitelist_scripts/derive_pci_passthrough_whi
telist.py"], "delta": "0:00:00.541409", "end": "2024-03-25 05:27:39.343868", "msg": "non-zero return code", "rc": 1, "start": "2024-03-25 05:27:38.802459", "stderr": "Traceback (most recent call last):\n  File \"/var/lib/pci_passthrough_w
hitelist_scripts/derive_pci_passthrough_whitelist.py\", line 543, in <module>\n    raise InvalidConfigException('user_config specified is not a list {!r}'.format(user_configs))\n__main__.InvalidConfigException: user_config specified is no
t a list None", "stderr_lines": ["Traceback (most recent call last):", "  File \"/var/lib/pci_passthrough_whitelist_scripts/derive_pci_passthrough_whitelist.py\", line 543, in <module>", "    raise InvalidConfigException('user_config spec
ified is not a list {!r}'.format(user_configs))", "__main__.InvalidConfigException: user_config specified is not a list None"], "stdout": "", "stdout_lines": []}
2024-03-25 05:27:39.365878 | 52540055-1ba6-877d-ff3a-0000000008b9 |     TIMING | run derive_pci_passthrough_whitelist.py | standalone | 0:20:33.005854 | 0.72s

```

[1] https://opendev.org/openstack/tripleo-heat-templates/src/branch/stable/wallaby/deployment/nova/nova-ironic-container-puppet.yaml
[2] https://opendev.org/openstack/tripleo-heat-templates/src/branch/stable/wallaby/deployment/neutron/derive_pci_passthrough_whitelist.py#L241