### PR TITLE
Revert "Add many more ping attempts to test vm FIP"

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -51,7 +51,7 @@
 - name: verify connectivity to the existing test VM instance using Floating IP
   when: prelaunch_test_instance|bool
   ansible.builtin.shell: |
-      ping -c10 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
+      ping -c4 {{ lookup('env', 'FIP') | default('192.168.122.20', True) }}
 
 - name: validate pings, new workloads after adoption and cleanup
   when: neutron_qe_test | default('false') | bool


### PR DESCRIPTION
This reverts commit 8da971c29ea1e5bc6d42346aa125e486fb8d4783 as the root cause is known and reverted[1].

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/777

Related-Issue: OSPCIX-503