### PR TITLE
Improve server related commands and add BFV server

### DIFF
--- a/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
+++ b/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
@@ -118,16 +118,16 @@ oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
 . Verify if Compute services can stop the existing test VM instance:
 +
 ----
-${BASH_ALIASES[openstack]} server list | grep -qF '| test | ACTIVE |' && ${BASH_ALIASES[openstack]} server stop test || echo PASS
-${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |' || echo FAIL
+${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test ACTIVE" && ${BASH_ALIASES[openstack]} server stop test || echo PASS
+${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test SHUTOFF" || echo FAIL
 ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test 2>&1 || echo PASS
 ----
 
 . Verify if Compute services can start the existing test VM instance:
 +
 ----
-${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |' && ${BASH_ALIASES[openstack]} server start test || echo PASS
-${BASH_ALIASES[openstack]} server list | grep -F '| test | ACTIVE |' && \
+${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test SHUTOFF" && ${BASH_ALIASES[openstack]} server start test || echo PASS
+${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test ACTIVE" && \
   ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test --fit-width -f json | jq -r '.state' | grep running || echo FAIL
 ----
 

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -9,8 +9,8 @@
   when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
     {{ nova_header }}
-    ${BASH_ALIASES[openstack]} server list | grep -qF '| test | ACTIVE |' && ${BASH_ALIASES[openstack]} server stop test || echo PASS
-    ${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |' || echo FAIL
+    ${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test ACTIVE" && ${BASH_ALIASES[openstack]} server stop test || echo PASS
+    ${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test SHUTOFF" || echo FAIL
     ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test 2>&1 || echo PASS
   register: nova_verify_stop_result
   until:
@@ -23,8 +23,8 @@
   when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
     {{ nova_header }}
-    ${BASH_ALIASES[openstack]} server list | grep -qF '| test | SHUTOFF |' && ${BASH_ALIASES[openstack]} server start test || echo PASS
-    ${BASH_ALIASES[openstack]} server list | grep -F '| test | ACTIVE |' && \
+    ${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test SHUTOFF" && ${BASH_ALIASES[openstack]} server start test || echo PASS
+    ${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test ACTIVE" && \
       ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test --fit-width -f json | jq -r '.state' | grep running || echo FAIL
   register: nova_verify_start_result
   until: ("FAIL" not in nova_verify_start_result.stdout_lines)

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -89,3 +89,14 @@ fi
 if ${BASH_ALIASES[openstack]} volume show disk -f json | jq -r '.status' | grep -q available ; then
     ${BASH_ALIASES[openstack]} server add volume test disk
 fi
+
+# create another bootable volume
+if ! ${BASH_ALIASES[openstack]} volume show boot-volume ; then
+    ${BASH_ALIASES[openstack]} volume create --image cirros --size 1 boot-volume
+    wait_for_status "volume show boot-volume" "test volume 'boot-volume' creation"
+fi
+
+# Launch an instance from boot-volume (BFV)
+if ${BASH_ALIASES[openstack]} volume show boot-volume -f json | jq -r '.status' | grep -q available ; then
+    ${BASH_ALIASES[openstack]} server create --flavor m1.small --volume boot-volume --nic net-id=private bfv-server --wait
+fi


### PR DESCRIPTION
In the verification phase for servers, we are using grep to find the associated server which works for our "test" server only. Adding additional servers will break the verification.
The ideal way should be to avoid using grep with hardcoded strings and use filters instead (--name and --status) as done in [nova verify: Use filters instead of grep] commit.

The second commit adds a BFV resource for 2 reasons,
1. testing the above logic works when we add additional servers
2. BFV servers are very common in deployments and it's good to have them in our testing as well.