### PR TITLE
Add variable to skip patching ansiblee csv

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -124,6 +124,7 @@ edpm_sshd_allowed_ranges: "{{ ['192.168.122.0/24'] if dataplane_os_net_config_se
 edpm_neutron_sriov_agent_enabled: true
 edpm_neutron_dhcp_agent_enabled: true
 nova_libvirt_backend: local
+skip_patching_ansibleee_csv: false
 # OS Diff automation steps
 os_diff_dir: tmp/os-diff
 os_diff_data_dir: tmp/os-diff

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -6,42 +6,45 @@
     ceph_backend_configuration_fsid_shell_vars: |
       CEPH_FSID=$(oc get secret ceph-conf-files -o json | jq -r '.data."ceph.conf"' | base64 -d | grep fsid | sed -e 's/fsid = //')
 
-- name: Save ansibleee-operator pod name to be able to wait for the rollout of the new pod
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc get -n openstack-operators pod -l app.kubernetes.io/name=openstack-ansibleee-operator -o name
-  register: old_ansibleee_operator_pod
+- name: Patch ansibleee csv to use image built from source or latest if none is defined
+  when: not skip_patching_ansibleee_csv | bool
+  block:
+    - name: Save ansibleee-operator pod name to be able to wait for the rollout of the new pod
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc get -n openstack-operators pod -l app.kubernetes.io/name=openstack-ansibleee-operator -o name
+      register: old_ansibleee_operator_pod
 
-- name: Get ansibleee-operator csv name
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc get csv -n openstack-operators -o name | grep ansibleee-operator
-  register: _ansibleee_csv_name
+    - name: Get ansibleee-operator csv name
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc get csv -n openstack-operators -o name | grep ansibleee-operator
+      register: _ansibleee_csv_name
 
-- name: use ansible-runner image built from source or latest if none is defined
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    {{ oc_login_command }}
-    # openstack-operator catalog pins the sha256, which might differ from latest with time
-    oc patch -n openstack-operators "{{ _ansibleee_csv_name.stdout }}" \
-      --type='json' -p='[{
-      "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
-      "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "{{ ansibleee_runner_img | default('quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest')}}"}}]'
-  register: ansibleee_csv_patched
+    - name: use ansible-runner image built from source or latest if none is defined
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        {{ oc_login_command }}
+        # openstack-operator catalog pins the sha256, which might differ from latest with time
+        oc patch -n openstack-operators "{{ _ansibleee_csv_name.stdout }}" \
+          --type='json' -p='[{
+          "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
+          "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "{{ ansibleee_runner_img | default('quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest')}}"}}]'
+      register: ansibleee_csv_patched
 
-- name: Wait for the ansible-operator to restart with the new ENV
-  no_log: "{{ use_no_log }}"
-  when: '"no change" not in ansibleee_csv_patched.stdout'
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc wait -n openstack-operators --timeout=120s --for=delete {{ old_ansibleee_operator_pod.stdout }}
+    - name: Wait for the ansible-operator to restart with the new ENV
+      no_log: "{{ use_no_log }}"
+      when: '"no change" not in ansibleee_csv_patched.stdout'
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc wait -n openstack-operators --timeout=120s --for=delete {{ old_ansibleee_operator_pod.stdout }}
 
 - name: ensure namespace
   no_log: "{{ use_no_log }}"


### PR DESCRIPTION
In some ocasions, like beta testing we want to skip patching the
ansiblee csv to set latest, and instead rely on the image that the
operator has by default. This change introduces a variable that we can
set to skip the related tasks in dataplane_adoption role. By default the
variable is set to false so we keep the current behaviour.
