### PR TITLE
Adjust mariadb_copy and stop_remaining_services for multinode CI job

### DIFF
--- a/tests/roles/mariadb_copy/defaults/main.yaml
+++ b/tests/roles/mariadb_copy/defaults/main.yaml
@@ -1,2 +1,4 @@
 edpm_node_hostname: standalone.localdomain
 mariadb_copy_tmp_dir: tmp/mariadb
+source_galera_members: |-
+  ["{{ edpm_node_hostname }}"]={{ source_mariadb_ip|default(external_mariadb_ip) }}

--- a/tests/roles/mariadb_copy/tasks/env_vars_src.yaml
+++ b/tests/roles/mariadb_copy/tasks/env_vars_src.yaml
@@ -8,8 +8,7 @@
       SOURCE_MARIADB_IP={{ source_mariadb_ip|default(external_mariadb_ip) }}
       declare -A SOURCE_GALERA_MEMBERS
       SOURCE_GALERA_MEMBERS=(
-      ["{{ edpm_node_hostname }}"]={{ source_mariadb_ip|default(external_mariadb_ip) }}
-      # ...
+        {{  source_galera_members }}
       )
       SOURCE_DB_ROOT_PASSWORD="{{ source_db_root_password|default(external_db_root_password) }}"
       MARIADB_CLIENT_ANNOTATIONS='--annotations=k8s.v1.cni.cncf.io/networks=internalapi'

--- a/tests/roles/stop_remaining_services/defaults/main.yaml
+++ b/tests/roles/stop_remaining_services/defaults/main.yaml
@@ -1,3 +1,5 @@
 edpm_node_hostname: standalone.localdomain
 install_yamls_path: /home/zuul/src/github.com/openstack-k8s-operators/install_yamls/
 edpm_privatekey_path: "{{ install_yamls_path }}/out/edpm/ansibleee-ssh-key-id_rsa"
+edpm_computes: |-
+  ["{{ edpm_node_hostname }}"]="{{ edpm_node_ip }}"

--- a/tests/roles/stop_remaining_services/tasks/main.yaml
+++ b/tests/roles/stop_remaining_services/tasks/main.yaml
@@ -8,7 +8,7 @@
       EDPM_PRIVATEKEY_PATH="{{ edpm_privatekey_path }}"
       declare -A computes
       computes=(
-        ["{{ edpm_node_hostname }}"]="{{ edpm_node_ip }}"
+        {{ edpm_computes }}
       )
 
 - name: stop pacemaker services


### PR DESCRIPTION
This adjusts the mariadb_copy and stop_remaining_services roles to handle the case for multiple edpm_compute nodes (3) in the multi node source tripleo CI job. The edpm_computes and source_galera_members vars will be sent through from rdo plays at [1]

https://issues.redhat.com/browse/OSPRH-5756

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/53365/