### PR TITLE
Document OVN gateway adoption procedure

### DIFF
--- a/docs_user/assemblies/assembly_adopting-the-data-plane.adoc
+++ b/docs_user/assemblies/assembly_adopting-the-data-plane.adoc
@@ -18,3 +18,5 @@ include::../modules/proc_stopping-infrastructure-management-and-compute-services
 include::../modules/proc_adopting-compute-services-to-the-data-plane.adoc[leveloffset=+1]
 
 include::../modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc[leveloffset=+1]
+
+include::../modules/proc_adopting-networker-services-to-the-data-plane.adoc[leveloffset=+1]

--- a/docs_user/modules/con_node-roles.adoc
+++ b/docs_user/modules/con_node-roles.adoc
@@ -2,12 +2,14 @@
 
 = About node roles
 
-In {OpenStackPreviousInstaller} deployments you had 4 different standard roles for the nodes:
-`Controller`, `Compute`, `Ceph Storage`, `Swift Storage`, but in the control plane you make a distinction based on where things are running, in
-{OpenShift} ({OpenShiftShort}) or external to it.
+In {OpenStackPreviousInstaller} deployments you had 5 different standard roles
+for the nodes: `Controller`, `Compute`, `Networker`, `Ceph Storage`, `Swift
+Storage`, but in the control plane you make a distinction based on where things
+are running, in {OpenShift} ({OpenShiftShort}) or external to it.
 
 When adopting a {OpenStackPreviousInstaller} {rhos_prev_long} ({OpenStackShort}) your `Compute` nodes will directly become
 external nodes, so there should not be much additional planning needed there.
+Your `Networker` nodes will also become external nodes.
 
 In many deployments being adopted the `Controller` nodes will require some
 thought because you have many {OpenShiftShort} nodes where the Controller services

--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -159,7 +159,7 @@ rm -f id*
 cd -
 ----
 
-. Create a `nova-compute-extra-config` service (with local storage backend for lbivrt):
+. Create a `nova-compute-extra-config` service (with local storage backend for `libvirt`):
 +
 . If TLS Everywhere is enabled, append the following to the OpenStackDataPlaneService spec:
 +
@@ -211,7 +211,7 @@ The secret `nova-cell<X>-compute-config` is auto-generated for each
 That service removes pre-FFU workarounds and configures Compute
 services for local storage backend.
 
-* Or, create a `nova-compute-extra-config` service (with Ceph backend for libvirt):
+* Or, create a `nova-compute-extra-config` service (with Ceph backend for `libvirt`):
 +
 [source,yaml]
 ----
@@ -361,7 +361,7 @@ endif::[]
           nova_libvirt_network: internalapi
 
         # edpm_network_config
-        # Default nic config template for a EDPM compute node
+        # Default nic config template for a EDPM node
         # These vars are edpm_network_config role vars
         edpm_network_config_template: |
            ---
@@ -505,10 +505,10 @@ spec:
         readOnly: true
 "
 ----
-+
-* Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
+Note that you should retain the original `OpenStackDataPlaneNodeSet` services
+composition, except the inserted `ceph-client` service.
 
