### PR TITLE
Use os_user variable in development_environment role

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -3,4 +3,3 @@ prelaunch_test_instance_script: pre_launch.bash
 edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 run_pre_adoption_validation: true
 os_cloud_name: standalone
-os_user: root

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -3,3 +3,4 @@ prelaunch_test_instance_script: pre_launch.bash
 edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 run_pre_adoption_validation: true
 os_cloud_name: standalone
+os_user: root

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -30,7 +30,7 @@
   no_log: "{{ use_no_log }}"
   environment:
     INSTALL_YAMLS_PATH: "{{ install_yamls_path }}"
-    CONTROLLER1_SSH="{{ controller1_ssh }}"
+    CONTROLLER1_SSH: "{{ controller1_ssh }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
   ansible.builtin.shell:
     cmd: |

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -30,14 +30,12 @@
   no_log: "{{ use_no_log }}"
   environment:
     INSTALL_YAMLS_PATH: "{{ install_yamls_path }}"
-    EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
-    OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
+    CONTROLLER1_SSH="{{ controller1_ssh }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
-    OS_USER: "{{ os_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="${CONTROLLER1_SSH} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} token issue -f value -c id
   register: before_adoption_token
 

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -10,7 +10,7 @@
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
 
 - name: creates Barbican secret
@@ -25,7 +25,7 @@
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} secret store --name testSecret --payload 'TestPayload'
 
 - name: saves a fernet token
@@ -39,7 +39,7 @@
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} token issue -f value -c id
   register: before_adoption_token
 

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -33,10 +33,11 @@
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
     OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
+    OS_USER: "{{ os_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} root@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} token issue -f value -c id
   register: before_adoption_token
 

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -6,10 +6,11 @@
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
     OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
+    OS_USER: "{{ os_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} root@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
 
 - name: creates Barbican secret
@@ -20,22 +21,25 @@
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
     OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
+    OS_USER: "{{ os_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} root@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} secret store --name testSecret --payload 'TestPayload'
 
 - name: saves a fernet token
   no_log: "{{ use_no_log }}"
   environment:
     INSTALL_YAMLS_PATH: "{{ install_yamls_path }}"
-    CONTROLLER1_SSH: "{{ controller1_ssh }}"
+    EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
+    OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
+    OS_USER: "{{ os_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="${CONTROLLER1_SSH} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} token issue -f value -c id
   register: before_adoption_token
 


### PR DESCRIPTION
For the HA RHEV env, we are using a non-root user for accessing the source cloud.