### PR TITLE
Disable TLS-E

### DIFF
--- a/docs_user/modules/openstack-backend_services_deployment.adoc
+++ b/docs_user/modules/openstack-backend_services_deployment.adoc
@@ -148,6 +148,10 @@ spec:
   secret: osp-secret
   storageClass: local-storage
 
+  tls:
+    podLevel:
+      enabled: false
+
   barbican:
     enabled: false
     template:

--- a/docs_user/modules/openstack-dataplane_adoption.adoc
+++ b/docs_user/modules/openstack-dataplane_adoption.adoc
@@ -260,6 +260,7 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack
 spec:
+  tlsEnabled: false
   networkAttachments:
       - ctlplane
   preProvisioned: true

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -6,6 +6,17 @@ spec:
   secret: osp-secret
   storageClass: local-storage
 
+  tls:
+    podLevel:
+      enabled: false
+
+  barbican:
+    enabled: false
+    template:
+      barbicanAPI: {}
+      barbicanWorker: {}
+      barbicanKeystoneListener: {}
+
   cinder:
     enabled: false
     template:

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -149,6 +149,7 @@
     metadata:
       name: openstack
     spec:
+      tlsEnabled: false
       networkAttachments:
         - ctlplane
       preProvisioned: true


### PR DESCRIPTION
Set TLS-E to disabled, since it's being enabled by default
for greenfield deployments. Settings should not be changed
during adoption, and the currently tested scenario doesn't
support TLS-E.

This also adds a barbican section that's present in the docs
but missing in the tests.
