### PR TITLE
Fail if mons in quorum are less than expected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-with-ceph:  ## Launch test suite with ceph
 test-ceph-migration: TEST_OUTFILE := tests/logs/test_ceph_migration_out_$(shell date +%FT%T%Z).log
 test-ceph-migration:  ## Launch test suite related to the ceph migration
 	mkdir -p tests/logs
-	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_CEPH_OVERRIDES) -e @$(TEST_SECRETS) $(TEST_ARGS) tests/playbooks/test_externalize_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
+	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_CEPH_OVERRIDES) -e @$(TEST_SECRETS) $(TEST_ARGS) tests/playbooks/test_externalize_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
 
 test-swift-migration: TEST_OUTFILE := tests/logs/test_swift_migration_out_$(shell date +%FT%T%Z).log
 test-swift-migration:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-with-ceph:  ## Launch test suite with ceph
 test-ceph-migration: TEST_OUTFILE := tests/logs/test_ceph_migration_out_$(shell date +%FT%T%Z).log
 test-ceph-migration:  ## Launch test suite related to the ceph migration
 	mkdir -p tests/logs
-	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_CEPH_OVERRIDES) -e @$(TEST_SECRETS) $(TEST_ARGS) tests/playbooks/test_externalize_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
+	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_VARS) -e @$(TEST_CEPH_OVERRIDES) -e @$(TEST_SECRETS) $(TEST_ARGS) tests/playbooks/test_externalize_ceph.yaml 2>&1 | tee $(TEST_OUTFILE)
 
 test-swift-migration: TEST_OUTFILE := tests/logs/test_swift_migration_out_$(shell date +%FT%T%Z).log
 test-swift-migration:

--- a/tests/playbooks/test_externalize_ceph.yaml
+++ b/tests/playbooks/test_externalize_ceph.yaml
@@ -1,3 +1,17 @@
+### CI CHECK ####
+
+- name: Restart Network
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Restart Network
+      ansible.builtin.systemd:
+        name: network
+        state: restarted
+    - name: Reset the SSH connection to handle network restart
+      ansible.builtin.meta: reset_connection
+### END CHECK ###
+
 - name: Externalize Ceph
   hosts: "{{ groups['overcloud'][0] | default([]) }}"
   gather_facts: false

--- a/tests/playbooks/test_externalize_ceph.yaml
+++ b/tests/playbooks/test_externalize_ceph.yaml
@@ -1,31 +1,6 @@
-### CI CHECK ####
-
-- name: Restart Network
-  hosts: all
-  gather_facts: false
-  tasks:
-    - name: Restart Network
-      ansible.builtin.systemd:
-        name: network
-        state: restarted
-    - name: Reset the SSH connection to handle network restart
-      ansible.builtin.meta: reset_connection
-### END CHECK ###
-
 - name: Externalize Ceph
   hosts: "{{ groups['overcloud'][0] | default([]) }}"
-  gather_facts: false
-  vars:
-    ceph_daemons_layout:
-      # rbd is used to group mon/mgr migration that
-      # happens within the same flow
-      rbd: false
-      rgw: true
-      mds: true
-      monitoring: false
-  module_defaults:
-    ansible.builtin.shell:
-      executable: /bin/bash
+  gather_facts: true
   tasks:
     # Load src Ceph cluster data
     - name: Load Ceph data
@@ -52,6 +27,15 @@
         tasks_from: ceph_containers
       tags:
         - ceph_containers
+        - always
+
+    # Add firewall rules
+    - name: Firewall
+      ansible.builtin.import_role:
+        name: ceph_migrate
+        tasks_from: ceph_firewall
+      tags:
+        - ceph_firewall
         - always
 
     # Monitoring Stack migration

--- a/tests/roles/ceph_migrate/defaults/main.yml
+++ b/tests/roles/ceph_migrate/defaults/main.yml
@@ -28,6 +28,7 @@ ceph_timeout: 30
 # wait for mon to be deployed and the orch spec to be
 # updated
 ceph_wait_mon_timeout: 10
+ceph_keep_mon_ipaddr: true
 
 # DEFAULT Ceph Reef container images
 ceph_haproxy_container_image: "quay.io/ceph/haproxy:2.3"

--- a/tests/roles/ceph_migrate/tasks/backup.yaml
+++ b/tests/roles/ceph_migrate/tasks/backup.yaml
@@ -1,8 +1,5 @@
 - name: Backup data for client purposes
   delegate_to: "{{ host }}"
-  when:
-    - ceph_client_ip is defined
-    - mon_ipaddr | default('')
   block:
     - name: Ensure backup directory exists
       ansible.builtin.file:
@@ -19,7 +16,7 @@
       become: true
       ansible.builtin.copy:
         remote_src: true
-        src: "/etc/ceph/{{ item }}"
+        src: "{{ item.path }}"
         dest: "{{ ceph_config_tmp_client_home }}"
         mode: '0644'
       loop: "{{ dir_ceph_files.files }}"

