### PR TITLE
Remove service_net_map references

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -297,10 +297,6 @@ ifeval::["{build}" == "downstream"]
 endif::[]
       ansibleVars:
         edpm_bootstrap_release_version_package: []
-        service_net_map:
-          nova_api_network: internalapi
-          nova_libvirt_network: internalapi
-
         # edpm_network_config
         # Default nic config template for a EDPM node
         # These vars are edpm_network_config role vars
@@ -399,12 +395,9 @@ ifeval::["{build}" == "downstream"]
 endif::[]
 
         gather_facts: false
-        enable_debug: false
         # edpm firewall, change the allowed CIDR if needed
         edpm_sshd_configure_firewall: true
         edpm_sshd_allowed_ranges: ['192.168.122.0/24']
-        # SELinux module
-        edpm_selinux_mode: enforcing
 
         # Do not attempt OVS major upgrades here
         edpm_ovs_packages:

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -180,13 +180,6 @@
             os_net_config_iface: {{ dataplane_os_net_config_iface | default ('nic1') }}
             os_net_config_set_route: {{ dataplane_os_net_config_set_route | default(true) | bool }}
             os_net_config_dns: {{ dataplane_os_net_config_dns | default("") }}
-
-            {%+ if compute_adoption|bool +%}
-            service_net_map:
-              nova_api_network: internalapi
-              nova_libvirt_network: internalapi
-            {%+ endif +%}
-
             edpm_bootstrap_command: |
               {{ edpm_bootstrap_command| indent(10) }}
 
@@ -216,12 +209,9 @@
             edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
 
             gather_facts: false
-            enable_debug: false
             # edpm firewall, change the allowed CIDR if needed
             edpm_sshd_configure_firewall: true
             edpm_sshd_allowed_ranges: {{ edpm_sshd_allowed_ranges }}
-            # SELinux module
-            edpm_selinux_mode: enforcing
 
             # Do not attempt OVS major upgrades here
             edpm_ovs_packages:


### PR DESCRIPTION
This change removes service_net_map variables from the OpenStackDataPlaneNodeSet. These are no longer used and have been removed from the dataplane-operator samples:
https://github.com/openstack-k8s-operators/dataplane-operator/commit/6ef58e68e88b73d81bcd43cb4407dafa030a116c

Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/486