-. Ensure that the `ovn-controller` settings that are configured in the `OpenStackDataPlaneNodeSet` CR are the same as were set in the Compute nodes before adoption. This configuration is stored in the `external_ids`` column in the `Open_vSwitch` table in the Open vSwitch database:
++ Ensure that the `ovn-controller` settings that are configured in the `OpenStackDataPlaneNodeSet` CR are the same as were set in the Compute nodes before adoption. This configuration is stored in the `external_ids` column in the `Open_vSwitch` table in the Open vSwitch database:
 +
 ----
 ovs-vsctl list Open .
@@ -516,9 +516,6 @@ ovs-vsctl list Open .
 external_ids        : {hostname=standalone.localdomain, ovn-bridge=br-int, ovn-bridge-mappings=<bridge_mappings>, ovn-chassis-mac-mappings="datacentre:1e:0a:bb:e6:7c:ad", ovn-encap-ip="172.19.0.100", ovn-encap-tos="0", ovn-encap-type=geneve, ovn-match-northd-version=False, ovn-monitor-all=True, ovn-ofctrl-wait-before-clear="8000", ovn-openflow-probe-interval="60", ovn-remote="tcp:ovsdbserver-sb.openstack.svc:6642", ovn-remote-probe-interval="60000", rundir="/var/run/openvswitch", system-id="2eec68e6-aa21-4c95-a868-31aeafc11736"}
 ...
 ----
-
-Note that you should retain the original `OpenStackDataPlaneNodeSet` services
-composition, except the inserted `ceph-client` service.
 
 +
 * Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
@@ -678,6 +675,13 @@ spec:
   - openstack
 EOF
 ----
+
+Note: if you have other node sets to deploy (e.g. for networker nodes), you may
+add them above in `nodeSets` list, or create separate
+`OpenStackDataPlaneDeployment` CRs later.
+
+Note that once a `OpenStackDataPlaneDeployment` CR is deployed, it's impossible
+to add new node sets to it later.
 
 .Verification
 

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -189,6 +189,8 @@ ifeval::["{build}" != "downstream"]
           # https://issues.redhat.com/browse/RHOSZUUL-1517
           dnf -y install crypto-policies
           update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+          ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
+          rm -rf repo-setup-main
 endif::[]
 ifeval::["{build}" == "downstream"]
         edpm_bootstrap_command: |

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -1,0 +1,346 @@
+[id="adopting-networker-services-to-the-data-plane_{context}"]
+
+= Adopting Networker services to the {rhos_acro} data plane
+
+If you have `Networker` nodes in your existing {rhos_acro} deployment, you
+should adopt them to the {rhos_acro} data plane too. The procedure is largely
+the same as for `Compute` nodes.
+
+The main difference between `Networker` and `Compute` nodes is that `Networker`
+nodes do not run `nova-compute` and `libvirt` services.
+
+You won't need to run `neutron-sriov` service on `Networker` nodes either. But
+depending on your topology, you might need to run `neutron-metadata` service
+there. Specifically, when you'd like to serve metadata to SR-IOV ports hosted
+on `Compute` nodes.
+
+Assuming you'd like to continue running OVN gateway services on `Networker`
+nodes, you will keep `ovn` service in the list to deploy. (You may later decide
+to deprovision OVN gateway services from `Networker` nodes and run them on OCP
+nodes instead. This is currently not recommended and is out of scope for the
+adoption procedure.)
+
+You may also want to run `neutron-dhcp` service on `Networker` nodes instead of
+`Compute` nodes. (But note that using `neutron-dhcp` with OVN is not generally
+needed.)
+
+Whatever the final list of services you'd like to run on `Networker` nodes, you
+will create a separate `OpenStackDataPlaneNodeSet` CR just for these nodes.
+
+. Define the following shell variable. The value that is used is an example
+and refers to a single node standalone {OpenStackPreviousInstaller} deployment.
+Adjust the value to your environment:
++
+[subs=+quotes]
+----
+declare -A networkers
+networkers=(
+  ["standalone.localdomain"]="192.168.122.100"
+  # ...
+)
+----
++
+** Replace `["standalone.localdomain"]="192.168.122.100"` with the name of the `Networker` node and its IP address.
+
+. Deploy the other `OpenStackDataPlaneNodeSet` CR. For simplicity, you can
+reuse most of the `nodeTemplate` section from the `openstack` CR designated for
+`Compute` nodes, though strictly speaking, some of the variables may be
+unnecessary because of a more limited set of services running on `Networker`
+nodes. Make sure `edpm_enable_chassis_gw: true` is set to run `ovn-controller`
+in gateway mode.
++
+. If TLS Everywhere is enabled, change `spec:tlsEnabled` to `true`.
++
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-networker
+spec:
+  tlsEnabled: false
+  networkAttachments:
+      - ctlplane
+  preProvisioned: true
+  services:
+    - bootstrap
+    - download-cache
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - install-certs
+    - ovn
+  env:
+    - name: ANSIBLE_CALLBACKS_ENABLED
+      value: "profile_tasks"
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  nodes:
+    standalone:
+      hostName: standalone
+      ansible:
+        ansibleHost: ${networkers[standalone.localdomain]}
+      networks:
+      - defaultRoute: true
+        fixedIP: ${networkers[standalone.localdomain]}
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-adoption-secret
+    ansible:
+      ansibleUser: root
+ifeval::["{build}" == "downstream"]
+      ansibleVarsFrom:
+      - prefix: subscription_manager_
+        secretRef:
+          name: subscription-manager
+      - prefix: registry_
+        secretRef:
+          name: redhat-registry
+endif::[]
+      ansibleVars:
+        # edpm_network_config
+        # Default nic config template for a EDPM node
+        # These vars are edpm_network_config role vars
+        edpm_network_config_template: |
+           ---
+           {% set mtu_list = [ctlplane_mtu] %}
+           {% for network in nodeset_networks %}
+           {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+           {%- endfor %}
+           {% set min_viable_mtu = mtu_list | max %}
+           network_config:
+           - type: ovs_bridge
+             name: {{ neutron_physical_bridge_name }}
+             mtu: {{ min_viable_mtu }}
+             use_dhcp: false
+             dns_servers: {{ ctlplane_dns_nameservers }}
+             domain: {{ dns_search_domains }}
+             addresses:
+             - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+             routes: {{ ctlplane_host_routes }}
+             members:
+             - type: interface
+               name: nic1
+               mtu: {{ min_viable_mtu }}
+               # force the MAC address of the bridge to this interface
+               primary: true
+           {% for network in nodeset_networks %}
+             - type: vlan
+               mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+               vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+               addresses:
+               - ip_netmask:
+                   {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+               routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+           {% endfor %}
+
+        edpm_network_config_hide_sensitive_logs: false
+        #
+        # These vars are for the network config templates themselves and are
+        # considered EDPM network defaults.
+        neutron_physical_bridge_name: br-ctlplane
+        neutron_public_interface_name: eth0
+
+        # edpm_nodes_validation
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+
+        # edpm ovn-controller configuration
+        edpm_ovn_bridge_mappings: <bridge_mappings>
+        edpm_ovn_bridge: br-int
+        edpm_ovn_encap_type: geneve
+        ovn_match_northd_version: false
+        ovn_monitor_all: true
+        edpm_ovn_remote_probe_interval: 60000
+        edpm_ovn_ofctrl_wait_before_clear: 8000
+
+        # serve as a OVN gateway
+        edpm_enable_chassis_gw: true
+
+        timesync_ntp_servers:
+ifeval::["{build}" != "downstream"]
+        - hostname: pool.ntp.org
+endif::[]
+ifeval::["{build}" == "downstream"]
+        - hostname: clock.redhat.com
+        - hostname: clock2.redhat.com
+endif::[]
+
+ifeval::["{build}" != "downstream"]
+        edpm_bootstrap_command: |
+          # This is a hack to deploy RDO Delorean repos to RHEL as if it were Centos 9 Stream
+          set -euxo pipefail
+          curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
+          python3 -m venv ./venv
+          PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
+          # This is required for FIPS enabled until trunk.rdoproject.org
+          # is not being served from a centos7 host, tracked by
+          # https://issues.redhat.com/browse/RHOSZUUL-1517
+          dnf -y install crypto-policies
+          update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+endif::[]
+ifeval::["{build}" == "downstream"]
+        edpm_bootstrap_command: |
+          subscription-manager register --username {{ subscription_manager_username }} --password {{ subscription_manager_password }}
+          subscription-manager release --set=9.2
+          subscription-manager repos --disable=*
+          subscription-manager repos --enable=rhel-9-for-x86_64-baseos-eus-rpms --enable=rhel-9-for-x86_64-appstream-eus-rpms --enable=rhel-9-for-x86_64-highavailability-eus-rpms --enable=openstack-17.1-for-rhel-9-x86_64-rpms --enable=fast-datapath-for-rhel-9-x86_64-rpms --enable=openstack-dev-preview-for-rhel-9-x86_64-rpms
+          podman login -u {{ registry_username }} -p {{ registry_password }} registry.redhat.io
+endif::[]
+
+        gather_facts: false
+        enable_debug: false
+        # edpm firewall, change the allowed CIDR if needed
+        edpm_sshd_configure_firewall: true
+        edpm_sshd_allowed_ranges: ['192.168.122.0/24']
+        # SELinux module
+        edpm_selinux_mode: enforcing
+
+        # Do not attempt OVS major upgrades here
+        edpm_ovs_packages:
+        - openvswitch3.1
+EOF
+----
+
+. Ensure that the `ovn-controller` settings that are configured in the `OpenStackDataPlaneNodeSet` CR are the same as were set in the `Networker` nodes before adoption. This configuration is stored in the `external_ids`` column in the `Open_vSwitch` table in the Open vSwitch database:
++
+----
+ovs-vsctl list Open .
+...
+external_ids        : {hostname=standalone.localdomain, ovn-bridge=br-int, ovn-bridge-mappings=<bridge_mappings>, ovn-chassis-mac-mappings="datacentre:1e:0a:bb:e6:7c:ad", ovn-cms-options=enable-chassis-as-gw, ovn-encap-ip="172.19.0.100", ovn-encap-tos="0", ovn-encap-type=geneve, ovn-match-northd-version=False, ovn-monitor-all=True, ovn-ofctrl-wait-before-clear="8000", ovn-openflow-probe-interval="60", ovn-remote="tcp:ovsdbserver-sb.openstack.svc:6642", ovn-remote-probe-interval="60000", rundir="/var/run/openvswitch", system-id="2eec68e6-aa21-4c95-a868-31aeafc11736"}
+...
+----
+
++
+* Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
+
+. Optional: Enable `neutron-metadata` in the `OpenStackDataPlaneNodeSet` CR:
++
+[source,yaml]
+----
+oc patch openstackdataplanenodeset openstack-networker --type='json' --patch='[
+  {
+    "op": "add",
+    "path": "/spec/services/-",
+    "value": "neutron-metadata"
+  }]'
+----
+
+. Optional: Enable `neutron-dhcp` in the `OpenStackDataPlaneNodeSet` CR:
++
+[source,yaml]
+----
+oc patch openstackdataplanenodeset openstack-networker --type='json' --patch='[
+  {
+    "op": "add",
+    "path": "/spec/services/-",
+    "value": "neutron-dhcp"
+  }]'
+----
+
+. Run pre-adoption validation for `Networker` nodes. This step reuses the
+service that was previously created for `Compute` nodes:
+
+.. Create a `OpenStackDataPlaneDeployment` CR that runs the validation only:
++
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-pre-adoption-networker
+spec:
+  nodeSets:
+  - openstack-networker
+  servicesOverride:
+  - pre-adoption-validation
+EOF
+----
++
+Wait for the validation to finish.
+
+.. Confirm that all the Ansible EE pods reach a `Completed` status:
++
+----
+# watching the pods
+watch oc get pod -l app=openstackansibleee
+----
++
+----
+# following the ansible logs with:
+oc logs -l app=openstackansibleee -f --max-log-requests 20
+----
+
+.. Wait for the deployment to reach the `Ready` status:
++
+----
+oc wait --for condition=Ready openstackdataplanedeployment/openstack-pre-adoption-networker --timeout=10m
+----
+
+. Deploy the `OpenStackDataPlaneDeployment` CR for `Networker` nodes:
++
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-networker
+spec:
+  nodeSets:
+  - openstack-networker
+EOF
+----
+
+Note: alternatively, you could include the `Networker` specific node set in the
+`nodeSets` list when creating the main, `openstack`,
+`OpenStackDataPlaneDeployment` CR.
+
+Note that once a `OpenStackDataPlaneDeployment` CR is deployed, it's impossible
+to add new node sets to it later.
+
+.Verification
+
+. Confirm that all the Ansible EE pods reach a `Completed` status:
++
+----
+# watching the pods
+watch oc get pod -l app=openstackansibleee
+----
++
+----
+# following the ansible logs with:
+oc logs -l app=openstackansibleee -f --max-log-requests 20
+----
+
+. Wait for the data plane node set to reach the `Ready` status:
++
+----
+oc wait --for condition=Ready osdpns/openstack-networker --timeout=30m
+----
+
+. Verify that {networking} agents are alive (the list of agents may
+vary depending on the services you've enabled):
++
+----
+oc exec openstackclient -- openstack network agent list
++--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
+| ID                                   | Agent Type                   | Host                   | Availability Zone | Alive | State | Binary                     |
++--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
+| 174fc099-5cc9-4348-b8fc-59ed44fcfb0e | DHCP agent                   | standalone.localdomain | nova              | :-)   | UP    | neutron-dhcp-agent         |
+| 10482583-2130-5b0d-958f-3430da21b929 | OVN Metadata agent           | standalone.localdomain |                   | :-)   | UP    | neutron-ovn-metadata-agent |
+| a4f1b584-16f1-4937-b2b0-28102a3f6eaa | OVN Controller Gateway agent | standalone.localdomain |                   | :-)   | UP    | ovn-controller             |
++--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
+----

