### PR TITLE
swift_adoption: Add check for swift-storage

### DIFF
--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -42,6 +42,7 @@
     {{ shell_header }}
     {{ oc_header }}
     oc get pod -l component=swift-proxy -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
+    oc get pod -l component=swift-storage -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running
   register: swift_running_result
   until: swift_running_result is success
   retries: 60


### PR DESCRIPTION
When deploying the swift CR, we launch pods for swiftProxy, swiftStorage and swiftRing.
The swiftStorage pod runs multiple containers namely account-server, account-replicator, account-auditor etc.
We should wait for the swift storage pod to be active as well to ensure swift is running properly.
The reason for not including swift-ring is that it runs and terminates with Completed state.

swift Ring
swift-ring-rebalance-lpg5w  0/1  Completed  0  62d

swift Storage
oc get pod -l component=swift-storage -o jsonpath='{.items[0].status.phase}{"\n"}' | grep Running Running