### PR TITLE
consolidated variables into adoption-attributes file

### DIFF
--- a/docs_user/adoption-attributes.adoc
+++ b/docs_user/adoption-attributes.adoc
@@ -2,7 +2,77 @@
 :context: assembly
 :build: downstream
 
-ifeval::["{build}" != "downstream"]
+//Identity service (keystone)
+:identity_service_first_ref: Identity service (keystone)
+:identity_service: Identity service
+
+//Shared File Systems service (manila)
+:rhos_component_storage_file_first_ref: Shared File Systems service (manila)
+:rhos_component_storage_file: Shared File Systems service
+
+//OpenStack Key Manager (barbican)
+:key_manager_first_ref: Key Manager service (barbican)
+:key_manager: Key Manager service
+
+//OpenStack Networking service (neutron)
+:networking_first_ref: Networking service (neutron)
+:networking_service: Networking service
+
+//Object Storage service (swift)
+:object_storage_first_ref: Object Storage service (swift)
+:object_storage: Object Storage service
+
+//Image service (glance)
+:image_service_first_ref: Image Service (glance)
+:image_service: Image service
+
+//Compute service (nova)
+:compute_service_first_ref: Compute service (nova)
+:compute_service: Compute service
+
+//Block Storage (cinder)
+:block_storage_first_ref: Block Storage service (cinder)
+:block_storage: Block Storage service
+
+//Dashboard service (horizon)
+:dashboard_first_ref: Dashboard service (horizon)
+:dashboard_service: Dashboard service
+
+//Bare Metal Provisioning service (ironic)
+:bare_metal_first_ref: Bare Metal Provisioning service (ironic)
+:bare_metal: Bare Metal Provisioning service
+
+//Orchestration service (heat)
+:orchestration_first_ref: Orchestration service (heat)
+:orchestration: Orchestration service
+
+//Telemetry service
+:telemetry: Telemetry service
+
+//rhel versions
+:rhel_prev_ver: 9.2
+:rhel_curr_ver: 9.4
+
+// OCP version attributes
+
+:ocp_curr_ver: 4.15
+
+ifeval::["{build}" == "downstream"]
+:rhos_long: Red{nbsp}Hat OpenStack Services on OpenShift (RHOSO)
+:rhos_prev_long: Red{nbsp}Hat OpenStack Platform
+:rhos_acro: RHOSO
+:rhos_curr_ver: 18.0
+:rhos_prev_ver: 17.1
+:OpenStackShort: RHOSP
+:OpenShift: Red Hat OpenShift Container Platform
+:OpenShiftShort: RHOCP
+:OpenStackPreviousInstaller: director
+:Ceph: Red Hat Ceph Storage 
+:CephCluster: Red Hat Ceph Storage
+:CephVernum: 7 
+endif::[]
+
+ifeval::["{build}" == "upstream"]
 :OpenShift: OpenShift
 :rhos_long: OpenStack
 :rhos_prev_long: OpenStack
@@ -11,126 +81,66 @@ ifeval::["{build}" != "downstream"]
 :OpenShiftShort: OCP
 :rhos_curr_ver: Antelope
 :rhos_prev_ver: Wallaby
-:rhel_curr_ver: 9.4
-:rhel_prev_ver: 9.2
 :OpenStackPreviousInstaller: TripleO
 :Ceph: Ceph
 :CephCluster: Ceph Storage
