### PR TITLE
added short module for storage driver certification requirement

### DIFF
--- a/docs_user/assemblies/assembly_storage-requirements.adoc
+++ b/docs_user/assemblies/assembly_storage-requirements.adoc
@@ -14,4 +14,6 @@ you can deploy the services.
 
 //*TODO: Galera, RabbitMQ, Swift, Glance, etc.*
 
+include::../modules/con_storage-driver-certification.adoc[leveloffset=+1]
+
 include::../modules/con_block-storage-service-requirements.adoc[leveloffset=+1]

--- a/docs_user/modules/con_storage-driver-certification.adoc
+++ b/docs_user/modules/con_storage-driver-certification.adoc
@@ -1,0 +1,8 @@
+[id="storage-driver-certification_{context}"]
+
+= Storage driver certification
+
+Before you adopt your {rhos_prev_long} {rhos_prev_ver} deployment to a {rhos_long} {rhos_curr_ver} deployment, confirm that your deployed storage drivers are certified for use with {rhos_acro} {rhos_curr_ver}.
+
+//kgilliga: Note to self: I need to add a link to the certified software website for GA. The website currently does not include RHOSO 18.0 certified software.
+


### PR DESCRIPTION
Added a short module based on the "Storage driver certification" module from the 17.1 FFU guide.
[1]https://issues.redhat.com/browse/RHOSPDOC-1738
[2]https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/17.1/html-single/framework_for_upgrades_16.2_to_17.1/index#con_confirm-driver-certification

