### PR TITLE
Add many more ping attempts

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -51,4 +51,4 @@
 - name: verify connectivity to the existing test VM instance using Floating IP
   when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
-      ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
+      ping -c10 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}


### PR DESCRIPTION
Add many more ping attempts to the test vm FIP to check if the missing
connectivity error is time-dependent.

Resolves: OSPCIX-503