### PR TITLE
Remove download-cache-openstack service

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -248,7 +248,6 @@ spec:
   preProvisioned: true
   services:
     - bootstrap
-    - download-cache
     - configure-network
     - validate-network
     - install-os
@@ -412,7 +411,6 @@ oc patch osdpns/openstack --type=merge --patch "
 spec:
   services:
     - repo-setup
-    - download-cache
     - bootstrap
     - configure-network
     - validate-network

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -148,7 +148,6 @@
       preProvisioned: true
       services:
         - bootstrap
-        - download-cache
         - configure-network
         - validate-network
         - install-os
@@ -254,7 +253,6 @@
     spec:
       services:
         - bootstrap
-        - download-cache
         - configure-network
         - validate-network
         - install-os


### PR DESCRIPTION
During Dataplane adoption, download-cache service tries to update libvirt related packages which is not needed.

Resolves: [OSPRH-7874](https://issues.redhat.com/browse/OSPRH-7874) 