### PR TITLE
Add internalapi network accessibility to mariadb helper pod

### DIFF
--- a/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
+++ b/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
@@ -87,6 +87,7 @@ metadata:
   name: mariadb-copy-data
   annotations:
     openshift.io/scc: anyuid
+    k8s.v1.cni.cncf.io/networks: internalapi
   labels:
     app: adoption
 spec:

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -32,6 +32,7 @@
       name: mariadb-copy-data
       annotations:
         openshift.io/scc: anyuid
+        k8s.v1.cni.cncf.io/networks: internalapi
       labels:
         app: adoption
     spec:


### PR DESCRIPTION
Mariadb helper pod is not able to connect to mysql server. Adding an internalapi network interface to the helper pod to provide connectivity.