### PR TITLE
Document needed /64 prefix per OCP host

### DIFF
--- a/docs_user/modules/proc_configuring-openshift-worker-nodes.adoc
+++ b/docs_user/modules/proc_configuring-openshift-worker-nodes.adoc
@@ -72,3 +72,18 @@ items:
       kubernetes.io/hostname: ocp-worker-0
       node-role.kubernetes.io/worker: ""
 ```
+
+// TODO: Move this to the IPv6 section once it is fully documented, both upstream and downstream.
+ifeval::["{build}" != "downstream"]
+[WARNING]
+In IPv6, {rhocp_long} worker nodes need a `/64` prefix allocation due to OVN
+limitations (RFC 4291). For dynamic IPv6 configuration, you need to change the
+prefix allocation on the Router Advertisement settings. If you want to use
+manual configuration for IPv6, define a similar CR to the
+`NodeNetworkConfigurationPolicy` CR example in this procedure, and define an
+IPv6 address and disable IPv4. Because the constraint for the `/64` prefix did
+not exist in {OpenstackPreviousInstaller}, your {OpenStackShort}
+control plane network might not have enough capacity to allocate these
+networks. If that is the case, allocate a prefix that fits a large enough number
+of addresses, for example, `/60`. The prefix depends on the number of worker nodes you have.
+endif::[]


### PR DESCRIPTION
RFC 4291 https://datatracker.ietf.org/doc/html/rfc4291 section 2.5.1 forces all interface IDs in unicast IPv6 to be 64 bits long. This is now reflected on the documentation to make all the adopters aware of the limitations, since OVN won't be able to work with different interface ID lengths.

Jira: OSPRH-3329