### PR TITLE
Do not backup Aodh database from previous release

### DIFF
--- a/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
+++ b/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
@@ -154,7 +154,7 @@ You must transition {compute_service_first_ref} services that are imported later
 ----
 $ oc rsh mariadb-copy-data << EOF
   mysql -h"${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" \
-  -N -e "show databases" | grep -E -v "schema|mysql|gnocchi" | \
+  -N -e "show databases" | grep -E -v "schema|mysql|gnocchi|aodh" | \
   while read dbname; do
     echo "Dumping \${dbname}";
     mysqldump -h"${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" \

--- a/tests/roles/mariadb_copy/templates/dump_dbs.bash
+++ b/tests/roles/mariadb_copy/templates/dump_dbs.bash
@@ -5,9 +5,10 @@
 
 # Note Filter the information and performance schema tables
 # Gnocchi is no longer used as a metric store, skip dumping gnocchi database as well
+# Migrating Aodh alarms from previous release is not supported, hence skip aodh database
 oc rsh mariadb-copy-data << EOF
   mysql -h"${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" \
-  -N -e "show databases" | grep -E -v "schema|mysql|gnocchi" | \
+  -N -e "show databases" | grep -E -v "schema|mysql|gnocchi|aodh" | \
   while read dbname; do
     echo "Dumping \${dbname}";
     mysqldump -h"${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" \


### PR DESCRIPTION
Since migrating Aodh alarms from previous release is not suported there is no good reason to restore the backup.