### PR TITLE
 Adjust the OpenStackVersion for manila-share and cinder-volume 

### DIFF
--- a/tests/roles/backend_services/templates/openstack_version.j2
+++ b/tests/roles/backend_services/templates/openstack_version.j2
@@ -69,6 +69,6 @@ spec:
     swiftObjectImage: {{ container_registry }}/{{ container_namespace }}/openstack-swift-object:{{ container_tag }}
     swiftProxyImage: {{ container_registry }}/{{ container_namespace }}/openstack-swift-proxy-server:{{ container_tag }}
     cinderVolumeImages:
-      default: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-volume:{{ container_tag }}
+      volume1: {{ container_registry }}/{{ container_namespace }}/openstack-cinder-volume:{{ container_tag }}
     manilaShareImages:
-      default: {{ container_registry }}/{{ container_namespace }}/openstack-manila-share:{{ container_tag }}
+      share1: {{ container_registry }}/{{ container_namespace }}/openstack-manila-share:{{ container_tag }}


### PR DESCRIPTION
We added OpenStackVersion with [1] as part of [2]. This patch aims to fix manila-share and cinder-volume which are still defaulting to the quay.io registry and ignoring the specified overrides for the periodic.

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/415
[2] https://issues.redhat.com/browse/OSPCIX-258