### PR TITLE
Adds os_cloud_name variable for development_environment role

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -332,7 +332,7 @@
             - openvswitch3.1
 
             # ovn-controller settings
-            edpm_ovn_bridge_mappings: ['datacentre:br-ctlplane']
+            edpm_ovn_bridge_mappings: ["datacentre:{{ neutron_physical_bridge_name }}"]
             edpm_ovn_bridge: br-int
             edpm_ovn_encap_type: geneve
             ovn_match_northd_version: false

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -2,3 +2,4 @@ prelaunch_test_instance: true
 prelaunch_test_instance_script: pre_launch.bash
 edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 run_pre_adoption_validation: true
+os_cloud_name: standalone

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -1,6 +1,6 @@
 set -e
 
-alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=standalone openstack"
+alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
 
 function wait_for_status() {
     local time=0

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -4,8 +4,10 @@
   environment:
     INSTALL_YAMLS_PATH: "{{ install_yamls_path }}"
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
+    OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
+    OS_CLOUD_NAME: "{{ os_cloud_name }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} root@{{ edpm_node_ip }} OS_CLOUD=standalone openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} root@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}


### PR DESCRIPTION
As part of [1] this adds a new os_cloud_name var for the development_environment role to be used with the prelaunch vm test instance creation. This retains current behaviour OS_CLOUD=standalone. Needed by [2].

https://issues.redhat.com/browse/OSPRH-5754

[1] https://issues.redhat.com/browse/OSPRH-3038
[2] https://review.rdoproject.org/r/c/rdo-jobs/+/52452