### PR TITLE
Add missing oc_header to task from mariadb_copy role

### DIFF
--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -72,6 +72,7 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     for i in "${!SOURCE_GALERA_MEMBERS[@]}"; do
       echo "Checking for the database node $i WSREP status Synced"


### PR DESCRIPTION
Add oc_header var to task 'check that the Galera database cluster members are online and synced' from maraiadb_copy role.