### PR TITLE
Rename the adoption github-check jobs using the new naming scheme

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -3,6 +3,6 @@
     name: openstack-k8s-operators/data-plane-adoption
     github-check:
       jobs:
-        - data-plane-adoption-osp-17-to-extracted-crc
-        - data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph
+        - adoption-standalone-to-crc-ceph
+        - adoption-standalone-to-crc-no-ceph
         - adoption-docs-preview


### PR DESCRIPTION
This renames the zuul github-check adoption jobs using the new names introduced with the depends-on

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/53788

https://issues.redhat.com/browse/OSPRH-8452