### PR TITLE
Don't mention particular ovs major update version in edpm samples

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -462,7 +462,7 @@ endif::[]
         # SELinux module
         edpm_selinux_mode: enforcing
 
-        # Do not attempt OVS 3.2 major upgrades here
+        # Do not attempt OVS major upgrades here
         edpm_ovs_packages:
         - openvswitch3.1
 EOF

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -327,7 +327,7 @@
             # SELinux module
             edpm_selinux_mode: enforcing
 
-            # Do not attempt OVS 3.2 major upgrades here
+            # Do not attempt OVS major upgrades here
             edpm_ovs_packages:
             - openvswitch3.1
 


### PR DESCRIPTION
The version for GA will be 3.3; but instead of bumping it, just removing it since it's not important which particular version we *don't* bump to during adoption.