### PR TITLE
Verify if the existing test VM instance is running

### DIFF
--- a/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
+++ b/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
@@ -120,6 +120,12 @@ $ oc exec -it nova-cell1-conductor-0 -- nova-manage db online_data_migrations
 $ oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
 ----
 
+. Verify if the existing test VM instance is running:
++
+---
+${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test 2>&1 || echo FAIL
+---
+
 . Verify if the Compute services can stop the existing test VM instance:
 +
 ----

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -5,7 +5,16 @@
       alias openstack="oc exec -t openstackclient -- openstack"
 
 # NOTE(bogdando): do not use 'set -o pipefail' for these verifications
-- name: verify if Nova services can stop the existing test VM instance
+- name: verify if the existing test VM instance is running
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell: |
+    {{ nova_header }}
+    ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test 2>&1 || echo FAIL
+  register: nova_verify_running_result
+  failed_when:
+    - ("FAIL" in nova_verify_running_result.stdout_lines)
+
+- name: verify if the Compute services can stop the existing test VM instance
   when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
     {{ nova_header }}
@@ -19,7 +28,7 @@
   retries: 10
   delay: 6
 
-- name: verify if Nova services can start the existing test VM instance
+- name: verify if the Compute services can start the existing test VM instance
   when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
     {{ nova_header }}


### PR DESCRIPTION
Add an extra verification of the test VM instance created on the source cloud, before adoption started.

This makes that failure mode verification more explicit, and the test suit to fail earlier.

Without that check, the next check to verify if the test VM instance can be stopped will fail, eventually. That is OK as well, yet obfuscates the real cause of an important failure mode - a test instance must survive adoption without downtime.

Related JIRA: [OSPRH-10215](https://issues.redhat.com/browse/OSPRH-10215)

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/55044