### PR TITLE
Escape quotes in `sed` command snippet

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -136,10 +136,10 @@ metadata:
 data:
     ssh-privatekey: |
 ifeval::["{build}" != "downstream"]
-$(cat ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa | base64 | sed 's/^/        /')
+$(cat ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa | base64 | sed \'s/^/        /')
 endif::[]
 ifeval::["{build}" == "downstream"]
-$(cat *<path to SSH key>* | base64 | sed 's/^/        /')
+$(cat *<path to SSH key>* | base64 | sed \'s/^/        /')
 endif::[]
 EOF
 ----


### PR DESCRIPTION
Without escapes, the quotes are not displayed in the rendered html, which breaks the command as follows:

sed: -e expression #1, char 4: unterminated `s' command