### PR TITLE
moved retrieving services module

### DIFF
--- a/docs_user/assemblies/assembly_adopting-openstack-control-plane-services.adoc
+++ b/docs_user/assemblies/assembly_adopting-openstack-control-plane-services.adoc
@@ -6,6 +6,8 @@
 
 Adopt your {rhos_prev_long} {rhos_prev_ver} control plane services to deploy them in the {rhos_long} {rhos_curr_ver} control plane.
 
+include::../modules/proc_retrieving-services-topology-specific-configuration.adoc[leveloffset=+1]
+
 include::../modules/proc_adopting-the-identity-service.adoc[leveloffset=+1]
 
 include::../modules/proc_adopting-key-manager-service.adoc[leveloffset=+1]

--- a/docs_user/assemblies/assembly_reviewing-the-openstack-control-plane-configuration.adoc
+++ b/docs_user/assemblies/assembly_reviewing-the-openstack-control-plane-configuration.adoc
@@ -12,4 +12,3 @@ link:planning.md#Configuration tooling[Configure os-diff]
 
 include::../modules/proc_pulling-configuration-from-a-tripleo-deployment.adoc[leveloffset=+1]
 
-include::../modules/proc_retrieving-services-topology-specific-configuration.adoc[leveloffset=+1]

--- a/docs_user/modules/proc_retrieving-services-topology-specific-configuration.adoc
+++ b/docs_user/modules/proc_retrieving-services-topology-specific-configuration.adoc
@@ -4,11 +4,11 @@
 
 //Check xrefs
 
-.Variables
+.Prerequisites
 
-Define the shell variables used in the steps below. The values are
+* Define the shell variables used in the steps below. The values are
 just illustrative, use values that are correct for your environment:
-
++
 ----
 CONTROLLER_SSH="ssh -F ~/director_standalone/vagrant_ssh_config vagrant@standalone"
 ifeval::["{build}" != "downstream"]


### PR DESCRIPTION
Moved "Retrieving services topology specific-configuration" module to beginning of control plane chapter.