### PR TITLE
Fix inconsistent uses of storageClass

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -198,7 +198,7 @@ metadata:
   name: openstack
 spec:
   secret: osp-secret
-  storageClass: local-storage
+  storageClass: local-storage <1>
 
   barbican:
     enabled: false
@@ -347,6 +347,8 @@ spec:
         replicas: 1
 EOF
 ----
++
+<1> Select an existing storage class in your {OpenShiftShort} cluster.
 
 .Verification
 

--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -4,7 +4,7 @@ metadata:
   name: openstack
 spec:
   secret: osp-secret
-  storageClass: local-storage
+  storageClass: {{ storage_class_name }}
 
   barbican:
     enabled: false

--- a/tests/roles/glance_adoption/files/glance_ceph.yaml
+++ b/tests/roles/glance_adoption/files/glance_ceph.yaml
@@ -15,7 +15,6 @@ spec:
         rbd_store_pool=images
         store_description=Ceph glance store backend.
       storage:
-        storageClass: "local-storage"
         storageRequest: 10G
       glanceAPIs:
         default:

--- a/tests/roles/glance_adoption/files/glance_cinder.yaml
+++ b/tests/roles/glance_adoption/files/glance_cinder.yaml
@@ -6,7 +6,6 @@ spec:
     template:
       databaseInstance: openstack
       storage:
-        storageClass: "local-storage"
         storageRequest: 10G
       customServiceConfig: |
           [DEFAULT]

--- a/tests/roles/glance_adoption/files/glance_local.yaml
+++ b/tests/roles/glance_adoption/files/glance_local.yaml
@@ -12,7 +12,6 @@ spec:
         [default_backend]
         filesystem_store_datadir = /var/lib/glance/images/
       storage:
-        storageClass: "local-storage"
         storageRequest: 10G
       glanceAPIs:
         default:

--- a/tests/roles/glance_adoption/files/glance_swift.yaml
+++ b/tests/roles/glance_adoption/files/glance_swift.yaml
@@ -7,7 +7,6 @@ spec:
     template:
       databaseInstance: openstack
       storage:
-        storageClass: "local-storage"
         storageRequest: 10G
       customServiceConfig: |
         [DEFAULT]

--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-storage_class_name: crc-csi-hostpath-provisioner
+storage_class_name: local-storage
 dns_server_provisioning_ip: 192.168.122.80
 ironic_patch: |
   spec:

--- a/tests/roles/mariadb_copy/defaults/main.yaml
+++ b/tests/roles/mariadb_copy/defaults/main.yaml
@@ -1,4 +1,5 @@
 edpm_node_hostname: standalone.localdomain
 mariadb_copy_tmp_dir: tmp/mariadb
+storage_reclaim_policy: delete
 source_galera_members: |-
   ["{{ edpm_node_hostname }}"]={{ source_mariadb_ip|default(external_mariadb_ip) }}

--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -1,5 +1,5 @@
 ovn_image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
-storage_class_name: crc-csi-hostpath-provisioner
+storage_class_name: local-storage
 storage_reclaim_policy: delete
 ironic_adoption: false
 

--- a/tests/roles/swift_adoption/defaults/main.yaml
+++ b/tests/roles/swift_adoption/defaults/main.yaml
@@ -11,7 +11,7 @@ swift_patch: |
           replicas: 0
           networkAttachments:
           - storage
-          storageClass: local-storage
+          storageClass: {{ storage_class_name }}
           storageRequest: 10Gi
         swiftProxy:
           secret: osp-secret

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -23,7 +23,7 @@ reset_crc_storage: true
 # Pre-launch test VM instance on the source cloud
 prelaunch_test_instance: false
 
-storage_class_name: crc-csi-hostpath-provisioner #CUSTOMIZE_THIS
+storage_class_name: local-storage #CUSTOMIZE_THIS
 storage_reclaim_policy: delete # or retain
 
 # Snippet to get the desired 'oc' command onto $PATH.


### PR DESCRIPTION
- Advise in docs that 'local-storage' should be changed according to the OCP env.

- Use the `storage_class_name` variable consistently in tests.

- Remove explicit `storageClass: local-storage` from places that should inherit the storageClass from the `OpenStackControlPlane` CR.

- Default `storage_class_name` to `local-storage`.