### PR TITLE
Let git ignore the venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /tests/logs
 
 .vscode
+/venv
 
 # rendered docs
 /site


### PR DESCRIPTION
The documentation uses the venv folder for
creating a Python venv. We don't want to track
it in Git.