### PR TITLE
Restores the name of the data-plane-adoption no ceph job

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -4,5 +4,5 @@
     github-check:
       jobs:
         - data-plane-adoption-osp-17-to-extracted-crc
-        - data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph-rdojobs
+        - data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph
         - adoption-docs-preview


### PR DESCRIPTION
Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/53044 