### PR TITLE
Remove networkAttachment for ovnNorthd

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -244,7 +244,6 @@ spec:
           storageRequest: 10G
           networkAttachment: internalapi
       ovnNorthd:
-        networkAttachment: internalapi
         replicas: 0
       ovnController:
         networkAttachment: tenant

--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -124,7 +124,6 @@ spec:
           networkAttachment: internalapi
       ovnNorthd:
         replicas: 0
-        networkAttachment: internalapi
       ovnController:
         networkAttachment: tenant
         nodeSelector:
@@ -177,7 +176,6 @@ spec:
     enabled: true
     template:
       ovnNorthd:
-        networkAttachment: internalapi
         replicas: 1
 '
 ----

--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -109,7 +109,6 @@ spec:
         nodeSelector:
           node: non-existing-node-name
       ovnNorthd:
-        networkAttachment: internalapi
         replicas: 0
       ovnDBCluster:
         ovndbcluster-nb:

--- a/tests/config/periodic_ci/container_image_overrides.yaml
+++ b/tests/config/periodic_ci/container_image_overrides.yaml
@@ -94,7 +94,6 @@ spec:
           storageRequest: 10G
           networkAttachment: internalapi
       ovnNorthd:
-        networkAttachment: internalapi
         replicas: 0
       ovnController:
         networkAttachment: tenant

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -180,7 +180,6 @@
         enabled: true
         template:
           ovnNorthd:
-            networkAttachment: internalapi
             replicas: 1
     '
 


### PR DESCRIPTION
ovnNorthd does not require additional interface via networkAttachment, this patch removes it from the sample files.

Closes: OSPRH-659