### PR TITLE
Do not use bootstrap release package in adoption job

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -253,6 +253,7 @@
         ansible:
           ansibleUser: {{ edpm_user }}
           ansibleVars:
+            edpm_bootstrap_release_version_package: []
             os_net_config_iface: {{ dataplane_os_net_config_iface | default ('nic1') }}
             os_net_config_set_route: {{ dataplane_os_net_config_set_route | default(true) | bool }}
             os_net_config_dns: {{ dataplane_os_net_config_dns | default("") }}


### PR DESCRIPTION
[1] Moved the release package name to "rhoso-release"
for redhat distribution. But the package is only
relevant for 18.0 repos which upstream adoption job
do not use.

For adoption jobs as we using mixed repos i.e
RHOSP 17.1 and RDO Antelope and none have the
requested rpm. 17.1 have rhosp-release rpm which
can be used but with [2] that would also not
work as 17.1 repos being dropped before tests run.

The rpm doesn't seems to be used so this patch just
drops it's usage.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/53454

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/669
[2] https://review.rdoproject.org/r/c/rdo-jobs/+/53425
Closes-Issue: OSPCIX-332