### PR TITLE
Move manila cephfs spec definition under the related template

### DIFF
--- a/tests/roles/manila_adoption/defaults/main.yaml
+++ b/tests/roles/manila_adoption/defaults/main.yaml
@@ -1,2 +1,2 @@
-# manila_backend can be 'cephfs' or 'ceph_nfs'
+# manila_backend can be 'cephfs' or 'cephnfs'
 manila_backend: cephfs

--- a/tests/roles/manila_adoption/tasks/main.yaml
+++ b/tests/roles/manila_adoption/tasks/main.yaml
@@ -1,55 +1,17 @@
-- name: deploy podified Manila with cephfs backend
-  when: manila_backend == "cephfs"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch '
-    spec:
-      manila:
-        enabled: true
-        apiOverride:
-          route: {}
-        template:
-          databaseInstance: openstack
-          databaseAccount: manila
-          manilaAPI:
-            customServiceConfig: |
-              [DEFAULT]
-              enabled_share_protocols=cephfs
-            replicas: 1
-            networkAttachments:
-            - internalapi
-            override:
-              service:
-                internal:
-                  metadata:
-                    annotations:
-                      metallb.universe.tf/address-pool: internalapi
-                      metallb.universe.tf/allow-shared-ip: internalapi
-                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-                  spec:
-                    type: LoadBalancer
-          manilaScheduler:
-            replicas: 1
-          manilaShares:
-            share1:
-              customServiceConfig: |
-                [DEFAULT]
-                enabled_share_backends=cephfs
-                enabled_share_protocols=cephfs
-                [cephfs]
-                driver_handles_share_servers=False
-                share_backend_name=cephfs
-                share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
-                cephfs_conf_path=/etc/ceph/ceph.conf
-                cephfs_auth_id=openstack
-                cephfs_cluster_name=ceph
-                cephfs_volume_mode=0755
-                cephfs_protocol_helper_type=CEPHFS
-              replicas: 1
-              networkAttachments:
-              - storage
-    '
+- name: Deploy Podified Manila
+  when: manila_backend == "cephfs" or manila_backend == "cephnfs"
+  block:
+    - name: generate CR config based on the selected backend
+      ansible.builtin.template:
+        src: manila_cephfs.yaml.j2
+        dest: /tmp/manila_cephfs.yaml
+        mode: "0600"
+
+    - name: deploy podified Manila with cephfs backend
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/manila_cephfs.yaml
 
 - name: wait for Manila to start up
   ansible.builtin.shell: |

--- a/tests/roles/manila_adoption/templates/manila_cephfs.yaml.j2
+++ b/tests/roles/manila_adoption/templates/manila_cephfs.yaml.j2
@@ -1,0 +1,56 @@
+spec:
+  manila:
+    enabled: true
+    apiOverride:
+      route: {}
+    template:
+      databaseInstance: openstack
+      databaseAccount: manila
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          {% if manila_backend == "cephnfs" -%}
+          enabled_share_protocols=nfs
+          {% else -%}
+          enabled_share_protocols=cephfs
+          {%- endif %}
+
+        replicas: 1
+        networkAttachments:
+          - internalapi
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_share_backends=cephfs
+            host = hostgroup
+
+            [cephfs]
+            driver_handles_share_servers=False
+            share_backend_name=cephfs
+            share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+            cephfs_conf_path=/etc/ceph/ceph.conf
+            cephfs_auth_id=openstack
+            cephfs_cluster_name=ceph
+            cephfs_volume_mode=0755
+            cephfs_protocol_helper_type= {{ (manila_backend == "cephfs") | ternary('CEPHFS', 'NFS') }}
+            {% if manila_backend == "cephnfs" -%}
+            cephfs_nfs_cluster_id=cephfs
+            cephfs_ganesha_server_ip= {{ cephnfs_vip | default("") }}
+            {%- endif %}
+
+          replicas: 1
+          networkAttachments:
+            - storage


### PR DESCRIPTION
Instead of hardcoding the `manila_cephfs` config to the `ansible` task,
this change organizes it into a template, that is rendered and applied
during the adoption run.
The template adds an initial support for `NFS` backend, in preparation to
a follow up patch where the `NFS` adoption test will be added.