--- a/tests/roles/ceph_migrate/tasks/backup.yaml
+++ b/tests/roles/ceph_migrate/tasks/backup.yaml
@@ -1,0 +1,25 @@
+- name: Backup data for client purposes
+  delegate_to: "{{ host }}"
+  when:
+    - ceph_client_ip is defined
+    - mon_ipaddr | default('')
+  block:
+    - name: Ensure backup directory exists
+      ansible.builtin.file:
+        path: "{{ ceph_config_tmp_client_home }}"
+        state: directory
+        mode: '0755'
+    - name: Check file in the src directory
+      ansible.builtin.find:
+        paths: /etc/ceph
+        patterns: "*"
+      register: dir_ceph_files
+    - name: Backup ceph client data
+      when: dir_ceph_files.files | length > 0
+      become: true
+      ansible.builtin.copy:
+        remote_src: true
+        src: "/etc/ceph/{{ item }}"
+        dest: "{{ ceph_config_tmp_client_home }}"
+        mode: '0644'
+      loop: "{{ dir_ceph_files.files }}"

--- a/tests/roles/ceph_migrate/tasks/ceph_client.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_client.yaml
@@ -23,3 +23,23 @@
     host: "{{ client_node }}"
   tags:
     - ceph_backup
+
+# Refresh ceph.conf information when mon addresses are **not** migrated
+# (not ceph_keep_mon_ipaddr)
+- name: Refresh ceph.conf info
+  delegate_to: "{{ client_node }}"
+  become: true
+  when:
+    - not ceph_keep_mon_ipaddr | default(false)
+    - node_map is defined
+  tags:
+    - ceph_conf_refresh
+  block:
+    - name: Render global ceph.conf
+      ansible.builtin.template:
+        src: ceph.conf.j2
+        dest: "{{ ceph_config_tmp_client_home }}/ceph.conf"
+        mode: '0644'
+        force: true
+      vars:
+        ceph_fsid: "{{ mon_dump.fsid }}"

--- a/tests/roles/ceph_migrate/tasks/ceph_client.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_client.yaml
@@ -1,23 +1,8 @@
-# Assign an IP Address on the Storage network to mon[0], that is going to
-# be decommissioned: it will be used during the entire migration procedure as
-# a client
-- name: TMP_CLIENT - Get current mon IP address
-  ansible.builtin.set_fact:
-    mon_ipaddr: "{{ mon_ip | split(':') | first | ansible.utils.ipaddr }}"
-  vars:
-    mon_ip: |-
-      {% for mon in mon_dump.mons %}
-      {%   if mon.name == cur_mon.split('.')[0] %}
-      {{ mon.addr }}
-      {%   endif %}
-      {% endfor %}
-
 - name: TMP_CLIENT - Setup a tmp client ip address on the src node
   when:
     - ceph_client_ip is defined
-    - mon_ipaddr | default('')
   become: true
-  delegate_to: "{{ cur_mon }}"
+  delegate_to: "{{ client_node }}"
   block:
     - name: TMP_CLIENT - Patch os-net-config config and setup a tmp client IP
       ansible.builtin.lineinfile:
@@ -35,6 +20,6 @@
 - name: Backup data for client purposes
   ansible.builtin.include_tasks: backup.yaml
   vars:
-    host: "{{ cur_mon }}"
+    host: "{{ client_node }}"
   tags:
     - ceph_backup

--- a/tests/roles/ceph_migrate/tasks/ceph_client.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_client.yaml
@@ -1,3 +1,6 @@
+# Assign an IP Address on the Storage network to mon[0], that is going to
+# be decommissioned: it will be used during the entire migration procedure as
+# a client
 - name: TMP_CLIENT - Get current mon IP address
   ansible.builtin.set_fact:
     mon_ipaddr: "{{ mon_ip | split(':') | first | ansible.utils.ipaddr }}"
@@ -28,30 +31,10 @@
       ansible.builtin.command:
         "os-net-config -c {{ os_net_conf_path }}"
 
+# Backup data
 - name: Backup data for client purposes
-  delegate_to: "{{ cur_mon }}"
-  when:
-    - ceph_client_ip is defined
-    - mon_ipaddr | default('')
-  block:
-    - name: Ensure backup directory exists
-      ansible.builtin.file:
-        path: "{{ ceph_config_tmp_client_home }}"
-        state: directory
-        mode: '0755'
-    - name: Check file in the src directory
-      ansible.builtin.find:
-        paths: /etc/ceph
-        patterns: "*"
-      register: dir_ceph_files
-    - name: Backup ceph client data
-      when: dir_ceph_files.files | length > 0
-      become: true
-      ansible.builtin.copy:
-        remote_src: true
-        src: "/etc/ceph/{{ item }}"
-        dest: "{{ ceph_config_tmp_client_home }}"
-        mode: '0666'
-      loop:
-        - ceph.conf
-        - ceph.client.admin.keyring
+  ansible.builtin.include_tasks: backup.yaml
+  vars:
+    host: "{{ cur_mon }}"
+  tags:
+    - ceph_backup