-:CephRelease: Reef
-
-//Components and services
-
-//Identity service (keystone)
-:identity_service_first_ref: Identity service (keystone)
-:identity_service: Identity service
-
-//Shared File Systems service (manila)
-:rhos_component_storage_file_first_ref: Shared File Systems service (manila)
-:rhos_component_storage_file: Shared File Systems service
-
-//OpenStack Key Manager (barbican)
-:key_manager_first_ref: Key Manager service (barbican)
-:key_manager: Key Manager service
-
-//OpenStack Networking service (neutron)
-:networking_first_ref: Networking service (neutron)
-:networking: Networking service
-
-//Object Storage service (swift)
-:object_storage_first_ref: Object Storage service (swift)
-:object_storage: Object Storage service
-
-//Image service (glance)
-:image_service_first_ref: Image Service (glance)
-:image_service: Image service
-
-//Compute service (nova)
-:compute_service_first_ref: Compute service (nova)
-:compute_service: Compute service
-
-//Block Storage (cinder)
-:block_storage_first_ref: Block Storage service (cinder)
-:block_storage: Block Storage service
-
-//Dashboard service (horizon)
-:dashboard_first_ref: Dashboard service (horizon)
-:dashboard: Dashboard service
-
-//Bare Metal Provisioning service (ironic)
-:bare_metal_first_ref: Bare Metal Provisioning service (ironic)
-:bare_metal: Bare Metal Provisioning service
-
-//Orchestration service (heat)
-:orchestration_first_ref: Orchestration service (heat)
-:orchestration: Orchestration service
-
-//Telemetry service
-:telemetry: Telemetry service
-
+:CephVernum: Reef
 endif::[]
 
-ifeval::["{build}" == "downstream"]
-:rhos_long: Red{nbsp}Hat OpenStack Services on OpenShift (RHOSO)
-:rhos_acro: RHOSO
-:rhos_prev_long: Red{nbsp}Hat OpenStack Platform
-:OpenStackShort: RHOSP
-:rhos_curr_ver: 18.0
-:rhos_prev_ver: 17.1
-:rhel_curr_ver: 9.4
-:rhel_prev_ver: 9.2
-:OpenShift: Red Hat OpenShift Container Platform
-:OpenShiftShort: RHOCP
-:OpenStackPreviousInstaller: director
-:Ceph: Red Hat Ceph Storage
-:CephCluster: Red Hat Ceph Storage
-:CephRelease: 7
+// Common URLs. Do not override. Do not delete.
 
-//Components and services
+:base_url: https://access.redhat.com/documentation
+:defaultURL: https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{rhos_curr_ver}/html
+:defaultOCPURL: https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp_curr_ver}/html
+:defaultCephURL:  https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/{CephVernum}/html
 
-//Identity service (keystone)
-:identity_service_first_ref: Identity service (keystone)
-:identity_service: Identity service
+// books
 
-//Shared File Systems service (manila)
-:rhos_component_storage_file_first_ref: Shared File Systems service (manila)
-:rhos_component_storage_file: Shared File Systems service
+:release-notes:       {defaultURL}/release_notes 
+:intro-to-rhosp:      {defaultURL}/introduction_to_red_hat_openstack_platform
+:adopting-data-plane: {defaultURL}/adopting_the_red_hat_openstack_platform_data_plane
+:deploy-at-scale:     {defaultURL}/deploying_red_hat_openstack_platform_at_scale
+:intro-to-containers: {defaultURL}/introduction_to_containerized_services_in_red_hat_openstack_platform
+:installing-director: {defaultURL}/installing_and_managing_red_hat_openstack_platform_with_director
+:dcn:                 {defaultURL}/deploying_a_distributed_compute_node_dcn_architecture
+:ffu:                 {defaultURL}/framework_for_upgrades_16.2_to_17.1
+:managing-ha:         {defaultURL}/managing_high_availability_services
+:test-suite:          {defaultURL}/validating_your_cloud_with_the_red_hat_openstack_platform_integration_test_suite
+:backing-up:          {defaultURL}/backing_up_and_restoring_the_undercloud_and_control_plane_nodes
+:minor-update:        {defaultURL}/performing_a_minor_update_of_red_hat_openstack_platform
+:deploy-in-rhocp:     {defaultURL}/deploying_an_overcloud_in_a_red_hat_openshift_container_platform_cluster_with_director_operator
+:configure-compute:   {defaultURL}/configuring_the_compute_service_for_instance_creation
+:bare-metal:          {defaultURL}/configuring_the_bare_metal_provisioning_service
+:security-guide:      {defaultURL}/hardening_red_hat_openstack_platform
+:configuring-nfv:     {defaultURL}/configuring_network_functions_virtualization
+:spine-leaf:          {defaultURL}/configuring_spine-leaf_networking
+:bgp:                 {defaultURL}/configuring_dynamic_routing_in_red_hat_openstack_platform
+:networking:          {defaultURL}/configuring_red_hat_openstack_platform_networking
+:ipv6:                {defaultURL}/configuring_ipv6_networking_for_the_overcloud
+:dns-as-a-service:    {defaultURL}/configuring_dns_as_a_service
+:lbaas:               {defaultURL}/configuring_load_balancing_as_a_service
+:migrating-to-ovn:    {defaultURL}/migrating_to_the_ovn_mechanism_driver
+:firewall-rules:      {defaultURL}/firewall_rules_for_red_hat_openstack_platform
+:configuring-storage: {defaultURL}/configuring_persistent_storage
+:rhos-deployed-ceph:  {defaultURL}/deploying_red_hat_ceph_storage_and_red_hat_openstack_platform_together_with_director
+:existing-ceph:       {defaultURL}/integrating_an_overcloud_with_an_existing_red_hat_ceph_storage_cluster
+:backing-up-volumes:  {defaultURL}/backing_up_block_storage_volumes
+:hci:                 {defaultURL}/deploying_a_hyperconverged_infrastructure
+:identity:            {defaultURL}/managing_openstack_identity_resources
+:external-identity:   {defaultURL}/integrating_openstack_identity_with_external_user_management_services
+:dashboard:           {defaultURL}/managing_cloud_resources_with_the_openstack_dashboard
+:creating-images:     {defaultURL}/creating_and_managing_images
+:creating-instances:  {defaultURL}/creating_and_managing_instances
+:auto-scaling:        {defaultURL}/auto-scaling_for_instances
+:ha-for-instances:    {defaultURL}/configuring_high_availability_for_instances
+:barbican:            {defaultURL}/managing_secrets_with_the_key_manager_service
+:stf:                 {defaultURL}/service_telemetry_framework_1.5
+:stf-release-notes:   {defaultURL}/service_telemetry_framework_release_notes_1.5
+:observability:       {defaultURL}/managing_overcloud_observability
+:commandline-ref:     {defaultURL}/command_line_interface_reference
+:configuration-ref:   {defaultURL}/configuration_reference
+:oc-params:           {defaultURL}/overcloud_parameters
 
