### PR TITLE
nit: Don't instruct to replace path_to_SSH_key for upstream

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -129,7 +129,9 @@ endif::[]
 EOF
 ----
 +
+ifeval::["{build}" == "downstream"]
 * Replace `<path_to_SSH_key>` with the path to your SSH key.
+endif::[]
 
 . Generate an ssh key-pair `nova-migration-ssh-key` secret:
 +

--- a/docs_user/modules/proc_stopping-infrastructure-management-and-compute-services.adoc
+++ b/docs_user/modules/proc_stopping-infrastructure-management-and-compute-services.adoc
@@ -26,7 +26,9 @@ computes=(
 ----
 +
 ** Replace `["standalone.localdomain"]="192.168.122.100"` with the name and IP address of the Compute node.
+ifeval::["{build}" == "downstream"]
 ** Replace `<path_to_SSH_key>` with the path to your SSH key.
+endif::[]
 
 .Procedure
 


### PR DESCRIPTION
For upstream variant, we refer to install-yamls instead, so suggestion to replace the string makes no sense to the reader.