### PR TITLE
Remove telemetry template - already removed in tests

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -318,7 +318,6 @@ spec:
 
   telemetry:
     enabled: false
-    template: {}
 
   swift:
     enabled: false


### PR DESCRIPTION
This is a docs change that follows this PR:

https://github.com/openstack-k8s-operators/data-plane-adoption/pull/525