-//OpenStack Key Manager (barbican)
-:key_manager_first_ref: Key Manager service (barbican)
-:key_manager: Key Manager service
+// Specific links
 
-//OpenStack Networking service (neutron)
-:networking_first_ref: Networking service (neutron)
-:networking: Networking service
-
-//Object Storage service (swift)
-:object_storage_first_ref: Object Storage service (swift)
-:object_storage: Object Storage service
-
-//Image service (glance)
-:image_service_first_ref: Image Service (glance)
-:image_service: Image service
-
-//Compute service (nova)
-:compute_service_first_ref: Compute service (nova)
-:compute_service: Compute service
-
-//Block Storage (cinder)
-:block_storage_first_ref: Block Storage service (cinder)
-:block_storage: Block Storage service
-
-//Dashboard service (horizon)
-:dashboard_first_ref: Dashboard service (horizon)
-:dashboard: Dashboard service
-
-//Bare Metal Provisioning service (ironic)
-:bare_metal_first_ref: Bare Metal Provisioning service (ironic)
-:bare_metal: Bare Metal Provisioning service
-
-//Orchestration service (heat)
-:orchestration_first_ref: Orchestration service (heat)
-:orchestration: Orchestration service
-
-//Telemetry service
-:telemetry: Telemetry service
-endif::[]
+:setup-tlse: {defaultURL}/hardening_red_hat_openstack_platform/assembly_securing-rhos-with-tls-and-pki_security_and_hardening#proc_implementing-tls-e-with-ansible_encryption-and-key-management[Implementing TLS-e with Ansible]

--- a/docs_user/assemblies/assembly_migrating-ceph-monitoring-stack.adoc
+++ b/docs_user/assemblies/assembly_migrating-ceph-monitoring-stack.adoc
@@ -23,10 +23,10 @@ this procedure is to migrate and relocate the Ceph Monitoring components to
 free Controller nodes.
 
 For this procedure, we assume that we are beginning with a {OpenStackShort}
-based on {rhos_prev_ver} and a {Ceph} {CephRelease} deployment managed by
+based on {rhos_prev_ver} and a {Ceph} {CephVernum} deployment managed by
 {OpenStackPreviousInstaller}. We assume that:
 
