### PR TITLE
Increase timeout for heat check.

### DIFF
--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -52,5 +52,5 @@
     ${BASH_ALIASES[openstack]} stack list
   register: heat_responding_result
   until: heat_responding_result is success
-  retries: 15
+  retries: 60
   delay: 2


### PR DESCRIPTION
15 retries is not enogh as job failed on heat. Though manual check showed that all services are up and running