### PR TITLE
Log console of the test VM if ping fails

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -1,6 +1,5 @@
 ---
 - name: set Neutron services shell vars
-  no_log: "{{ use_no_log }}"
   ansible.builtin.set_fact:
     neutron_header: |
       alias openstack="oc exec -t openstackclient -- openstack"
@@ -33,5 +32,13 @@
     success_msg: "neutron-sriov-nic-agent is ALIVE after adoption"
 
 - name: verify connectivity to the existing test VM instance using Floating IP
-  ansible.builtin.shell: |
-      ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
+  block:
+    - name: Ping VM using Floating IP
+      ansible.builtin.shell: |
+        ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
+  rescue:
+    - name: Get console log of the test VM
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ neutron_header }}
+        ${BASH_ALIASES[openstack]} console log show test


### PR DESCRIPTION
After adoption, if ping to the test VM fails, we will now log console log of the test VM - that can help in some cases what was wrong and why VM is not responding anymore.

Related: OSPCIX-226