### PR TITLE
Remove databaseUser from barbican tests

### DIFF
--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -17,7 +17,6 @@
           route: {}
         template:
           databaseInstance: openstack
-          databaseUser: barbican
           databaseAccount: barbican
           rabbitMqClusterName: rabbitmq
           secret: osp-secret


### PR DESCRIPTION
This commit complements the doc edits in
https://github.com/openstack-k8s-operators/data-plane-adoption/pull/534