### PR TITLE
Add test-migrate-ceph target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TEST_INVENTORY ?= tests/inventory.yaml
 TEST_VARS ?= tests/vars.yaml
+TEST_CEPH_OVERRIDES ?= tests/ceph_overrides.yaml
 TEST_SECRETS ?= tests/secrets.yaml
 TEST_CONFIG ?= tests/ansible.cfg
 TEST_ARGS ?=
@@ -32,6 +33,11 @@ test-with-ceph: TEST_OUTFILE := tests/logs/test_with_ceph_out_$(shell date +%FT%
 test-with-ceph:  ## Launch test suite with ceph
 	mkdir -p tests/logs
 	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_SECRETS) $(TEST_ARGS) tests/playbooks/test_with_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
+
+test-ceph-migration: TEST_OUTFILE := tests/logs/test_ceph_migration_out_$(shell date +%FT%T%Z).log
+test-ceph-migration:  ## Launch test suite related to the ceph migration
+	mkdir -p tests/logs
+	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_CEPH_OVERRIDES) -e @$(TEST_SECRETS) $(TEST_ARGS) tests/playbooks/test_externalize_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
 
 test-swift-migration: TEST_OUTFILE := tests/logs/test_swift_migration_out_$(shell date +%FT%T%Z).log
 test-swift-migration:

--- a/tests/roles/ceph_migrate/defaults/main.yml
+++ b/tests/roles/ceph_migrate/defaults/main.yml
@@ -28,3 +28,11 @@ ceph_timeout: 30
 # wait for mon to be deployed and the orch spec to be
 # updated
 ceph_wait_mon_timeout: 10
+
+# DEFAULT Ceph Reef container images
+ceph_haproxy_container_image: "quay.io/ceph/haproxy:2.3"
+ceph_keepalived_container_image: "quay.io/ceph/keepalived:2.1.5"
+ceph_alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.25.0"
+ceph_grafana_container_image: "quay.io/ceph/ceph-grafana:9.4.7"
+ceph_node_exporter_container_image: "quay.io/prometheus/node-exporter:v1.5.0"
+ceph_prometheus_container_image: "quay.io/prometheus/prometheus:v2.43.0"

--- a/tests/roles/ceph_migrate/tasks/ceph_client.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_client.yaml
@@ -14,7 +14,7 @@
     - ceph_client_ip is defined
     - mon_ipaddr | default('')
   become: true
-  delegate_to: "{{ cur_mon.split('.')[0] }}.ctlplane"
+  delegate_to: "{{ cur_mon }}"
   block:
     - name: TMP_CLIENT - Patch os-net-config config and setup a tmp client IP
       ansible.builtin.lineinfile:
@@ -29,7 +29,7 @@
         "os-net-config -c {{ os_net_conf_path }}"
 
 - name: Backup data for client purposes
-  delegate_to: "{{ cur_mon.split('.')[0] }}.ctlplane"
+  delegate_to: "{{ cur_mon }}"
   when:
     - ceph_client_ip is defined
     - mon_ipaddr | default('')

--- a/tests/roles/ceph_migrate/tasks/ceph_load.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_load.yaml
@@ -87,7 +87,7 @@
     - name: Print Ceph config dump
       when: debug | default(false)
       ansible.builtin.debug:
-        msg: "{{ ceph_conf | from_json }}"
+        msg: "{{ ceph_conf.stdout | from_json }}"
 
     # Dump config to a log file
     - name: Dump ceph config dump output to log file

--- a/tests/roles/ceph_migrate/tasks/ceph_validate.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_validate.yaml
@@ -73,7 +73,7 @@
     - name: ansible.builtin.fail if Mons are not in quorum
       ansible.builtin.fail:
         msg: "Mons: {{ ceph.monmap.num_mons }}"
-      when: ceph.monmap.num_mons != decomm_nodes | length
+      when: ceph.monmap.num_mons <= decomm_nodes | length
 
 - name: Mgr is active
   block:

--- a/tests/roles/ceph_migrate/tasks/drain.yaml
+++ b/tests/roles/ceph_migrate/tasks/drain.yaml
@@ -8,6 +8,7 @@
 
 # Check if mon even exists before removing it
 - name: MON - wait daemons
+  become: true
   ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type mon --daemon_id {{ daemon_id }} -f json"
   register: psm
   vars:
@@ -15,7 +16,7 @@
 
 - name: DRAIN - Delete the mon running on the current controller node
   when: psm.stdout | from_json | community.general.json_query('[*].daemon_name') | length > 0
-  delegate_to: "{{ host.split('.')[0] }}.ctlplane"
+  delegate_to: "{{ host }}"
   become: true
   ansible.builtin.command:
     "{{ ceph_cli }} orch daemon rm mon.{{ host.split('.')[0] }} --force"
@@ -41,7 +42,7 @@
 - name: DRAIN - Drain the host
   when: psm.stdout | from_json | community.general.json_query('[*].daemon_name') | length > 0
   become: true