--- a/tests/roles/ceph_migrate/tasks/ceph_firewall.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_firewall.yaml
@@ -1,0 +1,61 @@
+# Add firewall rules for all the Ceph Services
+
+- name: Update firewall rules on the target nodes
+  when: ceph_daemons_layout.monitoring | default(true) | bool
+  ansible.builtin.include_tasks: firewall.yaml
+  vars:
+    node: "{{ n }}"
+    ifports:
+      - 3100
+      - 8444
+      - 9090
+      - 9092
+      - 9093
+      - 9094
+      - 9100
+      - 9283
+  loop: "{{ target_nodes }}"
+  loop_control:
+    loop_var: n
+  tags:
+    - ceph_monitoring
+
+- name: Update firewall rules on the target nodes
+  ansible.builtin.include_tasks: firewall.yaml
+  vars:
+    ifports_range: "6800:7300"
+    node: "{{ n }}"
+  loop: "{{ target_nodes }}"
+  loop_control:
+    loop_var: n
+  tags:
+    - ceph_rbd
+
+# Update the firewall on the target nodes
+- name: Update firewall rules on the target nodes
+  ansible.builtin.include_tasks: firewall.yaml
+  vars:
+    ifports:
+      - 3300
+      - 6789
+    node: "{{ n }}"
+  loop: "{{ target_nodes }}"
+  loop_control:
+    loop_var: n
+  tags:
+    - ceph_mon
+
+- name: Update firewall rules on the target nodes
+  when: ceph_daemons_layout.rgw | default(true) | bool
+  ansible.builtin.include_tasks: firewall.yaml
+  vars:
+    node: "{{ n }}"
+    ifports:
+      - 8080
+      - 8090
+      - 8989
+  loop: "{{ target_nodes }}"
+  loop_control:
+    loop_var: n
+  tags:
+    - ceph_rgw

--- a/tests/roles/ceph_migrate/tasks/ceph_validate.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_validate.yaml
@@ -73,7 +73,7 @@
     - name: ansible.builtin.fail if Mons are not in quorum
       ansible.builtin.fail:
         msg: "Mons: {{ ceph.monmap.num_mons }}"
-      when: ceph.monmap.num_mons <= decomm_nodes | length
+      when: ceph.monmap.num_mons < decomm_nodes | length
 
 - name: Mgr is active
   block:

--- a/tests/roles/ceph_migrate/tasks/drain.yaml
+++ b/tests/roles/ceph_migrate/tasks/drain.yaml
@@ -67,6 +67,7 @@
     ceph_fsid: "{{ mon_dump.fsid }}"
 
 - name: MON - Remove host from the Ceph hostmap
+  become: true
   block:
     # Check if mon even exists before removing it
     - name: MON - check host in hostmap
@@ -78,6 +79,5 @@
     # The node should be empty at this point, let's remove it from the Ceph cluster
     - name: MON - rm the cur_mon host from the Ceph cluster
       when: lsh.stdout | from_json | community.general.json_query('[*].hostname') | length > 0
-      become: true
       ansible.builtin.command:
         "{{ ceph_cli }} orch host rm {{ cur_mon }} --force"

--- a/tests/roles/ceph_migrate/tasks/firewall.yaml
+++ b/tests/roles/ceph_migrate/tasks/firewall.yaml
@@ -39,6 +39,7 @@
 
 - name: Firewall save block
   delegate_to: "{{ node }}"
+  when: ceph_firewall_save | default(false)
   become: true
   block:
     - name: Save firewall rules ipv4

--- a/tests/roles/ceph_migrate/tasks/labels.yaml
+++ b/tests/roles/ceph_migrate/tasks/labels.yaml
@@ -15,7 +15,7 @@
 # under the License.
 
 - name: Print INPUT
-  when: debug | default(true)
+  when: debug | default(false)
   block:
     - name: Set/Unset labels - {{ act }}
       ansible.builtin.debug:

--- a/tests/roles/ceph_migrate/tasks/mds.yaml
+++ b/tests/roles/ceph_migrate/tasks/mds.yaml
@@ -5,17 +5,6 @@
     ceph_fsid: "{{ mon_dump.fsid }}"
     ceph_cluster: ceph
 
-- name: Update firewall rules on the target nodes
-  ansible.builtin.include_tasks: firewall.yaml
-  vars:
-    ifports_range: "6800:7300"
-    node: "{{ n }}"
-  loop: "{{ target_nodes }}"
-  loop_control:
-    loop_var: n
-  tags:
-    - ceph_firewall
-
 - name: MDS - Load Spec from the orchestrator
   ansible.builtin.set_fact:
     mds_spec: "{{ mds }}"

--- a/tests/roles/ceph_migrate/tasks/mgr.yaml
+++ b/tests/roles/ceph_migrate/tasks/mgr.yaml
@@ -5,17 +5,6 @@
     ceph_fsid: "{{ mon_dump.fsid }}"
     ceph_cluster: ceph
 
-- name: MGR - Update firewall rules on the target nodes
-  ansible.builtin.include_tasks: firewall.yaml
-  vars:
-    ifports_range: "6800:7300"
-    node: "{{ n }}"
-  loop: "{{ target_nodes }}"
-  loop_control:
-    loop_var: n
-  tags:
-    - ceph_firewall
-
 # Extend mgr labels to the target nodes to not fail during the mgr failover
 - name: MGR - Setup Mon/Mgr label to the target node
   ansible.builtin.include_tasks: labels.yaml

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -11,13 +11,13 @@
   ansible.builtin.debug:
     msg: "Migrate mon: {{ cur_mon }} to node: {{ target_node }}"
 
-- name: MON - Get current mon IP address from mon_map override
-  when: mon_map is defined
+- name: MON - Get current mon IP address from node_map override
+  when: node_map is defined
   ansible.builtin.set_fact:
     mon_ipaddr: "{{ mon_ip | trim | ansible.utils.ipaddr }}"
   vars:
     mon_ip: |-
-      {% for mon in mon_map %}
+      {% for mon in node_map %}
       {%   if mon.hostname == cur_mon %}
       {{ mon.ip }}
       {%   endif %}
