### PR TITLE
WIP: Add customization on netconfig_network

### DIFF
--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -126,7 +126,7 @@ spec:
             metadata:
               annotations:
                 metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+                metallb.universe.tf/loadBalancerIPs: 172.17.1.85
             spec:
               type: LoadBalancer
       rabbitmq-cell1:
@@ -135,7 +135,7 @@ spec:
             metadata:
               annotations:
                 metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+                metallb.universe.tf/loadBalancerIPs: 172.17.1.86
             spec:
               type: LoadBalancer
 

--- a/tests/roles/barbican_adoption/defaults/main.yaml
+++ b/tests/roles/barbican_adoption/defaults/main.yaml
@@ -26,7 +26,7 @@ barbican_patch: |
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
         barbicanWorker:

--- a/tests/roles/cinder_adoption/defaults/main.yaml
+++ b/tests/roles/cinder_adoption/defaults/main.yaml
@@ -21,7 +21,7 @@ cinder_scheduler_api_patch: |
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
         cinderBackup:

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -15,9 +15,9 @@ netconfig_networks:
     subnets:
       - name: subnet1
         allocationRanges:
-          - end: 172.17.0.250
-            start: 172.17.0.100
-        cidr: 172.17.0.0/24
+          - end: "{{ internalapi_allocation_end | default('172.17.0.250') }}"
+            start: "{{ internalapi_allocation_start | default('172.17.0.100') }}"
+        cidr: "{{ internalapi_cidr | default('172.17.0.0/24') }}"
         vlan: 20
   - name: External
     dnsDomain: external.example.com
@@ -33,27 +33,27 @@ netconfig_networks:
     subnets:
       - name: subnet1
         allocationRanges:
-          - end: 172.18.0.250
-            start: 172.18.0.100
-        cidr: 172.18.0.0/24
+          - end: "{{ storage_allocation_end | default('172.18.0.250') }}"
+            start: "{{ storage_allocation_start | default('172.18.0.100') }}"
+        cidr: "{{ storage_cidr | default('172.18.0.0/24') }}"
         vlan: 21
   - name: storagemgmt
     dnsDomain: storagemgmt.example.com
     subnets:
       - name: subnet1
         allocationRanges:
-          - end: 172.20.0.250
-            start: 172.20.0.100
-        cidr: 172.20.0.0/24
+          - end: "{{ storagemgmt_allocation_end | default('172.20.0.250') }}"
+            start: "{{ storagemgmt_allocation_start | default('172.20.0.100') }}"
+        cidr: "{{ storagemgmt_cidr | default('172.20.0.0/24') }}"
         vlan: 23
   - name: tenant
     dnsDomain: tenant.example.com
     subnets:
       - name: subnet1
         allocationRanges:
-          - end: 172.19.0.250
-            start: 172.19.0.100
-        cidr: 172.19.0.0/24
+          - end: "{{ tenant_allocation_end | default('172.19.0.250') }}"
+            start: "{{ tenant_allocation_start | default('172.19.0.100') }}"
+        cidr: "{{ tenant_cidr | default('172.19.0.0/24') }}"
         vlan: 22
 registry_name: "quay.io"
 registry_namespace: "podified-antelope-centos9"

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -4,6 +4,27 @@
     nova_header: |
       alias openstack="oc exec -t openstackclient -- openstack"
 
+- name: DEBUG ARNAU list VMs
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell: |
+    {{ nova_header }}
+    ${BASH_ALIASES[openstack]} server list
+  ignore_errors: true
+
+- name: DEBUG ARNAU show test VMs
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell: |
+    {{ nova_header }}
+    ${BASH_ALIASES[openstack]} server show test
+  ignore_errors: true
+
+- name: DEBUG ARNAU show diagnostics
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell: |
+    {{ nova_header }}
+    ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test
+  ignore_errors: true
+
 # NOTE(bogdando): do not use 'set -o pipefail' for these verifications
 - name: verify if Nova services can stop the existing test VM instance
   when: prelaunch_test_instance|bool

--- a/tests/roles/glance_adoption/files/glance_ceph.yaml.j2
+++ b/tests/roles/glance_adoption/files/glance_ceph.yaml.j2
@@ -27,7 +27,7 @@ spec:
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
           networkAttachments:

--- a/tests/roles/glance_adoption/files/glance_cinder.yaml.j2
+++ b/tests/roles/glance_adoption/files/glance_cinder.yaml.j2
@@ -1,3 +1,4 @@
+{% raw %}
 spec:
   glance:
     enabled: true
@@ -32,7 +33,8 @@ spec:
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+{% endraw %}
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer
           networkAttachments:

--- a/tests/roles/glance_adoption/files/glance_local.yaml.j2
+++ b/tests/roles/glance_adoption/files/glance_local.yaml.j2
@@ -1,28 +1,22 @@
 spec:
   glance:
     enabled: true
-    apiOverrides:
-      default:
-        route: {}
     template:
       databaseInstance: openstack
-      storage:
-        storageClass: "local-storage"
-        storageRequest: 10G
+      databaseAccount: glance
       customServiceConfig: |
         [DEFAULT]
-        enabled_backends = default_backend:swift
+        enabled_backends = default_backend:file
         [glance_store]
         default_backend = default_backend
         [default_backend]
-        swift_store_create_container_on_put = True
-        swift_store_auth_version = 3
-        swift_store_auth_address = {{ .KeystoneInternalURL }}
-        swift_store_endpoint_type = internalURL
-        swift_store_user = service:glance
-        swift_store_key = {{ .ServicePassword }}
+        filesystem_store_datadir = /var/lib/glance/images/
+      storage:
+        storageClass: "local-storage"
+        storageRequest: 10G
       glanceAPIs:
         default:
