### PR TITLE
Change the name of the ssh user used to access openstack configs before adoption

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -3,4 +3,4 @@ prelaunch_test_instance_script: pre_launch.bash
 edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 run_pre_adoption_validation: true
 os_cloud_name: standalone
-os_user: root
+source_osp_ssh_user: root

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -6,11 +6,11 @@
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
     OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
-    OS_USER: "{{ os_user }}"
+    SOURCE_OSP_SSH_USER: "{{ source_osp_ssh_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${SOURCE_OSP_SSH_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
 
 - name: creates Barbican secret
@@ -21,11 +21,11 @@
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
     OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
-    OS_USER: "{{ os_user }}"
+    SOURCE_OSP_SSH_USER: "{{ source_osp_ssh_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${SOURCE_OSP_SSH_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} secret store --name testSecret --payload 'TestPayload'
 
 - name: saves a fernet token
@@ -35,11 +35,11 @@
     EDPM_PRIVATEKEY_PATH: "{{ edpm_privatekey_path }}"
     OS_CLOUD_IP: "{{ standalone_ip | default(edpm_node_ip) }}"
     OS_CLOUD_NAME: "{{ os_cloud_name }}"
-    OS_USER: "{{ os_user }}"
+    SOURCE_OSP_SSH_USER: "{{ source_osp_ssh_user }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
-      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${OS_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+      alias openstack="ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no ${SOURCE_OSP_SSH_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
       ${BASH_ALIASES[openstack]} token issue -f value -c id
   register: before_adoption_token
 


### PR DESCRIPTION
The change requirement is discussed here: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/545