### PR TITLE
Make RGW doc examples more generic

### DIFF
--- a/docs_user/modules/proc_deploying-a-ceph-ingress-daemon.adoc
+++ b/docs_user/modules/proc_deploying-a-ceph-ingress-daemon.adoc
@@ -102,9 +102,17 @@ spec:
   monitor_port: 8898
   virtual_interface_networks:
     - <external_network>
+  ssl_cert: |
+     -----BEGIN CERTIFICATE-----
+     ...
+     -----END CERTIFICATE-----
+     -----BEGIN PRIVATE KEY-----
+     ...
+     -----END PRIVATE KEY-----
 ----
 +
 * Replace `<external_network>` with your external network, for example, `10.0.0.0/24`. For more information, see xref:completing-prerequisites-for-migrating-ceph-rgw_{context}[Completing prerequisites for migrating {Ceph} RGW].
+* If TLS is enabled, add the  SSL certificate and key concatenation as described in link:{configuring-storage}/assembly_configuring-red-hat-ceph-storage-as-the-backend-for-rhosp-storage#proc_ceph-configure-rgw-with-tls_ceph-back-end[Configuring RGW with TLS for an external Red Hat Ceph Storage cluster] in _{configuring-storage-t}_.
 
 . Apply the `rgw_ingress` spec by using the Ceph orchestrator CLI:
 +

--- a/docs_user/modules/proc_migrating-the-rgw-backends.adoc
+++ b/docs_user/modules/proc_migrating-the-rgw-backends.adoc
@@ -3,23 +3,16 @@
 = Migrating the {Ceph} RGW back ends
 
 You must migrate your Ceph Object Gateway (RGW) back ends from your Controller nodes to your {Ceph} nodes. To ensure that you distribute the correct amount of services to your available nodes, you use `cephadm` labels to refer to a group of nodes where a given daemon type is deployed. For more information about the cardinality diagram, see xref:ceph-daemon-cardinality_migrating-ceph[{Ceph} daemon cardinality].
+The following procedure assumes that you have three target nodes, `cephstorage-0`, `cephstorage-1`, `cephstorage-2`.
 
 .Procedure
 
 . Add the RGW label to the {Ceph} nodes that you want to migrate your RGW back ends to:
 +
 ----
-for i in 0 1 2; {
-    ceph orch host label add cephstorage-$i rgw;
-}
-----
-+
-----
-[ceph: root@controller-0 /]#
-
-for i in 0 1 2; {
-    ceph orch host label add cephstorage-$i rgw;
-}
+$ ceph orch host label add cephstorage-0 rgw;
+$ ceph orch host label add cephstorage-1 rgw;
+$ ceph orch host label add cephstorage-2 rgw;
 
 Added label rgw to host cephstorage-0
 Added label rgw to host cephstorage-1
@@ -39,12 +32,9 @@ controller-2   192.168.24.38  _admin mon mgr
 ----
 
 ifeval::["{build}" != "downstream"]
-. During the overcloud deployment, RGW is applied at step 2
-(external_deployment_steps), and a cephadm compatible spec is generated in
-`/home/ceph-admin/specs/rgw` from the https://github.com/openstack/tripleo-ansible/blob/master/tripleo_ansible/ansible_plugins/modules/ceph_mkspec.py[ceph_mkspec] ansible module.
-Find and patch the RGW spec, specifying the right placement using the labels
-approach, and change the rgw backend port to 8090 to avoid conflicts
-with the https://github.com/openstack/tripleo-ansible/blob/master/tripleo_ansible/roles/tripleo_cephadm/tasks/rgw.yaml#L26-L30[Ceph Ingress Daemon] (*)
+. During the overcloud deployment, a `cephadm`-compatible spec is generated in
+  `/home/ceph-admin/specs/rgw`. Find and patch the RGW spec, specify the right placement by using labels,
+  and change the RGW back-end port to `8090` to avoid conflicts with the Ceph ingress daemon front-end port.
 endif::[]
 ifeval::["{build}" != "upstream"]
 . Locate the RGW spec:
@@ -68,26 +58,38 @@ spec:
   rgw_realm: default
   rgw_zone: default
 ----
++
+This example assumes that `172.17.3.0/24` is the `storage` network.
 
 . In the `placement` section, ensure that the `label` and `rgw_frontend_port` values are set:
 +
 ----
 ---
 networks:
-- 172.17.3.0/24
+- 172.17.3.0/24<1>
 placement:
-  label: rgw <1>
+  label: rgw <2>
 service_id: rgw
 service_name: rgw.rgw
 service_type: rgw
 spec:
-  rgw_frontend_port: 8090 <2>
+  rgw_frontend_port: 8090 <3>
   rgw_realm: default
   rgw_zone: default
+  rgw_frontend_ssl_certificate: | <4>
+     -----BEGIN PRIVATE KEY-----
+     ...
+     -----END PRIVATE KEY-----
+     -----BEGIN CERTIFICATE-----
+     ...
+     -----END CERTIFICATE-----
+  ssl: true
 ----
 +
