### PR TITLE
Add a note regarding neutron-dhcp and baremetal

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -493,11 +493,9 @@ oc patch openstackdataplanenodeset openstack --type='json' --patch='[
   }]'
 ----
 
-Note that in order to use `neutron-dhcp` with OVN for baremetal
-provisioning the `disable_ovn_dhcp_for_baremetal_ports` configuration
-option for Neutron needs to be set to `true` (it defaults to
-`false`). This configuration can be set in the `NeutronAPI` spec as
-follows:
++
+[NOTE]
+To use `neutron-dhcp` with OVN for the {bare_metal_first_ref}, you must set the `disable_ovn_dhcp_for_baremetal_ports` configuration option for the {networking_first_ref}  to `true`.  You can set this configuration in the `NeutronAPI` spec:
 
 [source,yaml]
 ----

--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -493,6 +493,23 @@ oc patch openstackdataplanenodeset openstack --type='json' --patch='[
   }]'
 ----
 
+Note that in order to use `neutron-dhcp` with OVN for baremetal
+provisioning the `disable_ovn_dhcp_for_baremetal_ports` configuration
+option for Neutron needs to be set to `true` (it defaults to
+`false`). This configuration can be set in the `NeutronAPI` spec as
+follows:
+
+[source,yaml]
+----
+..
+spec:
+  serviceUser: neutron
+   ...
+      customServiceConfig: |
+          [ovn]
+          disable_ovn_dhcp_for_baremetal_ports = true
+----
+
 . Run pre-adoption validation:
 
 .. Create the validation service:


### PR DESCRIPTION
This patch is adding a note in the section that explains how to enable neutron-dhcp about using it for baremetal provisioning.

For baremetal provisoning, either the built-in DHCP from OVN or Neutron DHCP Agent can be used to provide PXE and DHCP for the baremetal nodes. By default, the OVN built-in DHCP is used.