### PR TITLE
Avoid hardcoding parameters in pre_launch script

### DIFF
--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -1,6 +1,6 @@
 set -e
 
-alias openstack="ssh -q -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
+alias openstack="ssh -q -i ${EDPM_PRIVATEKEY_PATH} ${SOURCE_OSP_SSH_USER}@${OS_CLOUD_IP} OS_CLOUD=${OS_CLOUD_NAME} openstack"
 
 function wait_for_status() {
     local time=0


### PR DESCRIPTION
Don't hardcode connection information in the pre_launch script, but use
the variables that are already defined in the calling task.
