### PR TITLE
Update the documentation to add internalapi connectivity to ovn helper pod

### DIFF
--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -74,6 +74,7 @@ metadata:
   name: ovn-copy-data
   annotations:
     openshift.io/scc: anyuid
+    k8s.v1.cni.cncf.io/networks: internalapi
   labels:
     app: adoption
 spec:


### PR DESCRIPTION
Based on the PR change https://github.com/openstack-k8s-operators/data-plane-adoption/pull/232 The internalapi network connectivity change should be reflected in the ovn migration user documentation.