-* {Ceph} has been upgraded to {CephRelease} and is managed by
+* {Ceph} has been upgraded to {CephVernum} and is managed by
   cephadm/orchestrator
 * Both the {Ceph} public and cluster networks are propagated,
   through {OpenStackPreviousInstaller}, to the target nodes

--- a/docs_user/main.adoc
+++ b/docs_user/main.adoc
@@ -8,10 +8,6 @@
 
 include::adoption-attributes.adoc[]
 
-ifeval::["{build}" == "downstream"]
-include::rhoso_attributes.adoc[]
-endif::[]
-
 include::assemblies/assembly_planning-the-new-deployment.adoc[leveloffset=+1]
 
 include::modules/proc_migrating-tls-everywhere.adoc[leveloffset=+1]

--- a/docs_user/modules/con_ceph-daemon-cardinality.adoc
+++ b/docs_user/modules/con_ceph-daemon-cardinality.adoc
@@ -24,7 +24,7 @@ nodes are required in a scenario that includes only RGW and RBD, without the
 | osd | mon/mgr/crash      | rgw/ingress |
 ----
 
-With the {dashboard}, and without {rhos_component_storage_file_first_ref}, at
+With the {dashboard_service}, and without {rhos_component_storage_file_first_ref}, at
 least 4 nodes are required. The {Ceph} dashboard has no failover:
 
 ----

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -333,7 +333,7 @@ oc logs -l app=openstackansibleee -f --max-log-requests 20
 oc wait --for condition=Ready osdpns/openstack-networker --timeout=30m
 ----
 
