### PR TITLE
Test connectivity only when VM instance exists

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -151,3 +151,4 @@ skip_patching_ansibleee_csv: false
 # OS Diff automation steps
 os_diff_dir: tmp/os-diff
 os_diff_data_dir: tmp/os-diff
+prelaunch_test_instance: true

--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -49,5 +49,6 @@
     success_msg: "neutron-dhcp-agent is ALIVE after adoption"
 
 - name: verify connectivity to the existing test VM instance using Floating IP
+  when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
       ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}


### PR DESCRIPTION
Test the connectivity to the VM test instance
only in the case it was launched in a previous step.
