### PR TITLE
Add test to check if Barbican secret payload is kept

### DIFF
--- a/docs_user/modules/proc_adopting-key-manager-service.adoc
+++ b/docs_user/modules/proc_adopting-key-manager-service.adoc
@@ -23,7 +23,7 @@ should be already adopted.
 which contains other service passwords:
 +
 ----
-oc set data secret/osp-secret "BarbicanSimpleCryptoKEK=$($CONTROLLER1_SSH "python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/barbican/etc/barbican/barbican.conf'); print(c['simple_crypto_plugin']['kek'])\"" | base64 -w 0)"
+oc set data secret/osp-secret "BarbicanSimpleCryptoKEK=$($CONTROLLER1_SSH "python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/barbican/etc/barbican/barbican.conf'); print(c['simple_crypto_plugin']['kek'])\"")"
 ----
 
 . Patch `OpenStackControlPlane` to deploy the {key_manager}:

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -78,8 +78,8 @@
     alias openstack="oc exec -t openstackclient -- openstack"
 
     secret_id=`${BASH_ALIASES[openstack]} secret list | grep testSecret | cut -d'|' -f 2 | xargs`
-      secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id --payload -f value`
-      if [ "$secret_payload" != "TestPayload" ]
-      then
-        exit 1
-      fi
+    secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id --payload -f value`
+    if [ "$secret_payload" != "TestPayload" ]
+    then
+      exit 1
+    fi

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -79,7 +79,6 @@
 
     secret_id=`${BASH_ALIASES[openstack]} secret list | grep testSecret | cut -d'|' -f 2 | xargs`
       secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id --payload -f value`
-      echo $secret_payload
       if [ "$secret_payload" != "TestPayload" ]
       then
         exit 1

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -69,3 +69,18 @@
   until: barbican_responding_result is success
   retries: 60
   delay: 2
+
+- name: check that Barbican secret payload was migrated successfully
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+
+    alias openstack="oc exec -t openstackclient -- openstack"
+
+    ${BASH_ALIASES[openstack]} secret get `openstack secret list | grep testSecret | cut -d'|' -f 2 | xargs` --payload -f value
+    secret_id=`${BASH_ALIASES[openstack]} secret list | grep testSecret | cut -d'|' -f 2 | xargs`
+      secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id`
+      if [ "$secret_payload" != "TestPayload" ]
+      then
+        exit 1
+      fi

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -77,9 +77,9 @@
 
     alias openstack="oc exec -t openstackclient -- openstack"
 
-    ${BASH_ALIASES[openstack]} secret get `openstack secret list | grep testSecret | cut -d'|' -f 2 | xargs` --payload -f value
     secret_id=`${BASH_ALIASES[openstack]} secret list | grep testSecret | cut -d'|' -f 2 | xargs`
-      secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id`
+      secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id --payload -f value`
+      echo $secret_payload
       if [ "$secret_payload" != "TestPayload" ]
       then
         exit 1

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -3,7 +3,7 @@
     {{ shell_header }}
     {{ oc_header }}
     CONTROLLER1_SSH="{{ controller1_ssh }}"
-    oc set data secret/osp-secret "BarbicanSimpleCryptoKEK=$($CONTROLLER1_SSH "python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/barbican/etc/barbican/barbican.conf'); print(c['simple_crypto_plugin']['kek'])\"" | base64 -w 0)"
+    oc set data secret/osp-secret "BarbicanSimpleCryptoKEK=$($CONTROLLER1_SSH "python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/barbican/etc/barbican/barbican.conf'); print(c['simple_crypto_plugin']['kek'])\"")"
 
 - name: deploy podified Barbican
   ansible.builtin.shell: |

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -86,3 +86,6 @@ fi
 if ${BASH_ALIASES[openstack]} volume show disk -f json | jq -r '.status' | grep -q available ; then
     ${BASH_ALIASES[openstack]} server add volume test disk
 fi
+
+# Create Barbican secret
+${BASH_ALIASES[openstack]} secret store --name testSecret --payload 'TestPayload'


### PR DESCRIPTION
This is to reflect the workload to adopt step on the documentation.

https://openstack-k8s-operators.github.io/data-plane-adoption/dev/#_creating_a_workload_to_adopt