-  delegate_to: "{{ host.split('.')[0] }}.ctlplane"
+  delegate_to: "{{ host }}"
   ansible.builtin.command:
     "{{ ceph_cli }} orch host drain {{ host }}"
 
@@ -55,7 +56,10 @@
 # This command is not documented, and leftovers on the node don't create any
 # problem.
 - name: DRAIN - cleanup the host
-  delegate_to: "{{ host.split('.')[0] }}.ctlplane"
+  delegate_to: "{{ host }}"
+  # instead of using ignore_errors, we disable
+  # this task in CI.
+  when: force_clean | default(false)
   become: true
   ansible.builtin.command:
     "cephadm rm-cluster --fsid {{ ceph_fsid }} --force"
@@ -69,7 +73,7 @@
       ansible.builtin.command: "{{ ceph_cli }} orch host ls --host_pattern {{ host_id }} -f json"
       register: lsh
       vars:
-        host_id: "{{ cur_mon.split('.')[0] }}"
+        host_id: "{{ cur_mon }}"
 
     # The node should be empty at this point, let's remove it from the Ceph cluster
     - name: MON - rm the cur_mon host from the Ceph cluster

--- a/tests/roles/ceph_migrate/tasks/firewall.yaml
+++ b/tests/roles/ceph_migrate/tasks/firewall.yaml
@@ -3,7 +3,7 @@
 # This set of tasks are supposed to manage the firewall using
 # iptables: adopted nodes still manage firewall this way
 - name: Firewall add block
-  delegate_to: "{{ node }}.ctlplane"
+  delegate_to: "{{ node }}"
   become: true
   block:
     - name: Ensure firewall is enabled/started
@@ -13,7 +13,7 @@
         enabled: true
 
 - name: Update firewall rules
-  delegate_to: "{{ node }}.ctlplane"
+  delegate_to: "{{ node }}"
   become: true
   block:
     - name: Update rules - List
@@ -38,7 +38,7 @@
         jump: ACCEPT
 
 - name: Firewall save block
-  delegate_to: "{{ node }}.ctlplane"
+  delegate_to: "{{ node }}"
   become: true
   block:
     - name: Save firewall rules ipv4

--- a/tests/roles/ceph_migrate/tasks/mds.yaml
+++ b/tests/roles/ceph_migrate/tasks/mds.yaml
@@ -13,6 +13,8 @@
   loop: "{{ target_nodes }}"
   loop_control:
     loop_var: n
+  tags:
+    - ceph_firewall
 
 - name: MDS - Load Spec from the orchestrator
   ansible.builtin.set_fact:

--- a/tests/roles/ceph_migrate/tasks/mgr.yaml
+++ b/tests/roles/ceph_migrate/tasks/mgr.yaml
@@ -13,6 +13,8 @@
   loop: "{{ target_nodes }}"
   loop_control:
     loop_var: n
+  tags:
+    - ceph_firewall
 
 # Extend mgr labels to the target nodes to not fail during the mgr failover
 - name: MGR - Setup Mon/Mgr label to the target node

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -9,7 +9,7 @@
 - name: Migrate mon
   when: debug | default(true)
   ansible.builtin.debug:
-    msg: "Migrate mon: {{ cur_mon.split('.')[0] }} to node: {{ target_node }}"
+    msg: "Migrate mon: {{ cur_mon }} to node: {{ target_node }}"
 
 # We add labels in advance to the target node to make sure we are able to
 # deploy a tmp mon that will be replaced with the right one (on the desired
@@ -42,7 +42,7 @@
     - ceph_mon_quorum
 
 - name: Backup data for client purposes
-  delegate_to: "{{ cur_mon.split('.')[0] }}.ctlplane"
+  delegate_to: "{{ cur_mon }}"
   tags:
     - ceph_backup
   block:
@@ -126,35 +126,39 @@
         msg: "{{ mon_ipaddr }}"
 
     - name: MON - Patch os-net-config config and REMOVE the current mon IP address
-      delegate_to: "{{ cur_mon.split('.')[0] }}.ctlplane"
+      delegate_to: "{{ cur_mon }}"
       ansible.builtin.lineinfile:
         path: "{{ os_net_conf_path }}"
         state: absent
         regexp: '{{ mon_ipaddr }}/24'
         backup: true
+      vars:
+        os_net_conf_path: "/etc/os-net-config/tripleo_config.yaml"
 
     - name: MON - Refresh os-net-config
-      delegate_to: "{{ cur_mon.split('.')[0] }}.ctlplane"
+      delegate_to: "{{ cur_mon }}"
       ansible.builtin.shell:
         "os-net-config -c {{ os_net_conf_path }}"
+      vars:
+        os_net_conf_path: "/etc/os-net-config/tripleo_config.yaml"
 
     - name: MON - Patch os-net-config config and add the mon IP
