### PR TITLE
Refactor wait services

### DIFF
--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -97,25 +97,20 @@
   args:
     chdir: "../config"
 
-- name: wait for mariadb to start up
+- name: wait for services to start up
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc get pod openstack-galera-0 -o jsonpath='{.status.phase}{"\n"}' | grep Running
-  register: mariadb_running_result
-  until: mariadb_running_result is success
-  retries: 60
+    oc get pod {{ item }} -o jsonpath='{.status.phase}{"\n"}' | grep Running
+  register: service_running_result
+  until: service_running_result is success
+  retries: 150
   delay: 2
-
-- name: wait for cell1 mariadb to start up
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc get pod openstack-cell1-galera-0 -o jsonpath='{.status.phase}{"\n"}' | grep Running
-  register: mariadb_running_result
-  until: mariadb_running_result is success
-  retries: 60
-  delay: 2
+  loop:
+    - openstack-galera-0
+    - openstack-cell1-galera-0
+    - rabbitmq-server-0
+    - rabbitmq-cell1-server-0
 
 - name: Patch openstack upstream dns server to set the correct value for the environment
   when: upstream_dns is defined


### PR DESCRIPTION
2 minutes is not enough on slow environments. So RHEV job failed as

TASK [backend_services : wait for mariadb to start up] *************************
Friday 06 September 2024  16:52:13 +0000 (0:00:00.856)       0:02:05.271 ******
FAILED - RETRYING: [localhost]: wait for mariadb to start up (60 retries left).
...
FAILED - RETRYING: [localhost]: wait for mariadb to start up (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 60, "changed": true, "cmd": "set -euxo pipefail\n\nexport KUBECONFIG=~/adoption/kubeconfig\n\noc get pod openstack-galera-0 -o jsonpath='{.status.phase}{\"\\n\"}' | grep Running\n", "delta": "0:00:00.215099", "end": "2024-09-06 16:54:43.144598", "msg": "non-zero return code", "rc": 1, "start": "2024-09-06 16:54:42.929499", "stderr": "+ export KUBECONFIG=/home/stack/adoption/kubeconfig\n+ KUBECONFIG=/home/stack/adoption/kubeconfig\n+ oc get pod openstack-galera-0 -o 'jsonpath={.status.phase}{\"\\n\"}'\n+ grep Running", "stderr_lines": ["+ export KUBECONFIG=/home/stack/adoption/kubeconfig", "+ KUBECONFIG=/home/stack/adoption/kubeconfig", "+ oc get pod openstack-galera-0 -o 'jsonpath={.status.phase}{\"\\n\"}'", "+ grep Running"], "stdout": "", "stdout_lines": []}

This patch increases timeouts allowing pod to start up.