### PR TITLE
Make telemetry adoption conditional.

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -64,9 +64,11 @@
     - role: telemetry_adoption
       tags:
         - telemetry_adoption
+      when: telemetry_adoption|default(true)
     - role: autoscaling_adoption
       tags:
         - autoscaling_adoption
+      when: telemetry_adoption|default(true)
     - role: stop_remaining_services
       tags:
         - stop_remaining_services

--- a/tests/playbooks/test_rollback_minimal.yaml
+++ b/tests/playbooks/test_rollback_minimal.yaml
@@ -60,6 +60,7 @@
     - role: telemetry_adoption
       tags:
         - telemetry_adoption
+      when: telemetry_adoption|default(true)
     - role: autoscaling_adoption
       tags:
         - autoscaling_adoption

--- a/tests/playbooks/test_rollback_with_ceph.yaml
+++ b/tests/playbooks/test_rollback_with_ceph.yaml
@@ -65,9 +65,11 @@
     - role: telemetry_adoption
       tags:
         - telemetry_adoption
+      when: telemetry_adoption|default(true)
     - role: autoscaling_adoption
       tags:
         - autoscaling_adoption
+      when: telemetry_adoption|default(true)
     - role: manila_adoption
       tags:
         - manila_adoption

--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -69,9 +69,11 @@
     - role: telemetry_adoption
       tags:
         - telemetry_adoption
+      when: telemetry_adoption|default(true)
     - role: autoscaling_adoption
       tags:
         - autoscaling_adoption
+      when: telemetry_adoption|default(true)
     - role: manila_adoption
       tags:
         - manila_adoption

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -152,3 +152,4 @@ skip_patching_ansibleee_csv: false
 os_diff_dir: tmp/os-diff
 os_diff_data_dir: tmp/os-diff
 prelaunch_test_instance: true
+telemetry_adoption: true

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -163,7 +163,9 @@
         - libvirt
         - nova
         {%+ endif +%}
+        {% if telemetry_adoption|bool +%}
         - telemetry
+        {%+ endif +%}
       env:
         - name: ANSIBLE_CALLBACKS_ENABLED
           value: "profile_tasks"
@@ -208,8 +210,10 @@
             edpm_nova_compute_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
             edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
             edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+            {% if telemetry_adoption|bool +%}
             edpm_telemetry_ceilometer_compute_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ceilometer-compute:{{ image_tag }}"
             edpm_telemetry_ceilometer_ipmi_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ceilometer-ipmi:{{ image_tag }}"
+            {%+ endif +%}
             edpm_neutron_sriov_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-sriov-agent:{{ image_tag }}"
             edpm_neutron_ovn_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-ovn-agent:{{ image_tag }}"
             edpm_neutron_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
@@ -276,7 +280,9 @@
         - neutron-metadata
         - libvirt
         - nova
+        {% if telemetry_adoption|bool +%}
         - telemetry
+        {%+ endif +%}
       nodeTemplate:
         extraMounts:
         - extraVolType: Ceph

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -58,3 +58,6 @@ run_pre_adoption_validation: true
 
 # Whether the adopted node will host compute services
 compute_adoption: true
+
+# Where perform or not telemetry installation during adoption
+telemetry_adoption: true


### PR DESCRIPTION
Since there are no real data migration telemetry role just creates a new telemetry installation. As it doesn't do any data migration it's not a mandatory for adoption. This patch makes a condition when telemetry can be turned on and off (default).