### PR TITLE
Creating an empty template does not allow telemetry to set up properl…

### DIFF
--- a/tests/config/base/openstack_control_plane.yaml
+++ b/tests/config/base/openstack_control_plane.yaml
@@ -141,7 +141,6 @@ spec:
 
   telemetry:
     enabled: false
-    template: {}
 
   swift:
     enabled: false


### PR DESCRIPTION
…y its defaults