### PR TITLE
Add Manila CephNFS support

### DIFF
--- a/tests/roles/manila_adoption/defaults/main.yaml
+++ b/tests/roles/manila_adoption/defaults/main.yaml
@@ -3,3 +3,4 @@ manila_backend: cephfs
 os_net_conf_path: "/etc/os-net-config/config.yaml"
 manila_storagenfs_nic: "nic2"
 manila_storagenfs_vlan_id: "70"
+ganesha_default_path: "/etc/ganesha/ganesha.conf"

--- a/tests/roles/manila_adoption/tasks/main.yaml
+++ b/tests/roles/manila_adoption/tasks/main.yaml
@@ -1,19 +1,42 @@
+- name: Check the required input when manila_backend is NFS
+  when: manila_backend == "cephnfs"
+  block:
+    - name: Set shell vars to connect to controller1
+      no_log: "{{ use_no_log }}"
+      ansible.builtin.set_fact:
+        controller_ssh: |
+          CONTROLLER1_SSH="{{ controller1_ssh }}"
+
+    - name: Get ceph-nfs IP Address
+      become: true
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ controller_ssh }}
+        ${CONTROLLER1_SSH} awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' {{ ganesha_default_path }}
+      register: cephnfs_vip
+
+    - name: Fail if the OLD Ganesha VIP is not a good input value
+      when:
+        - not (cephnfs_vip.stdout | ansible.builtin.ipaddr)
+      ansible.builtin.fail:
+        msg: "The (TRIPLEO) gathered Ganesha server IP is malformed"
+
 - name: Deploy Podified Manila
   when: manila_backend == "cephfs" or manila_backend == "cephnfs"
   block:
-    - name: generate CR config based on the selected backend
+    - name: Generate CR config based on the selected backend
       ansible.builtin.template:
         src: manila_cephfs.yaml.j2
         dest: /tmp/manila_cephfs.yaml
         mode: "0600"
 
-    - name: deploy podified Manila with cephfs backend
+    - name: Deploy podified Manila with cephfs backend
       ansible.builtin.shell: |
         {{ shell_header }}
         {{ oc_header }}
         oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/manila_cephfs.yaml
 
-- name: wait for Manila to start up
+- name: Wait for Manila to start up
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
@@ -25,7 +48,7 @@
   retries: 60
   delay: 2
 
-- name: check that Manila is reachable and its endpoints are defined
+- name: Check that Manila is reachable and its endpoints are defined
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}


### PR DESCRIPTION
This patch introduces a set of basic tasks to perform the adoption of `Manila` with a `CephNFS` backend.
Before performing the actual adoption, a new `CephNFS` `cephadm` based cluster must be created.
For this reason, the `manila_nfs` tasks require a few parameters as input:

1. A new `CephNFS` `VIP` where the `CephIngress` daemon (made by `Haproxy` and `keepalived`) is created;
2. A set of Ceph `target_nodes` where the "nfs" label is added: these nodes are supposed to host the new `CephNFS` cluster and must be different from controller nodes that are going to be decommisioned;
~3. The `TripleO` managed `Ganesha` `VIP`: this input can be actually retrieved by the existing `TripleO` deployment, but we can gather this input as part of the next iteration on this patch~

After the new `CephNFS` cluster is created, it is possible to build a `manila-share` with the expected NFS configuration.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/955