### PR TITLE
Verify cinder resources after adoption

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/cinder_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/cinder_verify.yaml
@@ -1,0 +1,27 @@
+- name: set Cinder services shell vars
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.set_fact:
+    osc_header: |
+      alias openstack="oc exec -t openstackclient -- openstack"
+
+- name: Verify that the volumes have correct name, status and size
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell: |
+    {{ osc_header }}
+    ${BASH_ALIASES[openstack]} volume list -c Name -c Status -c Size -f value | grep "disk in-use 1"
+    ${BASH_ALIASES[openstack]} volume list -c Name -c Status -c Size -f value | grep "boot-volume in-use 1"
+  register: cinder_verify_volumes
+  until: cinder_verify_volumes is success
+  retries: 10
+  delay: 2
+
+- name: verify the snapshot and backup of disk volume
+  when: prelaunch_test_instance|bool
+  ansible.builtin.shell: |
+    {{ osc_header }}
+    ${BASH_ALIASES[openstack]} volume snapshot list -c Name -c Status -c Size -f value | grep "snapshot available 1"
+    ${BASH_ALIASES[openstack]} volume backup list -c Name -c Status -c Size -f value | grep "backup available 1"
+  register: cinder_verify_resources
+  until: cinder_verify_resources is success
+  retries: 10
+  delay: 2

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -646,3 +646,7 @@
 - name: Adopted Neutron and OVN agents post-checks
   ansible.builtin.include_tasks:
     file: neutron_verify.yaml
+
+- name: Adopted Cinder post-checks
+  ansible.builtin.include_tasks:
+    file: cinder_verify.yaml


### PR DESCRIPTION
We should verify that the cinder volumes, snapshot and backup resources have consistent state before and after the adoption.