@@ -27,13 +27,13 @@
   become: true
   ansible.builtin.command: "{{ ceph_cli }} -s -f json"
   register: monmap
-  retries: 20
-  delay: 2
-  # >= is related to the fact that the current monmap might still have
-  # references to the old mon daemon coming from the drained node
-  until: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) >= ((decomm_nodes |default([]) | length | int) | default(3))
-  loop_control:
-    label: "MON - check mons quorum"
+  tags:
+    - ceph_mon_quorum
+
+- name: ansible.builtin.fail if there's no quorum
+  ansible.builtin.fail:
+    msg: "Mons are not in quorum"
+  when: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) < ((decomm_nodes |default([]) | length | int) | default(3))
   tags:
     - ceph_mon_quorum
 
@@ -72,26 +72,6 @@
         - mgr.active_name | length > 0
         - mgr.active_name | regex_search(cur_mon)
 
-- name: Unmanage mons
-  become: true
-  ceph_mkspec:
-    service_type: mon
-    cluster: ceph
-    apply: true
-    label: "mon"
-    render_path: "{{ ceph_spec_render_dir }}"
-    unmanaged: true
-  register: spc
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_container }}"
-    CEPH_CONTAINER_BINARY: "{{ ceph_container_cli }}"
-    CEPH_CONF: "{{ ceph_config_tmp_client_home }}"
-
-- name: Print the resulting spec
-  when: debug | default(false)
-  ansible.builtin.debug:
-    msg: "{{ spc }}"
-
 # Drain and rm the cur_mon from the Ceph cluster
 - name: MON - Drain and rm --force the cur_mon host
   # when: cur_mon in decomm_nodes
@@ -122,6 +102,7 @@
   # because there's no network related action that should be performed
   when:
     - mon_ipaddr | default('')
+    - ceph_keep_mon_ipaddr | default(true)
   block:
     - name: MON - Get current mon IP address
       when: debug | default(false)
@@ -176,23 +157,27 @@
         msg: "Can't reach the mon IP on the target node"
 
 - name: Redeploy MON
+  when: ceph_keep_mon_ipaddr | default(true)
   become: true
   block:
-    # We add labels in advance to the target node to make sure we are able to
-    # deploy a tmp mon that will be replaced with the right one (on the desired
-    # network). By adding an additional mon at this stage we can ensure we always
-    # have quorum and at least 3 active mons while migrating the src daemon to the
-    # target node.
-    - name: MON - Setup Mon/Mgr label to the target node
-      ansible.builtin.include_tasks: labels.yaml
-      vars:
-        nodes:
-          - "{{ target_node }}"
-        act: "add"
-        labels:
-          - "mon"
-          - "mgr"
-          - "_admin"
+    - name: Unmanage mons
+      become: true
+      ceph_mkspec:
+        service_type: mon
+        cluster: ceph
+        apply: true
+        label: "mon"
+        render_path: "{{ ceph_spec_render_dir }}"
+        unmanaged: true
+      register: spc
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_container }}"
+        CEPH_CONTAINER_BINARY: "{{ ceph_container_cli }}"
+        CEPH_CONF: "{{ ceph_config_tmp_client_home }}"
+    - name: Print the resulting spec
+      when: debug | default(false)
+      ansible.builtin.debug:
+        msg: "{{ spc }}"
 
     # Check if a mon exists in the target node and remove it
     - name: MON - Get tmp mon
@@ -211,7 +196,7 @@
       loop_control:
         label: "MON - Get tmp mon"
 
-    - name: Wait for the current mon to be deleted
+    - name: MON - Wait for the current mon to be deleted
       ansible.builtin.pause:
         seconds: "{{ ceph_wait_mon_timeout }}"
 
@@ -227,7 +212,7 @@
       ansible.builtin.command:
         "{{ ceph_cli }} orch daemon add mon {{ target_node }}:{{ mon_ipaddr }}"
 
-    - name: Wait for the spec to be updated
+    - name: MON - Wait for the spec to be updated
       ansible.builtin.pause:
         seconds: "{{ ceph_wait_mon_timeout }}"
 
@@ -235,13 +220,13 @@
   become: true
   ansible.builtin.command: "{{ ceph_cli }} -s -f json"
   register: monmap
-  retries: 30
-  delay: 4
-  # >= is related to the fact that the current monmap might still have
-  # references to the old mon daemon coming from the drained node
-  until: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) >= ((decomm_nodes |default([]) | length | int) | default(3))
-  loop_control:
-    label: "MON - check mons quorum"
+  tags:
+    - ceph_mon_quorum
+
+- name: ansible.builtin.fail if there's no quorum
+  ansible.builtin.fail:
+    msg: "Mons are not in quorum"
+  when: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) < ((decomm_nodes |default([]) | length | int) | default(3))
   tags:
     - ceph_mon_quorum
 
@@ -254,7 +239,7 @@
     - name: reconfig osds
       ansible.builtin.command: "{{ ceph_cli }} orch reconfig osd.default_drive_group "
 
-- name: Manage mons
+- name: MON - Manage mons
   # root privileges required to run cephadm
   # and apply the new spec
   become: true

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -11,6 +11,18 @@
   ansible.builtin.debug:
     msg: "Migrate mon: {{ cur_mon }} to node: {{ target_node }}"
 
