### PR TITLE
Remove old cinder-backup and cinder-scheduler services

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -67,6 +67,36 @@
   retries: 5
   delay: 2
 
+- name: Get cinder-backup down services
+  when: cinder_backup_backend != ''
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t openstackclient -- openstack volume service list --service cinder-backup --sort-column "Updated At" -c Host -f value | head -n -1
+  register: backup_down_services
+
+- name: Remove old cinder-backup service
+  when: cinder_backup_backend != ''
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t cinder-scheduler-0 -- cinder-manage service remove cinder-backup "{{ item }}"
+  loop: "{{ backup_down_services.stdout_lines }}"
+
+- name: Get cinder-scheduler down services
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler --sort-column "Updated At" -c Host -f value | head -n -1
+  register: scheduler_down_services
+
+- name: Remove old cinder-scheduler service
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t cinder-scheduler-0 -- cinder-manage service remove cinder-scheduler "{{ item }}"
+  loop: "{{ scheduler_down_services.stdout_lines }}"
+
 - name: Cinder online data migrations
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
After adoption, we create new services for cinder-scheduler and cinder-backup but we don't clean up the old service records resulting in them being shown up in the service list output as down.

+------------------+------------------------+------+---------+-------+----------------------------+
| Binary           | Host                   | Zone | Status | State | Updated At                  |
+------------------+------------------------+------+---------+-------+----------------------------+
| cinder-scheduler | standalone.localdomain | nova | enabled | down | 2024-08-22T11:56:04.000000  |
| cinder-backup    | standalone.localdomain | nova | enabled | down | 2024-08-22T11:56:04.000000  |
| cinder-volume    | hostgroup@tripleo_ceph | nova | enabled | up   | 2024-08-22T12:56:07.000000  |
| cinder-scheduler | cinder-scheduler-0     | nova | enabled | up   | 2024-08-22T12:56:07.000000  |
| cinder-backup    | cinder-backup-0        | nova | enabled | up   | 2024-08-22T12:56:08.000000  |
+------------------+------------------------+------+---------+-------+----------------------------+

This is incorrect and leads to bad indication that there is something wrong with the deployment. As mentioned in the adoption doc[1] Step 3, we should clean up the old cinder-backup and cinder-scheduler services which this patch aims to address.

[1] https://openstack-k8s-operators.github.io/data-plane-adoption/user/index.html#deploying-the-block-storage-services_preparing-block-storage