### PR TITLE
Make a switcher to disable metric storage

### DIFF
--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -11,3 +11,6 @@ use_no_log: false
 
 # Whether the adopted node will host compute services
 compute_adoption: true
+
+# Disable metric storage until ephemeral storage is implemented by setting to false
+telemetry_metric_storage: true

--- a/tests/roles/telemetry_adoption/tasks/main.yaml
+++ b/tests/roles/telemetry_adoption/tasks/main.yaml
@@ -27,6 +27,7 @@
   delay: 2
 
 - name: deploy metric storage
+  when: telemetry_metric_storage|bool
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
@@ -48,6 +49,7 @@
     '
 
 - name: wait for alertmanager metric storage to start up
+  when: telemetry_metric_storage|bool
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
@@ -58,6 +60,7 @@
   delay: 2
 
 - name: wait for prometheus metric storage to start up
+  when: telemetry_metric_storage|bool
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -58,3 +58,9 @@ run_pre_adoption_validation: true
 
 # Whether the adopted node will host compute services
 compute_adoption: true
+
+# Telemetry metric storage
+# Disable metric storage until https://issues.redhat.com/browse/OSPRH-9252 is implemented
+# Once implemented we'll be able to have a switcher to use ephemeral(testing)
+# or persistance(production) storage for telemetry_metric_storage
+telemetry_metric_storage: true


### PR DESCRIPTION
Metric Storage requires persistence storage which is not always possible in test environments. This patch makes a switcher to allow disable metric storage until persistance/ephemeral switcher is inmplemented in telemetry controller per [1]

[1] https://issues.redhat.com/browse/OSPRH-9252

Closes-Bug: OSPRH-9169