+- name: MON - Get current mon IP address from mon_map override
+  when: mon_map is defined
+  ansible.builtin.set_fact:
+    mon_ipaddr: "{{ mon_ip | trim | ansible.utils.ipaddr }}"
+  vars:
+    mon_ip: |-
+      {% for mon in mon_map %}
+      {%   if mon.hostname == cur_mon %}
+      {{ mon.ip }}
+      {%   endif %}
+      {% endfor %}
+
 - name: MON - check mons quorum
   become: true
   ansible.builtin.command: "{{ ceph_cli }} -s -f json"
@@ -25,30 +37,13 @@
   tags:
     - ceph_mon_quorum
 
+# Backup data
 - name: Backup data for client purposes
-  delegate_to: "{{ cur_mon }}"
+  ansible.builtin.include_tasks: backup.yaml
+  vars:
+    host: "{{ cur_mon }}"
   tags:
     - ceph_backup
-  block:
-    - name: Ensure backup directory exists
-      ansible.builtin.file:
-        path: "{{ ceph_config_tmp_client_home }}"
-        state: directory
-        mode: '0755'
-    - name: Check file in the src directory
-      ansible.builtin.find:
-        paths: /etc/ceph
-        patterns: "*"
-      register: dir_ceph_files
-    - name: Backup ceph client data
-      when: dir_ceph_files.files | length > 0
-      become: true
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ item.path }}"
-        dest: "{{ ceph_config_tmp_client_home }}"
-        mode: '0644'
-      loop: "{{ dir_ceph_files.files }}"
 
 # Before draining the current node, migrate the active mgr on a different
 # _admin host
@@ -77,6 +72,26 @@
         - mgr.active_name | length > 0
         - mgr.active_name | regex_search(cur_mon)
 
+- name: Unmanage mons
+  become: true
+  ceph_mkspec:
+    service_type: mon
+    cluster: ceph
+    apply: true
+    label: "mon"
+    render_path: "{{ ceph_spec_render_dir }}"
+    unmanaged: true
+  register: spc
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_container }}"
+    CEPH_CONTAINER_BINARY: "{{ ceph_container_cli }}"
+    CEPH_CONF: "{{ ceph_config_tmp_client_home }}"
+
+- name: Print the resulting spec
+  when: debug | default(false)
+  ansible.builtin.debug:
+    msg: "{{ spc }}"
+
 # Drain and rm the cur_mon from the Ceph cluster
 - name: MON - Drain and rm --force the cur_mon host
   # when: cur_mon in decomm_nodes
@@ -87,6 +102,9 @@
     - ceph_drain
 
 - name: MON - Get current mon IP address
+  when:
+    - mon_ipaddr is not defined
+    - discover_mons | bool | default(true)
   ansible.builtin.set_fact:
     mon_ipaddr: "{{ mon_ip | split(':') | first | ansible.utils.ipaddr }}"
   vars:
@@ -97,6 +115,7 @@
       {%   endif %}
       {% endfor %}
 
+# (fpantano): TODO: Move the ip migration to a dedicated network.yaml
 - name: MON - Move the mon IP Address to {{ target_node }}
   become: true
   # if no mon addr, this variable is False and the whole block is skipped
@@ -159,52 +178,6 @@
 - name: Redeploy MON
   become: true
   block:
-    # when a label is added, if we're not fast enough, a mon is automatically
-    # added on the storage network. However, in case the node has multiple ip
-    # addresses, it might happen that the mon is deployed using the right IP.
-    # For this reason we need to redeploy it by rm + add (as redeploy does not
-    # accept an IP as input
-    # - name: MON - Check quorum
-    #   ansible.builtin.command: "{{ ceph_cli }} mon stat -f json"
-    #   register: monstat
-    #   retries: 20
-    #   delay: 3
-    #   until: "'{{ target_node.split('.')[0] }}' in monstat.stdout | from_json | community.general.json_query('quorum[*].name') | default([]) | list"
-    #   loop_control:
-    #     label: "MON - Check quorum"
-
-    ## Even though we explicitly redeploy a given mon using the host:ip format,
-    # it is possible that the orchestrator (who owns the process and the spec)
-    # takes initiative to redeploy a mon, on an arbitrary ip address (if many)
-    # between the `ceph orch rm ...` command and the `ceph orch daemon add ...`
-    # one. For this reason, the deamon redeploy follows this flow:
-    # 1. update and unmanage the spec
-    # 2. redeploy on the right network as per the official doc:
-    #    https://docs.ceph.com/en/quincy/cephadm/services/mon/
-    # 3. manage the spec
-    # Note: a pause between the steps is required to allow the orchestrator to
-    #       process the spec and update the daemons ref
-    - name: Unmanage mons
-      # root privileges required to run cephadm
-      # and apply the new spec
-      ceph_mkspec:
-        service_type: mon
-        cluster: ceph
-        apply: true
-        label: "mon"
-        render_path: "{{ ceph_spec_render_dir }}"
-        unmanaged: true
-      register: spc
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_container }}"
-        CEPH_CONTAINER_BINARY: "{{ ceph_container_cli }}"
-        CEPH_CONF: "{{ ceph_config_tmp_client_home }}"
-
-    - name: Print the resulting spec
-      when: debug | default(false)
-      ansible.builtin.debug:
-        msg: "{{ spc }}"
-
     # We add labels in advance to the target node to make sure we are able to
     # deploy a tmp mon that will be replaced with the right one (on the desired
     # network). By adding an additional mon at this stage we can ensure we always
