### PR TITLE
 Add variable to set the controlplane storage class

### DIFF
--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -17,3 +17,4 @@ heat_auth_encryption_key: ''
 swift_password: ''
 dns_lb_ip: 192.168.122.80
 dns_server_ip: 192.168.122.1
+control_plane_storage_class: local-storage

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -96,8 +96,6 @@
     {{ shell_header }}
     {{ oc_header }}
     oc apply -f ../config/tmp/test_deployment.yaml
-  # args:
-  #   chdir: "../config"
 
 - name: wait for services to start up
   ansible.builtin.shell: |

--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -4,7 +4,7 @@ metadata:
   name: openstack
 spec:
   secret: osp-secret
-  storageClass: local-storage
+  storageClass: {{ control_plane_storage_class  }}
 
   barbican:
     enabled: false
@@ -77,11 +77,11 @@ spec:
       openstack:
         secret: osp-secret
         replicas: 1
-        storageRequest: 500M
+        storageRequest: 1Gi
       openstack-cell1:
         secret: osp-secret
         replicas: 1
-        storageRequest: 500M
+        storageRequest: 1Gi
 
   memcached:
     enabled: true

--- a/tests/roles/telemetry_adoption/defaults/main.yaml
+++ b/tests/roles/telemetry_adoption/defaults/main.yaml
@@ -12,6 +12,7 @@ telemetry_metric_storage_patch: |
             storage:
               strategy: persistent
               retention: 24h
+              storageClassName: {{ storage_class_name }}
               persistent:
                 pvcStorageRequest: 20G
 


### PR DESCRIPTION
Add a new variable control_plane_storage_class that is  used by the
controlplane. This allows us to deploy using an storage class different
than local-storage.
    
Also increase slightly the storage request for the database, since in
some environment it seems to use slightly more than 500 Mb.