### PR TITLE
Add pre-adoption optional reboot check

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -544,6 +544,26 @@ oc logs -l app=openstackansibleee -f --max-log-requests 20
 oc wait --for condition=Ready openstackdataplanedeployment/openstack-pre-adoption --timeout=10m
 ----
 
+.. Optional: Create a OpenStackDataPlaneDeployment CR that runs the reboot service in check-mode only.
+Reboot service is going to check if there is any reboot to be performed.:
++
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-pre-adoption-reboot-check
+spec:
+  nodeSets:
+  - openstack
+  servicesOverride:
+  - reboot-os
+  ansibleExtraVars:
+  - edpm_reboot_strategy: never
+EOF
+----
+
 . If any openstack-pre-adoption validations fail, you must first determine
 which ones were unsuccessful based on the ansible logs and then follow the
 instructions below for each case:
@@ -559,6 +579,9 @@ the 17 node.
 * if the tuned profile check failed then make sure that the
 `edpm_tuned_profile` variable in the `OpenStackDataPlaneNodeSet` is configured
 to use the same profile as set on the (source) OSP 17 node.
+
+* if reboot check returned that reboot is required then make sure that the
+ (source) OSP 17 nodes are rebooted before adoption.
 
 . Remove leftover {OpenStackPreviousInstaller} services
 

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -385,6 +385,57 @@
         echo "Run out of retries"
         exit 2
 
+    - name: Create OpenStackDataPlaneDeployment to run the reboot check
+      when: run_reboot_check|bool
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc apply -f - <<EOF
+        apiVersion: dataplane.openstack.org/v1beta1
+        kind: OpenStackDataPlaneDeployment
+        metadata:
+          name: openstack-pre-adoption-reboot-check
+        spec:
+          nodeSets:
+          - openstack
+          servicesOverride:
+          - reboot-os
+          ansibleExtraVars:
+          - edpm_reboot_strategy: never
+        EOF
+
+    - name: Wait for the reboot-check deployment to finish
+      when: run_reboot_check|bool
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+
+        DEPLOYMENT_NAME=openstack-pre-adoption-reboot-check
+        TRIES=180
+        DELAY=10
+        ALLOWED_JOB_RETRIES=1
+
+        for i in $(seq $TRIES)
+        do
+            ready=$(oc get osdpd/$DEPLOYMENT_NAME -o jsonpath='{.status.conditions[0].status}')
+            if [ "$ready" == "True" ]; then
+                echo "Pre adoption validation Deployment is Ready"
+                exit 0
+            else
+                failed=$(oc get jobs -l openstackdataplanedeployment=$DEPLOYMENT_NAME -o jsonpath="{.items[?(@.status.failed > $ALLOWED_JOB_RETRIES)].metadata.name}")
+                if [ ! -z "${failed}" ]; then
+                    echo "There are failed AnsibleEE jobs: $failed"
+                    exit 1
+                fi
+            fi
+
+        sleep $DELAY
+        done
+
+        echo "Run out of retries"
+        exit 2
+
 - name: Remove leftover OOO services
   block:
     - name: Create OpenStackDataPlaneService/tripleo-cleanup

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -50,5 +50,8 @@ ironic_adoption: false
 # Run pre-adoption validation before the deploying
 run_pre_adoption_validation: true
 
+# Run pre-adoption reboot check
+run_reboot_check: false
+
 # Whether the adopted node will host compute services
 compute_adoption: true


### PR DESCRIPTION
Add OpenStackDataPlaneDeployment with reboot service to check if there is any pre-adoption 
reboot to be performed. It will not start reboot and only display information in ansibleee logs.