@@ -241,13 +214,6 @@
     - name: Wait for the current mon to be deleted
       ansible.builtin.pause:
         seconds: "{{ ceph_wait_mon_timeout }}"
-
-    # Check if mon even exists before removing it
-    # - name: MON - Check there is no mon on {{ target_node }}
-    #   ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type mon --daemon_id {{ daemon_id }} -f json"
-    #   register: psmon
-    #   vars:
-    #     daemon_id: "{{ target_node.split('.')[0] }}"
 
     - name: MON - Redeploy mon on {{ target_node }}
       when: debug | default(false)

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -11,22 +11,6 @@
   ansible.builtin.debug:
     msg: "Migrate mon: {{ cur_mon }} to node: {{ target_node }}"
 
-# We add labels in advance to the target node to make sure we are able to
-# deploy a tmp mon that will be replaced with the right one (on the desired
-# network). By adding an additional mon at this stage we can ensure we always
-# have quorum and at least 3 active mons while migrating the src daemon to the
-# target node.
-- name: MON - Setup Mon/Mgr label to the target node
-  ansible.builtin.include_tasks: labels.yaml
-  vars:
-    nodes:
-      - "{{ target_node }}"
-    act: "add"
-    labels:
-      - "mon"
-      - "mgr"
-      - "_admin"
-
 - name: MON - check mons quorum
   become: true
   ansible.builtin.command: "{{ ceph_cli }} -s -f json"
@@ -81,7 +65,7 @@
         mgr: "{{ mgr.stdout | from_json }}"
 
     - name: Print active mgr
-      when: debug | default(true)
+      when: debug | default(false)
       ansible.builtin.debug:
         msg: "Active mgr: {{ mgr.active_name }}"
 
@@ -121,7 +105,7 @@
     - mon_ipaddr | default('')
   block:
     - name: MON - Get current mon IP address
-      when: debug | default(true)
+      when: debug | default(false)
       ansible.builtin.debug:
         msg: "{{ mon_ipaddr }}"
 
@@ -149,11 +133,17 @@
         insertafter: "{{ ceph_storage_net_prefix }}"
         line: "    - ip_netmask: {{ mon_ipaddr }}/24"
         backup: true
+      # (NOTE): TMP WORKAROUND TO TEST THE PLAYBOK W/O ADOPTION
+      vars:
+        os_net_conf_path: "/etc/os-net-config/tripleo_config.yaml"
 
     - name: MON - Refresh os-net-config
       delegate_to: "{{ target_node }}"
       ansible.builtin.command:
         "os-net-config -c {{ os_net_conf_path }}"
+      # (NOTE): TMP WORKAROUND TO TEST THE PLAYBOK W/O ADOPTION
+      vars:
+        os_net_conf_path: "/etc/os-net-config/tripleo_config.yaml"
 
     - name: MON - ping ip address to see if is reachable on the target node
       ansible.builtin.command:
@@ -174,16 +164,16 @@
     # addresses, it might happen that the mon is deployed using the right IP.
     # For this reason we need to redeploy it by rm + add (as redeploy does not
     # accept an IP as input
-    - name: MON - Check quorum
-      ansible.builtin.command: "{{ ceph_cli }} mon stat -f json"
-      register: monstat
-      retries: 20
-      delay: 3
-      until: "'{{ target_node.split('.')[0] }}' in monstat.stdout | from_json | community.general.json_query('quorum[*].name') | default([]) | list"
-      loop_control:
-        label: "MON - Check quorum"
+    # - name: MON - Check quorum
+    #   ansible.builtin.command: "{{ ceph_cli }} mon stat -f json"
+    #   register: monstat
+    #   retries: 20
+    #   delay: 3
+    #   until: "'{{ target_node.split('.')[0] }}' in monstat.stdout | from_json | community.general.json_query('quorum[*].name') | default([]) | list"
+    #   loop_control:
+    #     label: "MON - Check quorum"
 
-    # Even though we explicitly redeploy a given mon using the host:ip format,
+    ## Even though we explicitly redeploy a given mon using the host:ip format,
     # it is possible that the orchestrator (who owns the process and the spec)
     # takes initiative to redeploy a mon, on an arbitrary ip address (if many)
     # between the `ceph orch rm ...` command and the `ceph orch daemon add ...`
@@ -211,11 +201,27 @@
         CEPH_CONF: "{{ ceph_config_tmp_client_home }}"
 
     - name: Print the resulting spec
-      when: debug | default(true)
+      when: debug | default(false)
       ansible.builtin.debug:
         msg: "{{ spc }}"
 
-    # Check if mon even exists before removing it
+    # We add labels in advance to the target node to make sure we are able to
+    # deploy a tmp mon that will be replaced with the right one (on the desired
+    # network). By adding an additional mon at this stage we can ensure we always
+    # have quorum and at least 3 active mons while migrating the src daemon to the
+    # target node.
+    - name: MON - Setup Mon/Mgr label to the target node
+      ansible.builtin.include_tasks: labels.yaml
+      vars:
+        nodes:
+          - "{{ target_node }}"
+        act: "add"
+        labels:
+          - "mon"
+          - "mgr"
+          - "_admin"
+
+    # Check if a mon exists in the target node and remove it
     - name: MON - Get tmp mon
       ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type mon --daemon_id {{ daemon_id }} -f json"
       register: psmon
