### PR TITLE
keystone_adoption: Avoid deleting services with no endpoint

### DIFF
--- a/docs_user/modules/proc_adopting-the-identity-service.adoc
+++ b/docs_user/modules/proc_adopting-the-identity-service.adoc
@@ -64,7 +64,7 @@ control plane, excluding the {identity_service} and its endpoints:
 $ openstack endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
 
 for service in aodh heat heat-cfn barbican cinderv3 glance gnocchi manila manilav2 neutron nova placement swift ironic-inspector ironic; do
-  openstack service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
+  openstack service list | awk "/ $service /{ print \$2; }" | xargs -r ${BASH_ALIASES[openstack]} service delete || true
 done
 ----
 

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -66,7 +66,7 @@
     ${BASH_ALIASES[openstack]} endpoint list | grep keystone | awk '/admin/{ print $2; }' | xargs ${BASH_ALIASES[openstack]} endpoint delete || true
 
     for service in aodh heat heat-cfn barbican cinderv3 glance gnocchi manila manilav2 neutron nova placement swift ironic-inspector ironic; do
-      ${BASH_ALIASES[openstack]} service list | awk "/ $service /{ print \$2; }" | xargs ${BASH_ALIASES[openstack]} service delete || true
+      ${BASH_ALIASES[openstack]} service list | awk "/ $service /{ print \$2; }" | xargs -r ${BASH_ALIASES[openstack]} service delete || true
     done
 
 - name: debug token


### PR DESCRIPTION
While deleting the endpoints for services, we fetch the endpoint from ``openstack service list`` and pass the values using xargs to ``openstack service delete`` command.
Some services don't exist from the given list and the service delete errors out with invalid command.

usage: openstack service delete [-h] <service> [<service> ...]
openstack service delete: error: the following arguments are required: <service>
command terminated with exit code 2

We should avoid executing the service delete command for services that are non-existent in the catalog using the -r option.

-r, --no-run-if-empty
If the standard input does not contain any nonblanks, do not run the command.

This saves execution time and also avoids noise in the job run output[1].

EXAMPLE:

NOTE: service show is used as a	replacement for	service	delete for testing.

1. Without -r arg:

$ cat test_serv.sh
for service in aodh heat heat-cfn barbican cinderv3 glance gnocchi manila manilav2 neutron nova placement swift ironic-inspector ironic; do
    openstack service list | awk "/ $service /{ print \$2 ; }" | xargs openstack service show || true
done
stack@rajat-devstack:~$ time ./test_serv.sh
usage: openstack service show [-h] [-f {json,shell,table,value,yaml}] [-c COLUMN] [--noindent] [--prefix PREFIX] [--max-width <integer>] [--fit-width] [--print-empty] <service>
openstack service show: error: the following arguments are required: <service>
...
real	0m33.453s
user	0m30.103s
sys	0m2.290s

2. With -r arg:

$ cat test_serv.sh
for service in aodh heat heat-cfn barbican cinderv3 glance gnocchi manila manilav2 neutron nova placement swift ironic-inspector ironic; do
    openstack service list | awk "/ $service /{ print \$2 ; }" | xargs -r openstack service show || true
done

~$ time ./test_serv.sh
+-------------+----------------------------------+
| Field       | Value                            |
+-------------+----------------------------------+
| id          | 120e4f65484a493394ffe9c647287b4f |
| name        | barbican                         |
| type        | key-manager                      |
| enabled     | True                             |
| description | Barbican Key Manager Service     |
+-------------+----------------------------------+
...

real	0m24.360s
user	0m21.678s
sys	0m1.793s

33 seconds vs 24 seconds in the above run so ~9 seconds saved.

[1] https://logserver.rdoproject.org/01/601/bcff0f636f0a6e2bf0019a72d3b50fd0cb7a02f4/github-check/adoption-standalone-to-crc-ceph/82bf208/controller/data-plane-adoption-tests-repo/data-plane-adoption/tests/logs/test_with_ceph_out_2024-09-11T18:11:46EDT.log