### PR TITLE
Revert: Add test to check if Barbican secret payload is kept

### DIFF
--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -69,17 +69,3 @@
   until: barbican_responding_result is success
   retries: 60
   delay: 2
-
-- name: check that Barbican secret payload was migrated successfully
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-
-    alias openstack="oc exec -t openstackclient -- openstack"
-
-    secret_id=`${BASH_ALIASES[openstack]} secret list | grep testSecret | cut -d'|' -f 2 | xargs`
-    secret_payload=`${BASH_ALIASES[openstack]} secret get $secret_id --payload -f value`
-    if [ "$secret_payload" != "TestPayload" ]
-    then
-      exit 1
-    fi

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -86,6 +86,3 @@ fi
 if ${BASH_ALIASES[openstack]} volume show disk -f json | jq -r '.status' | grep -q available ; then
     ${BASH_ALIASES[openstack]} server add volume test disk
 fi
-
-# Create Barbican secret
-${BASH_ALIASES[openstack]} secret store --name testSecret --payload 'TestPayload'


### PR DESCRIPTION
This is a partial revert of #468, removing the additional test
that was added, which fails in a multinode environment.
