### PR TITLE
Update custom container images

### DIFF
--- a/docs_user/modules/con_block-storage-service-config-generation-helper-tool.adoc
+++ b/docs_user/modules/con_block-storage-service-config-generation-helper-tool.adoc
@@ -19,7 +19,8 @@ and outputs files to the current directory (unless `--out-dir` option is used).
 
 In the output directory you always get a `cinder.patch` file with the Cinder
 specific configuration patch to apply to the `OpenStackControlPlane` custom resource but you might also get an additional file called `cinder-prereq.yaml` file with some
-`Secrets` and `MachineConfigs`.
+`Secrets` and `MachineConfigs`, and an `openstackversion.yaml` file with the
+`OpenStackVersion` sample.
 
 Example of an invocation setting input and output explicitly to the defaults for
 a Ceph backend:
@@ -67,15 +68,24 @@ In this case there are additional messages. The following list provides an expla
 dependencies so the standard container image will not work. Unfortunately this
 image is still not available, so an older image is used in the output patch file
 for reference. You can then replace this image with one that you build or
-with a Red Hat official image once the image is available. In this case you can see in your `cinder.patch` file:
+with a Red Hat official image once the image is available. In this case you can
+see in your `cinder.patch` file that has an `OpenStackVersion` object:
 +
 [source,yaml]
 ----
-      cinderVolumes:
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
       hpe-fc:
         containerImage: registry.connect.redhat.com/hpe3parcinder/openstack-cinder-volume-hpe3parcinder17-0
 ----
 +
+The name of the `OpenStackVersion` must match the name of your `OpenStackControlPlane`, so in your case it may be other than `openstack`.
+
 * The FC message reminds you that this transport protocol requires specific HBA
 cards to be present on the nodes where Block Storage services are running.
 * In this case it has created the `cinder-prereq.yaml` file and within the file

--- a/docs_user/modules/proc_deploying-file-systems-service-control-plane.adoc
+++ b/docs_user/modules/proc_deploying-file-systems-service-control-plane.adoc
@@ -104,9 +104,12 @@ backend driver needs to use its own instance of the `manila-share`
 service.
 * If a storage backend driver needs a custom container image, find it on the
 https://catalog.redhat.com/software/containers/search?gs&q=manila[RHOSP Ecosystem Catalog]
-and set `manila: template: manilaShares: <custom name> : containerImage`
-value. The following example illustrates multiple storage backend drivers,
-using custom container images.
+and create or modify an `OpenStackVersion` manifest to specify the custom image
+using the same `<custom name>`.
++
+In the following example that illustrates multiple storage backend drivers,
+where only one is using a custom container image, we have the manila spec from
+`OpenStackControlPlane`:
 +
 [source,yaml]
 ----
@@ -147,9 +150,24 @@ using custom container images.
              share_driver = manila.share.drivers.purestorage.flashblade.FlashBladeShareDriver
              flashblade_mgmt_vip = 203.0.113.15
              flashblade_data_vip = 203.0.10.14
-            containerImage: registry.connect.redhat.com/purestorage/openstack-manila-share-pure-rhosp-18-0
             replicas: 1
 ----
++
+And then we have the `OpenStackVersion` to define the custom container image:
++
+[source,yaml]
+----
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      pure: registry.connect.redhat.com/purestorage/openstack-manila-share-pure-rhosp-18-0
+----
++
+The name of the `OpenStackVersion` must match the name of your `OpenStackControlPlane`, so in your case it may be other than `openstack`.
 
 . If providing sensitive information, such as passwords, hostnames and
 usernames, it is recommended to use {OpenShift} secrets, and the

--- a/docs_user/modules/proc_preparing-block-storage-service-by-customizing-configuration.adoc
+++ b/docs_user/modules/proc_preparing-block-storage-service-by-customizing-configuration.adoc
@@ -41,8 +41,10 @@ image. If they do, find the location of the image in the vendor's instruction
 available in the https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20OpenStack%20Platform&p=1&functionalCategories=Data%20storage[{rhos_prev_long} {block_storage} ecosystem
 page]
 //kgilliga: Shouldn't this link be this instead? https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20OpenStack%20Platform&p=1&functionalCategories=Data%20storage&certified_plugin_types=Block%20Storage%20(Cinder)
-and add it under the specific's driver section using the `containerImage` key.
-The following example shows a CRD for a Pure Storage array with a certified driver:
+and create or modify an `OpenStackVersion` manifest to specify the custom
+image using the key from the `cinderVolumes` section.
++
+For example, if we had this configuration:
 +
 [source,yaml]
 ----
@@ -52,11 +54,27 @@ spec:
     template:
       cinderVolume:
         pure:
-          containerImage: registry.connect.redhat.com/purestorage/openstack-cinder-volume-pure-rhosp-18-0'
           customServiceConfigSecrets:
             - openstack-cinder-pure-cfg
 < . . . >
 ----
++
+Then the `OpenStackVersion` describing the container image for that backend
+would look like this:
++
+[source,yaml]
+----
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      pure: registry.connect.redhat.com/purestorage/openstack-cinder-volume-pure-rhosp-18-0'
+----
++
+The name of the `OpenStackVersion` must match the name of your `OpenStackControlPlane`, so in your case it may be other than `openstack`.
 
 . External files: Block Storage services sometimes use external files, for example for
 a custom policy, or to store credentials, or SSL CA bundles to connect to a


### PR DESCRIPTION
The way custom images are specified has changed, and now it no longer uses the `containerImage` file in the cinder sections but instead needs to be specified in the `OpenStackVersion`.

This patch updates the cinder and manila docs to the latest code, as well as the cinder-cfg.py helper code.