### PR TITLE
Add swift into the deployed OpenStackControlPlane for scale-in check

### DIFF
--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -144,3 +144,13 @@ spec:
   telemetry:
     enabled: false
     template: {}
+
+  swift:
+    enabled: false
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 0
+      swiftProxy:
+        replicas: 1


### PR DESCRIPTION
As described in the related bug, we are not specifying swift in our initial controlplane deployment. The default for swiftStorage is to have replicas: 1 so when we patch the controlplane with replicas: 0 it triggers the 'no valid scale-in' validation.

Related-Bug: https://issues.redhat.com/browse/OSPCIX-320