### PR TITLE
Fix tls connection issues in tlse job

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -173,6 +173,7 @@ cd -
       - ctlplane
     issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle
+  edpmServiceType: nova
 ----
 +
 [source,yaml]

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -156,6 +156,7 @@
           - ctlplane
         issuer: osp-rootca-issuer-internal
       caCerts: combined-ca-bundle
+      edpmServiceType: nova
     {% endif %}
     EOF
 


### PR DESCRIPTION
The jobs with tlse keeps failing because of a SSL error on nova_compute.
The fixes for this problem [1][2] suggest that we should add a value for
EDPMServiceType.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/896
[2] https://github.com/openstack-k8s-operators/architecture/pull/247