@@ -227,8 +233,8 @@
       ansible.builtin.command: "{{ ceph_cli }} orch daemon rm mon.{{ target_node.split('.')[0] }} --force"
       until: '"Removed" in rmmon.stdout'
       register: rmmon
-      retries: 20
-      delay: 3
+      retries: 30
+      delay: 4
       loop_control:
         label: "MON - Get tmp mon"
 
@@ -237,14 +243,14 @@
         seconds: "{{ ceph_wait_mon_timeout }}"
 
     # Check if mon even exists before removing it
-    - name: MON - Check there is no mon on {{ target_node }}
-      ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type mon --daemon_id {{ daemon_id }} -f json"
-      register: psmon
-      vars:
-        daemon_id: "{{ target_node.split('.')[0] }}"
+    # - name: MON - Check there is no mon on {{ target_node }}
+    #   ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type mon --daemon_id {{ daemon_id }} -f json"
+    #   register: psmon
+    #   vars:
+    #     daemon_id: "{{ target_node.split('.')[0] }}"
 
     - name: MON - Redeploy mon on {{ target_node }}
-      when: debug | default(true)
+      when: debug | default(false)
       ansible.builtin.debug:
         msg: "{{ ceph_cli }} orch daemon add mon {{ target_node }}:{{ mon_ipaddr }}"
 
@@ -263,8 +269,8 @@
   become: true
   ansible.builtin.command: "{{ ceph_cli }} -s -f json"
   register: monmap
-  retries: 20
-  delay: 2
+  retries: 30
+  delay: 4
   # >= is related to the fact that the current monmap might still have
   # references to the old mon daemon coming from the drained node
   until: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) >= ((decomm_nodes |default([]) | length | int) | default(3))

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -39,6 +39,7 @@
 
 # Backup data
 - name: Backup data for client purposes
+  when: cur_mon != client_node
   ansible.builtin.include_tasks: backup.yaml
   vars:
     host: "{{ cur_mon }}"

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -49,13 +49,13 @@
 # _admin host
 - name: Migrate Ceph mgr from the current node if required
   block:
-    - name: Get the current mgrmap dump
+    - name: MON - Get the current active mgr
       become: true
       ansible.builtin.command:
-        "{{ ceph_cli }} mgr dump -f json"
+        "{{ ceph_cli }} mgr stat -f json"
       register: mgr
 
-    - name: Load mgr data
+    - name: MON - Load mgr data
       ansible.builtin.set_fact:
         mgr: "{{ mgr.stdout | from_json }}"
 
@@ -102,7 +102,7 @@
   # because there's no network related action that should be performed
   when:
     - mon_ipaddr | default('')
-    - ceph_keep_mon_ipaddr | default(true)
+    - ceph_keep_mon_ipaddr | default(false)
   block:
     - name: MON - Get current mon IP address
       when: debug | default(false)
@@ -157,7 +157,7 @@
         msg: "Can't reach the mon IP on the target node"
 
 - name: Redeploy MON
-  when: ceph_keep_mon_ipaddr | default(true)
+  when: ceph_keep_mon_ipaddr | default(false)
   become: true
   block:
     - name: Unmanage mons

--- a/tests/roles/ceph_migrate/tasks/monitoring.yaml
+++ b/tests/roles/ceph_migrate/tasks/monitoring.yaml
@@ -14,25 +14,6 @@
     labels:
       - "monitoring"
 
-- name: Update firewall rules on the target nodes
-  ansible.builtin.include_tasks: firewall.yaml
-  vars:
-    node: "{{ n }}"
-    ifports:
-      - 3100
-      - 8444
-      - 9090
-      - 9092
-      - 9093
-      - 9094
-      - 9100
-      - 9283
-  loop: "{{ target_nodes }}"
-  loop_control:
-    loop_var: n
-  tags:
-    - ceph_firewall
-
 - name: MONITORING - Load Spec from the orchestrator
   ansible.builtin.set_fact:
     monitoring_stack: "{{ monitoring }}"

--- a/tests/roles/ceph_migrate/tasks/rbd.yaml
+++ b/tests/roles/ceph_migrate/tasks/rbd.yaml
@@ -9,7 +9,7 @@
     # Use the inventory as source of truth to make sure we **always**
     # select mon[0] as client. If we stick on decomm_nodes nodes we
     # might end up selecting a different node on multiple runs.
-    cur_mon: "{{ groups['mon'][0] | default(decomm_nodes | list | sort | first) }}"
+    client_node: "{{ groups['mon'][0] | default(decomm_nodes | list | sort | first) }}"
     os_net_conf_path: "/etc/os-net-config/tripleo_config.yaml"
   tags:
     - ceph_client
@@ -20,21 +20,6 @@
   ansible.builtin.include_tasks: mgr.yaml
   tags:
     - ceph_mgr
-    - ceph_rbd
-
-# Update the firewall on the target nodes
-- name: Update firewall rules on the target nodes
-  ansible.builtin.include_tasks: firewall.yaml
-  vars:
-    ifports:
-      - 3300
-      - 6789
-    node: "{{ n }}"
-  loop: "{{ target_nodes }}"
-  loop_control:
-    loop_var: n
-  tags:
-    - ceph_firewall
     - ceph_rbd
 
 # Normalize the mon spec to use labels instead of hosts as placement
@@ -54,6 +39,21 @@
       {{ mon }}
   tags:
     - ceph_rbd
