### PR TITLE
Add ceph-hci-pre service when using ceph

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -355,6 +355,7 @@
         - configure-os
         - run-os
         - install-certs
+        - ceph-hci-pre
         - ceph-client
         - libvirt
         - nova-compute-extraconfig


### PR DESCRIPTION
When trying to run tempest tests with the standalone jobs, we found that after the edpm deployment, the firewall was blocking access to the ceph monitors, adding this service should configure the firewall to allow the traffic to the mons.