-. Verify that {networking} agents are alive (the list of agents may
+. Verify that {networking_service} agents are alive (the list of agents may
 vary depending on the services you've enabled):
 +
 ----

--- a/docs_user/modules/proc_adopting-the-networking-service.adoc
+++ b/docs_user/modules/proc_adopting-the-networking-service.adoc
@@ -1,8 +1,8 @@
 [id="adopting-the-networking-service_{context}"]
 
-= Adopting the {networking}
+= Adopting the {networking_service}
 
-Adopting {networking_first_ref} means that an existing `OpenStackControlPlane` custom resource (CR), where the {networking}
+Adopting {networking_first_ref} means that an existing `OpenStackControlPlane` custom resource (CR), where the {networking_service}
 is supposed to be disabled, should be patched to start the service with the
 configuration parameters provided by the source environment.
 
@@ -24,7 +24,7 @@ ifeval::["{build}" != "downstream"]
 As already done for https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/keystone_adoption.md[Keystone], the Neutron Adoption follows the same pattern.
 endif::[]
 
-* Patch `OpenStackControlPlane` to deploy {networking}:
+* Patch `OpenStackControlPlane` to deploy {networking_service}:
 +
 ----
 oc patch openstackcontrolplane openstack --type=merge --patch '
@@ -54,7 +54,7 @@ spec:
 
 .Verification
 
-* Inspect the resulting {networking} pods:
+* Inspect the resulting {networking_service} pods:
 +
 ----
 NEUTRON_API_POD=`oc get pods -l service=neutron | tail -n 1 | cut -f 1 -d' '`

--- a/docs_user/modules/proc_adopting-the-openstack-dashboard.adoc
+++ b/docs_user/modules/proc_adopting-the-openstack-dashboard.adoc
@@ -1,6 +1,6 @@
 [id="adopting-the-openstack-dashboard_{context}"]
 
-= Adopting the {dashboard}
+= Adopting the {dashboard_service}
 
 .Prerequisites
 
@@ -9,7 +9,7 @@
 
 .Procedure
 
-* Patch `OpenStackControlPlane` to deploy the {dashboard}:
+* Patch `OpenStackControlPlane` to deploy the {dashboard_service}:
 +
 ----
 oc patch openstackcontrolplane openstack --type=merge --patch '
@@ -26,13 +26,13 @@ spec:
 
 .Verification
 
-. See that the {dashboard} instance is successfully deployed and ready
+. See that the {dashboard_service} instance is successfully deployed and ready
 +
 ----
 oc get horizon
 ----
 
-. Check that the {dashboard} is reachable and returns status code `200`
+. Check that the {dashboard_service} is reachable and returns status code `200`
 +
 ----
 PUBLIC_URL=$(oc get horizon horizon -o jsonpath='{.status.endpoint}')

--- a/docs_user/modules/proc_migrating-ceph-mds.adoc
+++ b/docs_user/modules/proc_migrating-ceph-mds.adoc
@@ -14,10 +14,10 @@ This ensures that the human operator can easily visualize the status of the clus
 endif::[]
 //kgilliga: Note to self/SMEs: This intro will be rewritten for GA, so the text might not flow very well right now.
 
-For this procedure, we assume that we are beginning with a {OpenStackShort} based on {rhos_prev_ver} and a {Ceph} {CephRelease} deployment managed by {OpenStackPreviousInstaller}.
+For this procedure, we assume that we are beginning with a {OpenStackShort} based on {rhos_prev_ver} and a {Ceph} {CephVernum} deployment managed by {OpenStackPreviousInstaller}.
 We assume that:
 
-* {Ceph} is upgraded to {Ceph} {CephRelease} and is managed by cephadm/orchestrator.
+* {Ceph} is upgraded to {Ceph} {CephVernum} and is managed by cephadm/orchestrator.
 * Both the {Ceph} public and cluster networks are propagated, through{OpenStackPreviousInstaller}, to the target nodes.
 
 .Prerequisites

--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -11,7 +11,7 @@ The next step is to migrate data from OVN databases from the original
 * Make sure the previous Adoption steps have been performed successfully.
  ** The `OpenStackControlPlane` resource must be already created at this point.
  ** `NetworkAttachmentDefinition` CRDs for the original cluster are already defined. Specifically, `internalapi` network is defined.
- ** The original {networking} and OVN `northd` are not running.
+ ** The original {networking_service} and OVN `northd` are not running.
  ** There must be network routability between control plane services and the adopted cluster.
 * Define the following shell variables. The values that are used are examples. Replace these example values with values that are correct for your environment:
 +

--- a/docs_user/rhoso_attributes.adoc
+++ b/docs_user/rhoso_attributes.adoc
@@ -1,5 +1,5 @@
 // rhosp_attributes.adoc
-// Add this include statement in your master.adoc file: include::common/global/rhosp_attributes.adoc[]
+// Add this include statement in your master.adoc file: include::common/global/rhoso_attributes.adoc[]
 // Run this command to create a sym link in your doc folder:   $ ln -s ../common
 // Enclose the attribute in {} brackets in your modules.
 // Example: Use {osp_long} to display "OpenStack Platform".
@@ -17,10 +17,9 @@
 :rhos_prev_long: Red{nbsp}Hat OpenStack Platform
 :rhos_acro: RHOSO
 :rhos_curr_ver: 18.0
-:rhos_curr_ver_no_beta: 18.0
+:rhos_curr_ver_beta: 18.0-beta
 :rhos_prev_ver: 17.1
 :rhos_z_stream: 0
-
 
 // OCP version attributes
 
@@ -29,15 +28,65 @@
 
 // Ceph version attributes
 
-:CephVernum: 6.1
+:CephVernum: 7
 
 // Common URLs. Do not override. Do not delete.
 
 :base_url: https://access.redhat.com/documentation
-:defaultURL: https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{osp_curr_ver}/html
-:defaultOCPURL: https://docs.openshift.com/container-platform/{ocp_curr_ver}/
+:defaultURL: https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/{rhos_curr_ver}/html
+:defaultOCPURL: https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp_curr_ver}/html
 :defaultCephURL:  https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/{CephVernum}/html
+
+// books
+
+:release-notes:       {defaultURL}/release_notes 
+:intro-to-rhosp:      {defaultURL}/introduction_to_red_hat_openstack_platform
+:adopting-data-plane: {defaultURL}/adopting_the_red_hat_openstack_platform_data_plane
+:deploy-at-scale:     {defaultURL}/deploying_red_hat_openstack_platform_at_scale
+:intro-to-containers: {defaultURL}/introduction_to_containerized_services_in_red_hat_openstack_platform
+:installing-director: {defaultURL}/installing_and_managing_red_hat_openstack_platform_with_director
+:dcn:                 {defaultURL}/deploying_a_distributed_compute_node_dcn_architecture
+:ffu:                 {defaultURL}/framework_for_upgrades_16.2_to_17.1
+:managing-ha:         {defaultURL}/managing_high_availability_services
+:test-suite:          {defaultURL}/validating_your_cloud_with_the_red_hat_openstack_platform_integration_test_suite
+:backing-up:          {defaultURL}/backing_up_and_restoring_the_undercloud_and_control_plane_nodes
+:minor-update:        {defaultURL}/performing_a_minor_update_of_red_hat_openstack_platform
+:deploy-in-rhocp:     {defaultURL}/deploying_an_overcloud_in_a_red_hat_openshift_container_platform_cluster_with_director_operator
+:configure-compute:   {defaultURL}/configuring_the_compute_service_for_instance_creation
+:bare-metal:          {defaultURL}/configuring_the_bare_metal_provisioning_service
+:security-guide:      {defaultURL}/hardening_red_hat_openstack_platform
+:configuring-nfv:     {defaultURL}/configuring_network_functions_virtualization
+:spine-leaf:          {defaultURL}/configuring_spine-leaf_networking
+:bgp:                 {defaultURL}/configuring_dynamic_routing_in_red_hat_openstack_platform
+:networking:          {defaultURL}/configuring_red_hat_openstack_platform_networking
+:ipv6:                {defaultURL}/configuring_ipv6_networking_for_the_overcloud
+:dns-as-a-service:    {defaultURL}/configuring_dns_as_a_service
+:lbaas:               {defaultURL}/configuring_load_balancing_as_a_service
+:migrating-to-ovn:    {defaultURL}/migrating_to_the_ovn_mechanism_driver
+:firewall-rules:      {defaultURL}/firewall_rules_for_red_hat_openstack_platform
+:configuring-storage: {defaultURL}/configuring_persistent_storage
+:rhos-deployed-ceph:  {defaultURL}/deploying_red_hat_ceph_storage_and_red_hat_openstack_platform_together_with_director
+:existing-ceph:       {defaultURL}/integrating_an_overcloud_with_an_existing_red_hat_ceph_storage_cluster
+:backing-up-volumes:  {defaultURL}/backing_up_block_storage_volumes
+:hci:                 {defaultURL}/deploying_a_hyperconverged_infrastructure
+:identity:            {defaultURL}/managing_openstack_identity_resources
+:external-identity:   {defaultURL}/integrating_openstack_identity_with_external_user_management_services
+:dashboard:           {defaultURL}/managing_cloud_resources_with_the_openstack_dashboard
+:creating-images:     {defaultURL}/creating_and_managing_images
+:creating-instances:  {defaultURL}/creating_and_managing_instances
+:auto-scaling:        {defaultURL}/auto-scaling_for_instances
+:ha-for-instances:    {defaultURL}/configuring_high_availability_for_instances
+:barbican:            {defaultURL}/managing_secrets_with_the_key_manager_service
+:stf:                 {defaultURL}/service_telemetry_framework_1.5
+:stf-release-notes:   {defaultURL}/service_telemetry_framework_release_notes_1.5
+:observability:       {defaultURL}/managing_overcloud_observability
+:commandline-ref:     {defaultURL}/command_line_interface_reference
+:configuration-ref:   {defaultURL}/configuration_reference
+:oc-params:           {defaultURL}/overcloud_parameters
 
 // Specific links
 
 :setup-tlse: {defaultURL}/hardening_red_hat_openstack_platform/assembly_securing-rhos-with-tls-and-pki_security_and_hardening#proc_implementing-tls-e-with-ansible_encryption-and-key-management[Implementing TLS-e with Ansible]
+
+
+


### PR DESCRIPTION
Tl;dr This is not ready for review.

After a lot of testing, I consolidated the variables needed upstream and downstream into the adoption-attributes file. I migrated any common variables from the rhoso-attributes file into the adoption-attributes file. Then I used ifevals within the adoption-attributes file to differentiate upstream-specific and downstream-specific variables.

I am setting this PR to draft because I'm waiting for feedback from my team about the method used above, i.e., is there any reason why I need to keep the rhoso_attributes file, as long as I make sure the common variables are up to date?