### PR TITLE
Update dataplane docs to avoid the bootstrap release package

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -332,6 +332,7 @@ ifeval::["{build}" == "downstream"]
           name: redhat-registry
 endif::[]
       ansibleVars:
+        edpm_bootstrap_release_version_package: []
         service_net_map:
           nova_api_network: internalapi
           nova_libvirt_network: internalapi

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -109,6 +109,7 @@ ifeval::["{build}" == "downstream"]
           name: redhat-registry
 endif::[]
       ansibleVars:
+        edpm_bootstrap_release_version_package: []
         # edpm_network_config
         # Default nic config template for a EDPM node
         # These vars are edpm_network_config role vars


### PR DESCRIPTION
follow up to: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/486