--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -2,22 +2,17 @@
 
 = Migrating OVN data
 
-This document describes how to move OVN northbound and southbound databases
-from the original {rhos_prev_long} deployment to `ovsdb-server` instances running in the {OpenShift} cluster.
-While it may be argued that the control plane {networking_first_ref} ML2/OVN driver and OVN northd service will reconstruct the databases on startup, the reconstruction may be time consuming on large existing clusters. The procedure below allows to speed up data migration and avoid unnecessary data plane disruptions due to incomplete OpenFlow table contents.
+The next step is to migrate data from OVN databases from the original
+{rhos_prev_long} deployment to `ovsdb-server` instances running in the
+{OpenShift} cluster.
 
 .Prerequisites
 
 * Make sure the previous Adoption steps have been performed successfully.
  ** The `OpenStackControlPlane` resource must be already created at this point.
- ** NetworkAttachmentDefinition custom resource definitions (CRDs) for the original cluster are already
-defined. Specifically, `openstack/internalapi` network is defined.
- ** Control plane MariaDB and RabbitMQ may already run. The {networking} and OVN are not running yet.
- ** Original OVN is older or equal to the control plane version.
- ** Original Neutron Server and OVN northd services are stopped.
- ** There must be network routability between:
-  *** The adoption host and the original OVN.
-  *** The adoption host and the control plane OVN.
+ ** `NetworkAttachmentDefinition` CRDs for the original cluster are already defined. Specifically, `internalapi` network is defined.
+ ** The original {networking} and OVN `northd` are not running.
+ ** There must be network routability between control plane services and the adopted cluster.
 * Define the following shell variables. The values that are used are examples. Replace these example values with values that are correct for your environment:
 +
 ----
