### PR TITLE
Removing references to the database field of the PasswordSelectors struct

### DIFF
--- a/docs_user/modules/proc_adopting-the-orchestration-service.adoc
+++ b/docs_user/modules/proc_adopting-the-orchestration-service.adoc
@@ -72,7 +72,6 @@ spec:
       memcachedInstance: memcached
       passwordSelectors:
         authEncryptionKey: HeatAuthEncryptionKey
-        database: HeatDatabasePassword
         service: HeatPassword
 '
 ----

--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -27,7 +27,6 @@
           memcachedInstance: memcached
           passwordSelectors:
             authEncryptionKey: HeatAuthEncryptionKey
-            database: HeatDatabasePassword
             service: HeatPassword
     '
 


### PR DESCRIPTION
The field was removed from the api definitions
of the heat-operator. Using it while patching or creating resources causes errors.

JIRA: https://issues.redhat.com/browse/OSPRH-7867