### PR TITLE
Add keys for Swift ring file ConfigMap

### DIFF
--- a/docs_user/modules/openstack-swift_adoption.adoc
+++ b/docs_user/modules/openstack-swift_adoption.adoc
@@ -48,6 +48,9 @@ metadata:
   name: swift-ring-files
 binaryData:
   swiftrings.tar.gz: $($CONTROLLER1_SSH "cd /var/lib/config-data/puppet-generated/swift/etc/swift && tar cz *.builder *.ring.gz backups/ | base64 -w0")
+  account.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/account.ring.gz")
+  container.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/container.ring.gz")
+  object.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/object.ring.gz")
 EOF
 ----
 

--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -26,6 +26,9 @@
       name: swift-ring-files
     binaryData:
       swiftrings.tar.gz: $($CONTROLLER1_SSH "cd /var/lib/config-data/puppet-generated/swift/etc/swift && tar cz *.builder *.ring.gz backups/ | base64 -w0")
+      account.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/account.ring.gz")
+      container.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/container.ring.gz")
+      object.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/object.ring.gz")
     EOF
 
 - name: Deploy podified Swift


### PR DESCRIPTION
The swift-operator is going to use additional keys for the ring file ConfigMap. Adding these to the docs and tests.