-<1> Replace the Controller nodes with the `label: rgw` label.
-<2> Change the `rgw_frontend_port` value to `8090` to avoid conflicts with the Ceph ingress daemon.
+<1> Add the storage network where the RGW back ends are deployed.
+<2> Replace the Controller nodes with the `label: rgw` label.
+<3> Change the `rgw_frontend_port` value to `8090` to avoid conflicts with the Ceph ingress daemon.
+<4> Optional: if TLS is enabled, add the SSL certificate and key concatenation as described in link:{configuring-storage}/assembly_configuring-red-hat-ceph-storage-as-the-backend-for-rhosp-storage#proc_ceph-configure-rgw-with-tls_ceph-back-end[Configuring RGW with TLS for an external Red Hat Ceph Storage cluster] in _{configuring-storage-t}_.
 
 . Apply the new RGW spec by using the orchestrator CLI:
 +
@@ -96,7 +98,7 @@ $ cephadm shell -m /home/ceph-admin/specs/rgw
 $ cephadm shell -- ceph orch apply -i /mnt/rgw
 ----
 +
-This command triggers the redeploy:
+This command triggers the redeploy, for example:
 +
 ----
 ...
@@ -114,51 +116,26 @@ rgw.rgw.cephstorage-1.qynkan  cephstorage-1  172.17.3.26:8090  running (16s)
 rgw.rgw.cephstorage-2.krycit  cephstorage-2  172.17.3.81:8090  running (13s)
 ----
 
-. Ensure that the new RGW back ends are reachable on the new ports, so you can enable an IngressDaemon on port 8080 later. Log in to each {CephCluster} node that includes RGW and add the `iptables` rule to allow connections to both 8080 and 8090 ports in the {CephCluster} nodes:
+. Ensure that the new RGW back ends are reachable on the new ports, so you can enable an ingress daemon on port `8080` later. Log in to each {CephCluster} node that includes RGW and add the `iptables` rule to allow connections to both 8080 and 8090 ports in the {CephCluster} nodes:
 +
 ----
-iptables -I INPUT -p tcp -m tcp --dport 8080 -m conntrack --ctstate NEW -m comment --comment "ceph rgw ingress" -j ACCEPT
-
-iptables -I INPUT -p tcp -m tcp --dport 8090 -m conntrack --ctstate NEW -m comment --comment "ceph rgw backends" -j ACCEPT
-
-for port in 8080 8090; {
-    for i in 25 10 32; {
-       ssh heat-admin@192.168.24.$i sudo iptables -I INPUT \
-       -p tcp -m tcp --dport $port -m conntrack --ctstate NEW \
-       -j ACCEPT;
-   }
-}
+$ iptables -I INPUT -p tcp -m tcp --dport 8080 -m conntrack --ctstate NEW -m comment --comment "ceph rgw ingress" -j ACCEPT
+$ iptables -I INPUT -p tcp -m tcp --dport 8090 -m conntrack --ctstate NEW -m comment --comment "ceph rgw backends" -j ACCEPT
 ----
 
 . From a Controller node, such as `controller-0`, try to reach the RGW back ends:
 +
 ----
-for i in 26 23 81; do {
-    echo "---"
-    curl 172.17.3.$i:8090;
-    echo "---"
-    echo
-done
+$ curl http://cephstorage-0.storage:8090;
 ----
 +
 You should observe the following output:
 +
 ----
----
-Query 172.17.3.23
 <?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>anonymous</ID><DisplayName></DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>
----
-
----
-Query 172.17.3.26
-<?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>anonymous</ID><DisplayName></DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>
----
-
----
-Query 172.17.3.81
-<?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>anonymous</ID><DisplayName></DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>
----
 ----
++
+Repeat the verification for each node where a RGW daemon is deployed.
 
 . If you migrated RGW back ends to the {Ceph} nodes, there is no `internalAPI` network, except in the case of HCI nodes. You must reconfigure the RGW keystone endpoint to point to the external network that you propagated:
 +
@@ -166,7 +143,7 @@ Query 172.17.3.81
 [ceph: root@controller-0 /]# ceph config dump | grep keystone
 global   basic rgw_keystone_url  http://172.16.1.111:5000
 
-[ceph: root@controller-0 /]# ceph config set global rgw_keystone_url http://10.0.0.103:5000
+[ceph: root@controller-0 /]# ceph config set global rgw_keystone_url http://<keystone_endpoint>:5000
 ----
 +
-For more information about propagating the external network, see xref:completing-prerequisites-for-migrating-ceph-rgw_{context}[Completing prerequisites for migrating {Ceph} RGW].
+* Replace `<keystone_endpoint>` with the {identity_service_first_ref} internal endpoint of the service that is deployed in the `OpenStackControlPlane` CR when you adopt the {identity_service}.  For more information, see xref: adopting-the-identity-service_adopt-control-plane[Adopting the {identity_service}].


### PR DESCRIPTION
We currently have opinionated examples in the RGW doc. This is not necessarily a bad thing, but this patch makes them more generic and tells the human operator about the assumptions made in the examples (e.g. node names).