@@ -40,7 +35,8 @@ grep -rI 'ovn_[ns]b_conn' /var/lib/config-data/puppet-generated/
 
 .Procedure
 
-. Prepare the OVN DBs copy dir and the adoption helper pod (pick the storage requests to fit the OVN databases sizes)
+. Prepare temporary `PersistentVolume` and the helper pod for OVN backup.
+Please adjust storage requests for a large database, if needed.
 +
 [source,yaml]
 ----
@@ -119,14 +115,14 @@ oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6641 
 oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6642 > /backup/ovs-sb.db"
 ----
 
-. Backup OVN databases on a TLS everywhere environment.
+. Alternatively, backup OVN databases on a TLS everywhere environment.
 +
 ----
 oc exec ovn-copy-data -- bash -c "ovsdb-client backup --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$SOURCE_OVSDB_IP:6641 > /backup/ovs-nb.db"
 oc exec ovn-copy-data -- bash -c "ovsdb-client backup --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$SOURCE_OVSDB_IP:6642 > /backup/ovs-sb.db"
 ----
 
-. Start the control plane OVN database services prior to import, keeping `northd/ovn-controller` stopped.
+. Start control plane OVN database services prior to import, while keeping `northd` and `ovn-controller` disabled.
 +
 [source,yaml]
 ----
