### PR TITLE
Restart neutron pods after control plane adoption

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -6,6 +6,14 @@
     ceph_backend_configuration_fsid_shell_vars: |
       CEPH_FSID=$(oc get secret ceph-conf-files -o json | jq -r '.data."ceph.conf"' | base64 -d | grep fsid | sed -e 's/fsid = //')
 
+- name: Restart neutron pods after control plane adoption
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ oc_login_command }}
+    oc delete pod -n openstack -l service=neutron
+
 - name: Patch openstackversion to use image built from source or latest if none is defined
   when: not skip_patching_ansibleee_csv | bool
   no_log: "{{ use_no_log }}"


### PR DESCRIPTION
nova endpoints are missing(as created during nova_adoption) while neutron is adopted, and due to this nova port notifications fails as token is missing nova endpoints and this fails until token is refreshed after default token expiration i.e 3600.

This is a workaround to avoid random tempest failures as reported in related Jira Issue. Once we have some other fix this workaround can be removed.

Related-Issue: OSPCIX-453