-      delegate_to: "{{ target_node.split('.')[0] }}.ctlplane"
+      delegate_to: "{{ target_node }}"
       ansible.builtin.lineinfile:
         dest: "{{ os_net_conf_path }}"
         insertafter: "{{ ceph_storage_net_prefix }}"
-        line: "  - ip_netmask: {{ mon_ipaddr }}/24"
+        line: "    - ip_netmask: {{ mon_ipaddr }}/24"
         backup: true
 
     - name: MON - Refresh os-net-config
-      delegate_to: "{{ target_node.split('.')[0] }}.ctlplane"
+      delegate_to: "{{ target_node }}"
       ansible.builtin.command:
         "os-net-config -c {{ os_net_conf_path }}"
 
     - name: MON - ping ip address to see if is reachable on the target node
       ansible.builtin.command:
         "ping -W1 -c 3 {{ mon_ipaddr }}"
-      delegate_to: "{{ target_node.split('.')[0] }}.ctlplane"
+      delegate_to: "{{ target_node }}"
       register: ping_target_ip
 
     - name: MON - Fail if the IP address is not active in the target node
@@ -163,6 +167,7 @@
         msg: "Can't reach the mon IP on the target node"
 
 - name: Redeploy MON
+  become: true
   block:
     # when a label is added, if we're not fast enough, a mon is automatically
     # added on the storage network. However, in case the node has multiple ip
@@ -170,7 +175,6 @@
     # For this reason we need to redeploy it by rm + add (as redeploy does not
     # accept an IP as input
     - name: MON - Check quorum
-      become: true
       ansible.builtin.command: "{{ ceph_cli }} mon stat -f json"
       register: monstat
       retries: 20
@@ -193,7 +197,6 @@
     - name: Unmanage mons
       # root privileges required to run cephadm
       # and apply the new spec
-      become: true
       ceph_mkspec:
         service_type: mon
         cluster: ceph
@@ -221,7 +224,6 @@
 
     - name: MON - Delete the running mon
       when: psmon.stdout | from_json | community.general.json_query('[*].daemon_name') | length > 0
-      become: true
       ansible.builtin.command: "{{ ceph_cli }} orch daemon rm mon.{{ target_node.split('.')[0] }} --force"
       until: '"Removed" in rmmon.stdout'
       register: rmmon
@@ -244,15 +246,14 @@
     - name: MON - Redeploy mon on {{ target_node }}
       when: debug | default(true)
       ansible.builtin.debug:
-        msg: "{{ ceph_cli }} orch daemon add mon {{ target_node.split('.')[0] }}:{{ mon_ipaddr }}"
+        msg: "{{ ceph_cli }} orch daemon add mon {{ target_node }}:{{ mon_ipaddr }}"
 
     - name: MON - Redeploy mon on {{ target_node }}
-      become: true
       when:
         - mon_ipaddr | default('')
         - psmon.stdout | from_json | community.general.json_query('[*].daemon_name') | length == 0
       ansible.builtin.command:
-        "{{ ceph_cli }} orch daemon add mon {{ target_node.split('.')[0] }}:{{ mon_ipaddr }}"
+        "{{ ceph_cli }} orch daemon add mon {{ target_node }}:{{ mon_ipaddr }}"
 
     - name: Wait for the spec to be updated
       ansible.builtin.pause:

--- a/tests/roles/ceph_migrate/tasks/monitoring.yaml
+++ b/tests/roles/ceph_migrate/tasks/monitoring.yaml
@@ -30,6 +30,8 @@
   loop: "{{ target_nodes }}"
   loop_control:
     loop_var: n
+  tags:
+    - ceph_firewall
 
 - name: MONITORING - Load Spec from the orchestrator
   ansible.builtin.set_fact:

--- a/tests/roles/ceph_migrate/tasks/rbd.yaml
+++ b/tests/roles/ceph_migrate/tasks/rbd.yaml
@@ -10,6 +10,7 @@
     # select mon[0] as client. If we stick on decomm_nodes nodes we
     # might end up selecting a different node on multiple runs.
     cur_mon: "{{ groups['mon'][0] | default(decomm_nodes | list | sort | first) }}"
+    os_net_conf_path: "/etc/os-net-config/tripleo_config.yaml"
   tags:
     - ceph_client
     - ceph_rbd

--- a/tests/roles/ceph_migrate/tasks/rgw.yaml
+++ b/tests/roles/ceph_migrate/tasks/rgw.yaml
@@ -25,6 +25,8 @@
   loop: "{{ target_nodes }}"
   loop_control:
     loop_var: n
+  tags:
+    - ceph_firewall
 
 # - Expand labels to the target nodes
 - name: Apply RGW label to the target nodes


### PR DESCRIPTION
This patch introduces the `test-ceph-migration` target, required to conditionally trigger the ceph-migration from `rdo-jobs`.