@@ -153,14 +149,14 @@ spec:
 '
 ----
 
-. Wait for the OVN DB pods reaching the running phase.
+. Wait for OVN database services to reach the `Running` phase.
 +
 ----
 oc wait --for=jsonpath='{.status.phase}'=Running pod --selector=service=ovsdbserver-nb
 oc wait --for=jsonpath='{.status.phase}'=Running pod --selector=service=ovsdbserver-sb
 ----
 
-. Fetch the control plane OVN IP addresses on the clusterIP service network.
+. Fetch OVN database IP addresses on the `clusterIP` service network.
 +
 ----
 PODIFIED_OVSDB_NB_IP=$(oc get svc --selector "statefulset.kubernetes.io/pod-name=ovsdbserver-nb-0" -ojsonpath='{.items[0].spec.clusterIP}')
@@ -174,35 +170,35 @@ oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_NB
 oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_SB_IP:6642 > /backup/ovs-sb.ovsschema && ovsdb-tool convert /backup/ovs-sb.db /backup/ovs-sb.ovsschema"
 ----
 
-. Upgrade database schema for the backup files on a TLS everywhere environment.
+. Alternatively, upgrade database schema for the backup files on a TLS everywhere environment.
 +
 ----
 oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_NB_IP:6641 > /backup/ovs-nb.ovsschema && ovsdb-tool convert /backup/ovs-nb.db /backup/ovs-nb.ovsschema"
 oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_SB_IP:6642 > /backup/ovs-sb.ovsschema && ovsdb-tool convert /backup/ovs-sb.db /backup/ovs-sb.ovsschema"
 ----
 
