### PR TITLE
Add back reboot-os service into dataplane adoption NodeSet lists

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -316,6 +316,7 @@ spec:
     - configure-os
     - ssh-known-hosts
     - run-os
+    - reboot-os
     - install-certs
     - libvirt
     - nova-compute-extraconfig
@@ -486,6 +487,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - install-certs
     - ceph-client
     - libvirt

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -235,6 +235,7 @@
         - configure-os
         - ssh-known-hosts
         - run-os
+        - reboot-os
         - install-certs
         - libvirt
         - nova-compute-extraconfig
@@ -340,6 +341,7 @@
         - install-os
         - configure-os
         - run-os
+        - reboot-os
         - install-certs
         - ceph-hci-pre
         - ceph-client


### PR DESCRIPTION
Fix for reboot-os service casuing failure of adoption procedure is merged.[1] 
Add back reboot-os into the service list on the NodeSet lists.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/646