### PR TITLE
Use rdo|rhoso-openvswitch wrapper to pin versions

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -400,7 +400,12 @@ endif::[]
 
         # Do not attempt OVS major upgrades here
         edpm_ovs_packages:
-        - openvswitch3.1
+ifeval::["{build}" == "downstream"]
+        - rhoso-openvswitch-3.1
+endif::[]
+ifeval::["{build}" != "downstream"]
+        - rdo-openvswitch-3.1
+endif::[]
 EOF
 ----
 +

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -211,7 +211,12 @@ endif::[]
 
         # Do not attempt OVS major upgrades here
         edpm_ovs_packages:
-        - openvswitch3.1
+ifeval::["{build}" == "downstream"]
+        - rhoso-openvswitch-3.1
+endif::[]
+ifeval::["{build}" != "downstream"]
+        - rdo-openvswitch-3.1
+endif::[]
 EOF
 ----
 

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -215,7 +215,7 @@
 
             # Do not attempt OVS major upgrades here
             edpm_ovs_packages:
-            - openvswitch3.1
+            - {{ distribution }}-openvswitch-3.1
 
             # ovn-controller settings
             edpm_ovn_bridge_mappings: ["datacentre:{{ neutron_physical_bridge_name }}"]

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -52,3 +52,6 @@ run_pre_adoption_validation: true
 
 # Whether the adopted node will host compute services
 compute_adoption: true
+
+# Distribution to use for the adopted node. Supported values are 'rdo' and 'rhoso'.
+distribution: rdo


### PR DESCRIPTION
If openvswitch3.N is pinned, rdo-openvswitch is still upgraded, which replaces openvswitch3.N with openvswitch.N+1. But if the wrapper is pinned, then it doesn't.