### PR TITLE
Do not enable gw chassis on compute nodes

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -268,6 +268,3 @@ dataplane_cr: |
           ovn_monitor_all: true
           edpm_ovn_remote_probe_interval: 60000
           edpm_ovn_ofctrl_wait_before_clear: 8000
-
-          # serve as a OVN gateway
-          edpm_enable_chassis_gw: true


### PR DESCRIPTION
Was added by mistake when adding networker node
support[1], it was only meant for networker nodes.

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/475
Related-Issue: OSPRH-10283