### PR TITLE
Switch Maria IP to internal

### DIFF
--- a/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
+++ b/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
@@ -43,10 +43,10 @@ STORAGE_CLASS=local-storage
 MARIADB_IMAGE=registry.redhat.io/rhosp-dev-preview/openstack-mariadb-rhel9:18.0
 endif::[]
 # Replace with your environment's MariaDB Galera cluster VIP and backend IPs:
-SOURCE_MARIADB_IP=192.168.122.99
+SOURCE_MARIADB_IP=172.17.0.2
 declare -A SOURCE_GALERA_MEMBERS
 SOURCE_GALERA_MEMBERS=(
-  ["standalone.localdomain"]=192.168.122.100
+  ["standalone.localdomain"]=172.17.0.100
   # ...
 )
 SOURCE_DB_ROOT_PASSWORD=$(cat ~/tripleo-standalone-passwords.yaml | grep ' MysqlRootPassword:' | awk -F ': ' '{ print $2; }')

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -25,7 +25,7 @@ oc_header: |
   eval $(crc oc-env)
 
 # Source MariaDB Galera cluster VIP for DB exports.
-source_mariadb_ip: 192.168.122.99 #CUSTOMIZE_THIS
+source_mariadb_ip: 172.17.0.2 #CUSTOMIZE_THIS
 
 # Source OS diff config ip for Tripleo
 source_os_diff_config_ip: 192.168.122.100


### PR DESCRIPTION
Use internal MariaDB address for data transfer during adoption to prevernt any possible security leaks

Closes: OSPRH-6584