### PR TITLE
Add StrictHostKeyChecking=no ssh option

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -82,7 +82,8 @@
 
           echo "Writing $uuid to /var/lib/nova/compute_id on $name"
           ssh \
-            -i {{ edpm_privatekey_path | default("/tmp/ansible_private_key") }} \
+             -o StrictHostKeyChecking=no \
+             -i {{ edpm_privatekey_path | default("/tmp/ansible_private_key") }} \
             {{ edpm_user }}@"${computes[$name]}" \
             "grep -qF $uuid /var/lib/nova/compute_id || (echo $uuid | sudo tee /var/lib/nova/compute_id && sudo chown 42436:42436 /var/lib/nova/compute_id && sudo chcon -t container_file_t /var/lib/nova/compute_id)"
         done


### PR DESCRIPTION
Add StrictHostKeyChecking=no in populate compute_id file task.
In CI we need to skip hostkey finger check for ssh, otherwise task
hangs waiting on prompt for accepting key check.