-. Restore database backup to the control plane OVN database servers on an environment without TLS everywhere.
+. Restore database backup to the new OVN database servers on an environment without TLS everywhere.
 +
 ----
 oc exec ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
 oc exec ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
 ----
 
-. Restore database backup to control plane OVN database servers on a TLS everywhere environment.
+. Alternatively, restore database backup to the new OVN database servers on a TLS everywhere environment.
 +
 ----
 oc exec ovn-copy-data -- bash -c "ovsdb-client restore --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
 oc exec ovn-copy-data -- bash -c "ovsdb-client restore --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
 ----
 
-. Check that the control plane OVN databases contain objects from backup, for example:
+. Check that data was successfully migrated by issuing some `ovn-nbctl` and `ovn-sbctl` commands against the new database servers, for example:
 +
 ----
 oc exec -it ovsdbserver-nb-0 -- ovn-nbctl show
 oc exec -it ovsdbserver-sb-0 -- ovn-sbctl list Chassis
 ----
 
-. Finally, you can start `ovn-northd` service that will keep OVN northbound and southbound databases in sync.
+. Start the control plane `ovn-northd` service. It will keep both OVN databases in sync.
 +
 [source,yaml]
 ----
@@ -216,21 +212,25 @@ spec:
 '
 ----
 
-. Also enable `ovn-controller`:
+. If you'd like to run OVN gateway services on OCP nodes, also enable the control plane `ovn-controller` service:
 +
 [source,yaml]
 ----
 oc patch openstackcontrolplane openstack --type=json -p="[{'op': 'remove', 'path': '/spec/ovn/template/ovnController/nodeSelector'}]"
 ----
 
