### PR TITLE
Bypass Heat database validation

### DIFF
--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -21,16 +21,12 @@
         apiOverride:
           route: {}
         template:
-          databaseInstance: openstack
-          databaseAccount: heat
           secret: osp-secret
-          memcachedInstance: memcached
           passwordSelectors:
             authEncryptionKey: HeatAuthEncryptionKey
             database: HeatDatabasePassword
             service: HeatPassword
     '
-
 - name: wait for Heat to start up
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
This change adds the bypass annotation to the heat resource which will permit the changing of spec.databaseInstance.