### PR TITLE
DNM debug short circuit the adoption tests

### DIFF
--- a/tests/playbooks/_before_adoption.yaml
+++ b/tests/playbooks/_before_adoption.yaml
@@ -1,4 +1,5 @@
 - name: Prelude
+  failed_when: true # marios debug need to short circuit adoption tests
   hosts: local
   gather_facts: false
   module_defaults:


### PR DESCRIPTION
I am working on getting logging for overcloud tripleo nodes

https://issues.redhat.com/browse/OSPRH-5757