+          type: single
           replicas: 1
           override:
             service:
@@ -31,7 +25,7 @@ spec:
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
           networkAttachments:

--- a/tests/roles/glance_adoption/files/glance_swift.yaml.j2
+++ b/tests/roles/glance_adoption/files/glance_swift.yaml.j2
@@ -1,22 +1,29 @@
+{% raw %}
 spec:
   glance:
     enabled: true
+    apiOverrides:
+      default:
+        route: {}
     template:
       databaseInstance: openstack
-      databaseAccount: glance
-      customServiceConfig: |
-        [DEFAULT]
-        enabled_backends = default_backend:file
-        [glance_store]
-        default_backend = default_backend
-        [default_backend]
-        filesystem_store_datadir = /var/lib/glance/images/
       storage:
         storageClass: "local-storage"
         storageRequest: 10G
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       glanceAPIs:
         default:
-          type: single
           replicas: 1
           override:
             service:
@@ -25,7 +32,8 @@ spec:
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+{% endraw %}
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
           networkAttachments:

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -1,3 +1,9 @@
+- name: template out the local backend
+  ansible.builtin.template:
+    src: "{{ role_path }}/files/glance_local.yaml.j2"
+    dest: "{{ role_path }}/files/glance_local.yaml"
+    mode: '644'
+
 - name: deploy podified Glance with local backend
   when: glance_backend == 'nfs'
   block:
@@ -19,6 +25,12 @@
         {{ oc_header }}
         oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/glance_nfs.yaml
 
+- name: template out the glance backend
+  ansible.builtin.template:
+    src: "{{ role_path }}/files/glance_ceph.yaml.j2"
+    dest: "{{ role_path }}/files/glance_ceph.yaml"
+    mode: '644'
+
 - name: deploy podified Glance with Ceph backend
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -26,12 +38,24 @@
      oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_ceph.yaml
   when: glance_backend == 'ceph'
 
+- name: template out the swift backend
+  ansible.builtin.template:
+    src: "{{ role_path }}/files/glance_swift.yaml.j2"
+    dest: "{{ role_path }}/files/glance_swift.yaml"
+    mode: '644'
+
 - name: deploy podified Glance with Swift backend
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_swift.yaml
   when: glance_backend == 'swift'
+
+- name: template out the cinder backend
+  ansible.builtin.template:
+    src: "{{ role_path }}/files/glance_cinder.yaml.j2"
+    dest: "{{ role_path }}/files/glance_cinder.yaml"
+    mode: '644'
 
 - name: deploy podified Glance with Cinder backend
   ansible.builtin.shell: |

--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -17,7 +17,7 @@ ironic_patch: |
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
         ironicConductors:

--- a/tests/roles/keystone_adoption/defaults/main.yaml
+++ b/tests/roles/keystone_adoption/defaults/main.yaml
@@ -13,7 +13,7 @@ keystone_patch: |
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer
         databaseInstance: openstack

--- a/tests/roles/manila_adoption/templates/manila_cephfs.yaml.j2
+++ b/tests/roles/manila_adoption/templates/manila_cephfs.yaml.j2
@@ -25,7 +25,7 @@ spec:
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer
       manilaScheduler:

--- a/tests/roles/neutron_adoption/defaults/main.yaml
+++ b/tests/roles/neutron_adoption/defaults/main.yaml
@@ -13,7 +13,7 @@ neutron_config_patch: |
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer
         databaseInstance: openstack

--- a/tests/roles/nova_adoption/defaults/main.yaml
+++ b/tests/roles/nova_adoption/defaults/main.yaml
@@ -18,7 +18,7 @@ nova_libvirt_patch: |
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
           customServiceConfig: |
@@ -32,7 +32,7 @@ nova_libvirt_patch: |
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer
           customServiceConfig: |
@@ -57,7 +57,7 @@ nova_libvirt_patch: |
                       annotations:
                         metallb.universe.tf/address-pool: internalapi
                         metallb.universe.tf/allow-shared-ip: internalapi
-                        metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                        metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                     spec:
                       type: LoadBalancer
               customServiceConfig: |
@@ -84,7 +84,7 @@ nova_ironic_patch: |
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
           customServiceConfig: |
@@ -98,7 +98,7 @@ nova_ironic_patch: |
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer
           customServiceConfig: |

--- a/tests/roles/nova_adoption/tasks/nova_ironic.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_ironic.yaml
@@ -4,7 +4,6 @@
     {{ oc_header }}
     oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ nova_ironic_patch}}'
 
-
 - name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_tasks:
     file: wait.yaml

--- a/tests/roles/placement_adoption/defaults/main.yaml
+++ b/tests/roles/placement_adoption/defaults/main.yaml
@@ -16,6 +16,6 @@ placement_patch: |
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
               spec:
                 type: LoadBalancer

--- a/tests/roles/swift_adoption/defaults/main.yaml
+++ b/tests/roles/swift_adoption/defaults/main.yaml
@@ -26,7 +26,7 @@ swift_patch: |
                   annotations:
                     metallb.universe.tf/address-pool: internalapi
                     metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                 spec:
                   type: LoadBalancer
           networkAttachments:


### PR DESCRIPTION
dataplane_adoption role doesn't allow customization with the subnet ranges, this conflicts with testing scenario 1 (using different subnet ranges) during adoption.

Related: OSPRH-5881