### PR TITLE
Set pvcstorageclass for metric storage

### DIFF
--- a/tests/roles/telemetry_adoption/tasks/main.yaml
+++ b/tests/roles/telemetry_adoption/tasks/main.yaml
@@ -44,7 +44,7 @@
                 strategy: persistent
                 retention: 24h
                 persistent:
-                  pvcStorageClass: "local-storage"
+                  pvcStorageClass: local-storage
                   pvcStorageRequest: 20G
     '
 

--- a/tests/roles/telemetry_adoption/tasks/main.yaml
+++ b/tests/roles/telemetry_adoption/tasks/main.yaml
@@ -45,7 +45,7 @@
                 retention: 24h
                 persistent:
                   pvcStorageClass: local-storage
-                  pvcStorageRequest: 20G
+                  pvcStorageRequest: 10G
     '
 
 - name: wait for alertmanager metric storage to start up

--- a/tests/roles/telemetry_adoption/tasks/main.yaml
+++ b/tests/roles/telemetry_adoption/tasks/main.yaml
@@ -44,6 +44,7 @@
                 strategy: persistent
                 retention: 24h
                 persistent:
+                  pvcStorageClass: "local-storage"
                   pvcStorageRequest: 20G
     '
 


### PR DESCRIPTION
RHEV job is failing on telemetry adoption due to missing storage class **FailedBinding persistentvolume-controller no persistent volumes available for this claim and no storage class is set**(https://sf.hosted.upshift.rdu2.redhat.com/logs/23/523/5c1f579434e031b60bd4475fb64c240685f5b0f1/check-gitlab-cee/rhev-rhel9-osp18-base-adoption-test-archana/1664d8b/undercloud/data-plane-adoption-tests-repo/data-plane-adoption/tests/logs/test_minimal_out_2024-08-01T16:15:27UTC.log) 
