### PR TITLE
Add mariadb-copy-data clean up.

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -359,6 +359,7 @@ while oc get pod | grep openstack-galera-0; do
 done
 
 oc delete --wait=false pod ovn-copy-data || true
+oc delete --wait=false pod mariadb-copy-data || true
 oc delete secret osp-secret || true
 ----
 


### PR DESCRIPTION
When adoption fails on mariadb-copy-data it needs to be cleaned up.