### PR TITLE
Introduce Glance NFS adoption in the test suite

### DIFF
--- a/tests/roles/glance_adoption/defaults/main.yaml
+++ b/tests/roles/glance_adoption/defaults/main.yaml
@@ -1,2 +1,2 @@
-# glance_backend can be 'local', 'ceph', 'swift' or 'cinder'
+# glance_backend can be 'nfs', 'ceph', 'swift' or 'cinder'
 glance_backend: swift

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -1,9 +1,23 @@
 - name: deploy podified Glance with local backend
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch-file={{ role_path }}/files/glance_local.yaml
-  when: glance_backend == 'local'
+  when: glance_backend == 'nfs'
+  block:
+    - name: Fail if no nfs_server_addr/nfs_server_path are definied
+      when:
+        - nfs_server_addr is not defined
+        - nfs_server_path is not defined
+      ansible.builtin.fail:
+        msg:
+          - 'nfs_server_addr/nfs_server_path must be defined'
+    - name: Generate the glance CR config spec based on the selected backend
+      ansible.builtin.template:
+        src: templates/glance_nfs.yaml.j2
+        dst: /tmp/glance_nfs.yaml
+        mode: "0600"
+    - name: Deploy GlanceAPI with NFS backend
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/glance_nfs.yaml
 
 - name: deploy podified Glance with Ceph backend
   ansible.builtin.shell: |

--- a/tests/roles/glance_adoption/templates/glance_nfs.yaml.j2
+++ b/tests/roles/glance_adoption/templates/glance_nfs.yaml.j2
@@ -1,0 +1,28 @@
+spec:
+  glance:
+    template:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:file
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        filesystem_store_datadir = /var/lib/glance/images/
+      databaseInstance: openstack
+      glanceAPIs:
+        default:
+          replicas: 1
+          type: single
+      extraMounts:
+      - extraVol:
+        - extraVolType: NFS
+          mounts:
+          - mountPath: /var/lib/glance/images
+            name: nfs
+          volumes:
+          - name: nfs
+            nfs:
+              path: "{{ nfs_server_path }}"
+              server: "{{ nfs_server_address }}"
+        name: r1
+        region: r1


### PR DESCRIPTION
`Glance` previously had a `local` backend use case. It can be easily turned into the `NFS` backend through `extraMounts`.
This patch is supposed to delete that (unsupported) use case and introduce the `GlanceNFS` backend one.

Jira: https://issues.redhat.com/browse/OSPRH-8594