### PR TITLE
Remove compute_id pre-population

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -93,31 +93,6 @@ export computes=(
 
 .Procedure
 
-//* _Temporary fix_ until the OSP 17 https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid[backport of the stable compute UUID feature]
-//lands.
-//kgilliga: Revisit this step after 17.1.3 is on the CDN.
-. For each Compute node, write the UUID of the Compute service to the stable `compute_id` file in `/var/lib/nova/` directory:
-+
-[subs=+quotes]
-----
-for name in "${!computes[@]}";
-do
-  uuid=$(\
-    openstack hypervisor show $name \
-    -f value -c 'id'\
-  )
-  echo "Writing $uuid to /var/lib/nova/compute_id on $name"
-  ssh \
-ifeval::["{build}" != "downstream"]
-    -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-endif::[]
-ifeval::["{build}" == "downstream"]
-    -i *<path to SSH key>* \
-endif::[]
-    root@"${computes[$name]}" \
-      "grep -qF $uuid /var/lib/nova/compute_id || (echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id)"
-done
-----
 ifeval::["{build}" != "downstream"]
 . Create a https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets[ssh authentication secret] for the data plane nodes:
 //kgilliga:I need to check if we will document this in Red Hat docs.

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -51,43 +51,6 @@
   register: edpm_privatekey
   when: edpm_encoded_privatekey is undefined
 
-# Remove this when https://code.engineering.redhat.com/gerrit/q/topic:stable-compute-uuid
-# is released in 17.1.3. note that we use 42436:42436 as the nova user and group may not have
-# been created yet, and we need to ensure the file is owned by the correct user and group
-- name: Temporary fix to ensure stable compute UUID
-  when: compute_adoption|bool
-  block:
-    - name: ensure SSH key
-      ansible.builtin.copy:
-        dest: /tmp/ansible_private_key
-        content: "{{ edpm_encoded_privatekey | default(edpm_privatekey.content) | b64decode }}"
-        mode: "0600"
-      when: edpm_privatekey_path is undefined
-
-    - name: populate compute_id file
-      ansible.builtin.shell: |
-        {{ shell_header }}
-        {{ oc_header }}
-        declare -A computes
-        computes=(
-          {{ edpm_computes }}
-        )
-
-        for name in "${!computes[@]}";
-        do
-          uuid=$(\
-            oc exec -t openstackclient -- \
-              openstack hypervisor show $name \
-              -f value -c 'id'\
-          )
-
-          echo "Writing $uuid to /var/lib/nova/compute_id on $name"
-          ssh \
-            -i {{ edpm_privatekey_path | default("/tmp/ansible_private_key") }} \
-            {{ edpm_user }}@"${computes[$name]}" \
-            "grep -qF $uuid /var/lib/nova/compute_id || (echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id)"
-        done
-
 - name: create dataplane-adoption-secret.yaml
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
As 17.1.3 is released we don't need to pre-populate the compute_id file
before adoption as the 17.1.3 version of the nova-compute will do that
already.

Related: OSPRH-117