### PR TITLE
Pass node-exporter image and login vars to nodeset

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -215,6 +215,16 @@
             edpm_neutron_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
             edpm_neutron_dhcp_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-dhcp-agent:{{ image_tag }}"
             edpm_multipathd_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-multipathd:{{ image_tag }}"
+            {% if edpm_telemetry_node_exporter_image is defined -%}
+            edpm_telemetry_node_exporter_image: "{{ edpm_telemetry_node_exporter_image }}"
+            {% endif %}
+            {%- if edpm_container_registry_logins is defined -%}
+            edpm_container_registry_logins:
+              {% for login, value in edpm_container_registry_logins.items() -%}
+              {{ login | indent(10) }}:
+                {{ value | to_nice_yaml | trim }}
+              {% endfor -%}
+            {% endif %}
 
             gather_facts: false
             # edpm firewall, change the allowed CIDR if needed


### PR DESCRIPTION
Pass the edpm_telemetry_node_exporter_image and
edpm_container_registry_logins vars to the dataplane nodeset when
defined. This is needed to use the downstream version of node-exporter
image.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/54075
