### PR TITLE
Remove non-existing Swift template fields

### DIFF
--- a/docs_user/modules/proc_adopting-the-object-storage-service.adoc
+++ b/docs_user/modules/proc_adopting-the-object-storage-service.adoc
@@ -58,8 +58,6 @@ spec:
   swift:
     enabled: true
     template:
-      secret: osp-secret
-      swiftConfSecret: swift-conf
       memcachedInstance: memcached
       swiftRing:
         ringReplicas: 1

--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -40,8 +40,6 @@
       swift:
         enabled: true
         template:
-          secret: osp-secret
-          swiftConfSecret: swift-conf
           memcachedInstance: memcached
           swiftRing:
             ringReplicas: 1


### PR DESCRIPTION
spec.swift.template.swiftConfSecret has been removed in the swift-operator in commit #17bd4a6.

spec.swift.template.secret should be just spec.swift.template.swiftProxy.secret.

Jira: #OSPRH-6795