### PR TITLE
[WIP] Run network config in the end

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -167,8 +167,6 @@ dataplane_cr: |
     services:
       - bootstrap
       - download-cache
-      - configure-network
-      - validate-network
       - install-os
       - configure-os
       - ssh-known-hosts
@@ -177,6 +175,8 @@ dataplane_cr: |
       - install-certs
       - ovn
       - neutron-metadata
+      - configure-network
+      - validate-network
       {%+ if compute_adoption|bool +%}
       - libvirt
       - nova
@@ -268,6 +268,3 @@ dataplane_cr: |
           ovn_monitor_all: true
           edpm_ovn_remote_probe_interval: 60000
           edpm_ovn_ofctrl_wait_before_clear: 8000
-
-          # serve as a OVN gateway
-          edpm_enable_chassis_gw: true

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -166,8 +166,6 @@
       services:
         - bootstrap
         - download-cache
-        - configure-network
-        - validate-network
         - install-os
         - configure-os
         - ssh-known-hosts
@@ -176,6 +174,8 @@
         - install-certs
         - ovn
         - neutron-metadata
+        - configure-network
+        - validate-network
       env:
         - name: ANSIBLE_CALLBACKS_ENABLED
           value: "profile_tasks"


### PR DESCRIPTION
Running network config is re creating ovs bridges, leading to longer network downtime as ovs flows
misses until ovn is restarted.

Also disable gateway on computes, it got added by
mistake when adding networker support.

Related-Issue: https://issues.redhat.com/browse/OSPRH-10283