+
+# We add labels in advance to the target node to make sure we are able to
+# deploy a tmp mon that will be replaced with the right one (on the desired
+# network). By adding an additional mon at this stage we can ensure we always
+# have quorum and at least 3 active mons while migrating the src daemon to the
+# target node.
+- name: Expand MON labels to the overcloud nodes
+  ansible.builtin.import_tasks: labels.yaml
+  vars:
+    nodes: "{{ hostmap.keys() }}"
+    act: "add"
+    labels:
+      - "mon"
+      - "mgr"
+      - "_admin"
 
 - name: Normalize the mon spec to use labels
   # root privileges required to run cephadm

--- a/tests/roles/ceph_migrate/tasks/rbd.yaml
+++ b/tests/roles/ceph_migrate/tasks/rbd.yaml
@@ -85,7 +85,6 @@
         target_node: "{{ node.1 }}"
       # This condition might be a different one
       loop: "{{ decomm_nodes | zip(target_nodes) }}"
-      # loop: "{{ decomm_nodes|zip(hostmap.keys() | difference(decomm_nodes) | sort) | list }}"
       loop_control:
         loop_var: node
 

--- a/tests/roles/ceph_migrate/tasks/rbd.yaml
+++ b/tests/roles/ceph_migrate/tasks/rbd.yaml
@@ -52,7 +52,6 @@
     act: "add"
     labels:
       - "mon"
-      - "mgr"
       - "_admin"
 
 - name: Normalize the mon spec to use labels
@@ -72,6 +71,17 @@
   tags:
     - ceph_rbd
 
+# Wait for new mons as a result of the spec apply: we already have three mons
+# deployed on decomm_nodes, we should now see three more on target_node(s)
+- name: RBD - wait new daemons to be available
+  ansible.builtin.include_tasks: wait_daemons.yaml
+  vars:
+    daemon: mon
+    daemon_id: "{{ node.split('.')[0] }}"
+  loop: "{{ target_nodes }}"
+  loop_control:
+    loop_var: node
+
 # we need to serially migrate mons, so we loop over the nodes and run the
 # procedure provided by mon.yaml
 - name: MON - Migrate RBD node
@@ -83,6 +93,7 @@
       vars:
         cur_mon: "{{ node.0 }}"
         target_node: "{{ node.1 }}"
+        client_node: "{{ groups['mon'][0] | default(decomm_nodes | list | sort | first) }}"
       # This condition might be a different one
       loop: "{{ decomm_nodes | zip(target_nodes) }}"
       loop_control:

--- a/tests/roles/ceph_migrate/tasks/rgw.yaml
+++ b/tests/roles/ceph_migrate/tasks/rgw.yaml
@@ -14,20 +14,6 @@
   tags:
     - ceph_rgw_ingress
 
-- name: Update firewall rules on the target nodes
-  ansible.builtin.include_tasks: firewall.yaml
-  vars:
-    node: "{{ n }}"
-    ifports:
-      - 8080
-      - 8090
-      - 8989
-  loop: "{{ target_nodes }}"
-  loop_control:
-    loop_var: n
-  tags:
-    - ceph_firewall
-
 # - Expand labels to the target nodes
 - name: Apply RGW label to the target nodes
   ansible.builtin.import_tasks: labels.yaml
@@ -90,7 +76,7 @@
     CEPH_CONTAINER_BINARY: "{{ ceph_container_cli }}"
 
 - name: Print the resulting spec
-  when: debug | default(true)
+  when: debug | default(false)
   ansible.builtin.debug:
     msg: "{{ spc }}"
 
@@ -117,7 +103,7 @@
     - ceph_rgw_ingress
 
 - name: Print the resulting spec
-  when: debug | default(true)
+  when: debug | default(false)
   ansible.builtin.debug:
     msg: "{{ spc }}"
   tags:

--- a/tests/roles/ceph_migrate/tasks/wait_daemons.yaml
+++ b/tests/roles/ceph_migrate/tasks/wait_daemons.yaml
@@ -14,8 +14,8 @@
   become: true
   ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type {{ daemon }} {{ d_id }} -f json"
   register: daemonstat
-  retries: 20
-  delay: 3
+  retries: 200
+  delay: 5
   until: "'running' in daemonstat.stdout | from_json | community.general.json_query('[*].status_desc') | default([]) | list"
   loop_control:
     label: "wait for {{ daemon }}"

--- a/tests/roles/ceph_migrate/templates/ceph.conf.j2
+++ b/tests/roles/ceph_migrate/templates/ceph.conf.j2
@@ -1,0 +1,8 @@
+[global]
+fsid = {{ ceph_fsid }}
+mon host = {% if node_map is defined and node_map | length > 0 %}
+{%- for entry in node_map -%}
+{{ entry.ip }}
+{%- if not loop.last %},{% endif %}
+{%- endfor -%}
+{% endif -%}


### PR DESCRIPTION
This patch refines the Ceph migration flow to take into account situations relevant for CI integration.
1. Improved modularity: `backup.yaml` and `firewall.yaml` have been added to collect and reuse the same tasks in different parts of the playbook
2. Fixed the check related to `mon_quorum`, and wait for `mons` to appear in `Ceph` (it might require more time depending on the environment) 
3. Deduplicate code and turn off some debugging bool enabled by default
4. optionally skip the IP migration in case we do not require to keep mon IP addresses (false by default)

Jira: https://issues.redhat.com/browse/OSPRH-2540