### PR TITLE
Increase mariadb-copy-data timeout from 215 to 300 seconds

### DIFF
--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -62,11 +62,11 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc wait --for condition=Ready pod/mariadb-copy-data --timeout=30s
+    oc wait --for condition=Ready pod/mariadb-copy-data --timeout=10s
   register: mariadb_data_pod_result
   until: mariadb_data_pod_result is success
-  retries: 5
-  delay: 6
+  retries: 25
+  delay: 2
 
 - name: check that the Galera database cluster members are online and synced
   no_log: "{{ use_no_log }}"


### PR DESCRIPTION
The job failed as following

TASK [mariadb_copy : wait for the pod to come up] ******************************
Friday 06 September 2024  14:26:36 +0000 (0:00:00.606)       0:13:41.746 ******
FAILED - RETRYING: [localhost]: wait for the pod to come up (5 retries left).
FAILED - RETRYING: [localhost]: wait for the pod to come up (4 retries left).
FAILED - RETRYING: [localhost]: wait for the pod to come up (3 retries left).
FAILED - RETRYING: [localhost]: wait for the pod to come up (2 retries left).
FAILED - RETRYING: [localhost]: wait for the pod to come up (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 5, "changed": true, "cmd": "set -euxo pipefail\n\nexport KUBECONFIG=~/adoption/kubeconfig\n\noc wait --for cond>

This patch increased timeout to 30 attemts with 2 second delay giving 1 minute in total to come up helper pod