### PR TITLE
Add libvirt customIssuer

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -144,6 +144,9 @@ spec:
       internal:
         ca:
           customIssuer: rootca-internal
+      libvirt:
+        ca:
+          customIssuer: rootca-internal
       ovn:
         ca:
           customIssuer: rootca-internal

--- a/docs_user/modules/proc_migrating-tls-everywhere.adoc
+++ b/docs_user/modules/proc_migrating-tls-everywhere.adoc
@@ -117,6 +117,7 @@ metadata:
   labels:
     osp-rootca-issuer-public: ""
     osp-rootca-issuer-internal: ""
+    osp-rootca-issuer-libvirt: ""
     osp-rootca-issuer-ovn: ""
 spec:
   ca:

--- a/tests/roles/backend_services/templates/tls_overrides.j2
+++ b/tests/roles/backend_services/templates/tls_overrides.j2
@@ -10,6 +10,9 @@ spec:
       internal:
         ca:
           customIssuer: rootca-internal
+      libvirt:
+        ca:
+          customIssuer: rootca-internal
       ovn:
         ca:
           customIssuer: rootca-internal

--- a/tests/roles/tls_adoption/tasks/main.yaml
+++ b/tests/roles/tls_adoption/tasks/main.yaml
@@ -22,6 +22,7 @@
       labels:
         osp-rootca-issuer-public: ""
         osp-rootca-issuer-internal: ""
+        osp-rootca-issuer-libvirt: ""
         osp-rootca-issuer-ovn: ""
     spec:
       ca:


### PR DESCRIPTION
libvirt CA was recently introduced, a customIssuer needs to be
set to overwrite the defaults with the IPA extracted CA.