-. Delete the `ovn-data` pod and persistent volume claim with OVN databases backup (consider making a snapshot of it, before deleting):
+Note that running OVN gateways on OCP nodes may be prone to dataplane downtime
+during Open vSwitch upgrades. Consider running OVN gateways on dedicated
+`Networker` data plane nodes for production deployments instead.
+
+. Delete the `ovn-data` helper pod and the temporary `PersistentVolumeClaim` used to store OVN database backup files (consider making a snapshot of it before deleting):
 +
 ----
 oc delete pod ovn-copy-data
 oc delete pvc ovn-data
 ----
 
-. Stop old OVN database servers.
+. Stop adopted OVN database servers.
 +
 ----
 ServicesToStop=("tripleo_ovn_cluster_north_db_server.service"

--- a/docs_user/modules/proc_stopping-infrastructure-management-and-compute-services.adoc
+++ b/docs_user/modules/proc_stopping-infrastructure-management-and-compute-services.adoc
@@ -4,9 +4,9 @@
 
 The source cloud's control plane can be decomissioned,
 which is taking down only cloud controllers, database and messaging nodes.
-Nodes that must remain functional are those running the Compute, storage,
-or networker roles (in terms of composable roles covered by {OpenStackPreviousInstaller} Heat
-Templates).
+Nodes that must remain functional are those running the `Compute`, `Storage`,
+or `Networker` roles (in terms of composable roles covered by
+{OpenStackPreviousInstaller} Heat Templates).
 
 .Prerequisites
 

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -8,3 +8,6 @@ shell_header: |
 # Whether to use no_log on tasks which may output potentially
 # sensitive data.
 use_no_log: false
+
+# Whether the adopted node will host compute services
+compute_adoption: true

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -98,12 +98,14 @@ edpm_bootstrap_command: |
   # https://issues.redhat.com/browse/RHOSZUUL-1517
   dnf -y install crypto-policies
   update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+  {%+ if compute_adoption|bool +%}
   # FIXME: perform dnf upgrade for other packages in EDPM ansible
   # here we only ensuring that decontainerized libvirt can start
   ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
   dnf -y upgrade openstack-selinux
   rm -f /run/virtlogd.pid
   rm -rf repo-setup-main
+  {%+ endif +%}
 
 edpm_network_config_template: |
   {%- raw %}

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -98,14 +98,14 @@ edpm_bootstrap_command: |
   # https://issues.redhat.com/browse/RHOSZUUL-1517
   dnf -y install crypto-policies
   update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+  ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
   {%+ if compute_adoption|bool +%}
   # FIXME: perform dnf upgrade for other packages in EDPM ansible
   # here we only ensuring that decontainerized libvirt can start
-  ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
   dnf -y upgrade openstack-selinux
   rm -f /run/virtlogd.pid
-  rm -rf repo-setup-main
   {%+ endif +%}
+  rm -rf repo-setup-main
 
 edpm_network_config_template: |
   {%- raw %}

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -337,7 +337,9 @@
 # TODO: Apply the ceph backend config for Cinder in the original openstack CR, via kustomize
 - name: prepare adopted EDPM workloads to use Ceph backend for Cinder, if configured so
   no_log: "{{ use_no_log }}"
-  when: cinder_volume_backend == "ceph" or cinder_backup_backend == "ceph"
+  when:
+    - compute_adoption|bool
+    - cinder_volume_backend == "ceph" or cinder_backup_backend == "ceph"
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
@@ -353,10 +355,8 @@
         - run-os
         - install-certs
         - ceph-client
-        {%+ if compute_adoption|bool +%}
         - libvirt
         - nova-compute-extraconfig
-        {%+ endif +%}
         - ovn
         - neutron-metadata
       nodeTemplate:

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -55,6 +55,7 @@
 # is released in 17.1.3. note that we use 42436:42436 as the nova user and group may not have
 # been created yet, and we need to ensure the file is owned by the correct user and group
 - name: Temporary fix to ensure stable compute UUID
+  when: compute_adoption|bool
   block:
     - name: ensure SSH key
       ansible.builtin.copy:
@@ -102,6 +103,7 @@
     EOF
 
 - name: generate an ssh key-pair nova-migration-ssh-key secret
+  when: compute_adoption|bool
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -118,6 +120,7 @@
 
 - name: create a Nova Compute Extra Config service (no ceph backend in use)
   when:
+    - compute_adoption|bool
     - ('ceph' not in [nova_libvirt_backend])
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
@@ -160,8 +163,9 @@
     {% endif %}
     EOF
 
-- name: create a Nova Compute Extra Config service (with ceph backend)
+- name: create a Nova Compute Extra Config service (ceph backend in use)
   when:
+    - compute_adoption|bool
     - ('ceph' in [nova_libvirt_backend])
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
@@ -236,8 +240,10 @@
         - ssh-known-hosts
         - run-os
         - install-certs
+        {%+ if compute_adoption|bool +%}
         - libvirt
         - nova-compute-extraconfig
+        {%+ endif +%}
         - ovn
         - neutron-metadata
       env:
@@ -256,9 +262,12 @@
             os_net_config_iface: {{ dataplane_os_net_config_iface | default ('nic1') }}
             os_net_config_set_route: {{ dataplane_os_net_config_set_route | default(true) | bool }}
             os_net_config_dns: {{ dataplane_os_net_config_dns | default("") }}
+
+            {%+ if compute_adoption|bool +%}
             service_net_map:
               nova_api_network: internalapi
               nova_libvirt_network: internalapi
+            {%+ endif +%}
 
             edpm_bootstrap_command: |
               {{ edpm_bootstrap_command| indent(10) }}
@@ -308,6 +317,9 @@
             ovn_monitor_all: true
             edpm_ovn_remote_probe_interval: 60000
             edpm_ovn_ofctrl_wait_before_clear: 8000
+
+            # serve as a OVN gateway
+            edpm_enable_chassis_gw: true
     EOF
 
 - name: check ovs external-ids with os-diff before deployment
@@ -341,8 +353,10 @@
         - run-os
         - install-certs
         - ceph-client
+        {%+ if compute_adoption|bool +%}
         - libvirt
         - nova-compute-extraconfig
+        {%+ endif +%}
         - ovn
         - neutron-metadata
       nodeTemplate:
@@ -381,7 +395,9 @@
         "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors",
         "value": ""
       }]'
