### PR TITLE
Converge on using CONTROLLER1_SSH variable

### DIFF
--- a/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
+++ b/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
@@ -7,11 +7,12 @@
 * Define the following shell variables. The values that are used are examples. Replace these example values with values that are correct for your environment:
 +
 ----
-CONTROLLER_SSH="ssh -F ~/director_standalone/vagrant_ssh_config vagrant@standalone"
 ifeval::["{build}" != "downstream"]
+CONTROLLER1_SSH="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100"
 MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 endif::[]
 ifeval::["{build}" == "downstream"]
+CONTROLLER1_SSH="ssh -i *<path to SSH key>* root@*<node IP>*"
 MARIADB_IMAGE=registry.redhat.io/rhosp-dev-preview/openstack-mariadb-rhel9:18.0
 endif::[]
 SOURCE_MARIADB_IP=172.17.0.2
@@ -62,7 +63,7 @@ echo "$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES"
 . Get the list of mapped the {compute_service} cells:
 +
 ----
-export PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS=$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)
+export PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS=$($CONTROLLER1_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)
 echo "$PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS"
 ----
 +
@@ -84,7 +85,7 @@ PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$(oc run mariadb-client ${MARI
 PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$(oc run mariadb-client ${MARIADB_CLIENT_ANNOTATIONS} -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
     mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
     "select host from nova.services where services.binary='nova-compute';")"
-PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)"
+PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$($CONTROLLER1_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)"
 EOF
 chmod 0600 ~/.source_cloud_exported_variables
 ----

--- a/tests/roles/get_services_configuration/tasks/main.yaml
+++ b/tests/roles/get_services_configuration/tasks/main.yaml
@@ -3,7 +3,7 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.set_fact:
     pull_openstack_configuration_ssh_shell_vars: |
-      CONTROLLER_SSH="{{ controller1_ssh }}"
+      CONTROLLER1_SSH="{{ controller1_ssh }}"
 
 - name: get src database service environment variables
   ansible.builtin.include_role:
@@ -64,7 +64,7 @@
       ansible.builtin.shell: |
         {{ shell_header }}
         {{ pull_openstack_configuration_ssh_shell_vars }}
-        export PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS=$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)
+        export PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS=$($CONTROLLER1_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)
         echo "$PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS"
       register: _nova_cell_mappings_check
 
@@ -95,6 +95,6 @@
     PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$(oc run mariadb-client ${MARIADB_CLIENT_ANNOTATIONS} -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
         mysql -rsh $SOURCE_MARIADB_IP -uroot -p$SOURCE_DB_ROOT_PASSWORD nova_api -e \
         "select host from nova.services where services.binary='nova-compute';")"
-    PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$($CONTROLLER_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)"
+    PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$($CONTROLLER1_SSH sudo podman exec -it nova_api nova-manage cell_v2 list_cells)"
     EOF
     chmod 0600 ~/.source_cloud_exported_variables


### PR DESCRIPTION
For the manual workflow, CONTROLLER1_SSH is used elsewhere, let's just use that var instead of defining another CONTROLLER_SSH variable.