### PR TITLE
Fixing the adopting the data plane doc

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -150,8 +150,10 @@ To deploy using TLS everywhere enabled, instead run:
 [,bash]
 ----
 cd ~/install_yamls/devsetup
-TLS_ENABLED=true make standalone
+EDPM_COMPUTE_CEPH_ENABLED=false TLS_ENABLED=true DNS_DOMAIN=ooo.test make standalone
 ----
+
+This will disable the Ceph deployment, as the CI is not deploying with Ceph.
 
 == Install the openstack-k8s-operators (openstack-operator)
 

--- a/docs_user/modules/proc_migrating-tls-everywhere.adoc
+++ b/docs_user/modules/proc_migrating-tls-everywhere.adoc
@@ -46,6 +46,12 @@ endif::[]
 +
 [subs=+quotes]
 ----
+ifeval::["{build}" != "downstream"]
+EDPM_PRIVATEKEY_PATH="~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa"
+endif::[]
+ifeval::["{build}" == "downstream"]
+EDPM_PRIVATEKEY_PATH="*<path to SSH key>*"
+endif::[]
 declare -A computes
 computes=(
   ["standalone.localdomain"]="192.168.122.100"
@@ -90,7 +96,7 @@ With that file, you can also separately get the certificate and the key by using
 . Create the secret that contains the root CA:
 +
 ----
-oc create secret generic rootca-internal
+oc create secret generic rootca-internal -n openstack
 ----
 
 . Import the certificate and the key from FreeIPA:


### PR DESCRIPTION
Fixing the command to deploy a standalone environment with TLS, create rootca-internal secret on openstack namespace.