-  when: edpm_neutron_sriov_agent_enabled|bool
+  when:
+    - edpm_neutron_sriov_agent_enabled|bool
+    - compute_adoption|bool
 
 - name: set neutron-dhcp configuration in the OpenStackDataPlaneNodeSet CR
   no_log: "{{ use_no_log }}"
@@ -571,10 +587,12 @@
   register: osdpd_running_result
 
 - name: Complete Nova services Wallaby->Antelope FFU
+  when: compute_adoption|bool
   ansible.builtin.include_tasks:
     file: nova_ffu.yaml
 
 - name: Adopted Nova FFU post-checks
+  when: compute_adoption|bool
   ansible.builtin.include_tasks:
     file: nova_verify.yaml
 

--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -19,6 +19,7 @@
   delay: 1
 
 - name: get neutron-sriov-nic-agent alive state
+  when: compute_adoption|bool
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ neutron_header }}
@@ -26,6 +27,7 @@
   register: neutron_verify_sriov_nic_agent_result
 
 - name: verify that neutron-sriov-nic-agent is alive
+  when: compute_adoption|bool
   ansible.builtin.assert:
     that:
       - neutron_verify_sriov_nic_agent_result.stdout == 'ALIVE'

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -49,3 +49,6 @@ ironic_adoption: false
 
 # Run pre-adoption validation before the deploying
 run_pre_adoption_validation: true
+
+# Whether the adopted node will host compute services
+compute_adoption: true


### PR DESCRIPTION
Basically a truncated repeat of Compute procedure, with an emphasis on the list of services to include and on the fact that a separate NodeSet and Deployment is needed.