### PR TITLE
Drop the deprecated/removed ironic SSH driver

### DIFF
--- a/scenarios/hci/hieradata_overrides_undercloud.yaml
+++ b/scenarios/hci/hieradata_overrides_undercloud.yaml
@@ -4,8 +4,3 @@ parameter_defaults:
     ironic::disk_utils::image_convert_memory_limit: 2048
     ironic::conductor::heartbeat_interval: 20
     ironic::conductor::heartbeat_timeout: 120
-
-    # Ironic defaults to using `qemu:///system`.  When running libvirtd
-    # unprivileged we need to use `qemu:///session`.  This allows us to pass
-    # the value of libvirt_uri into /etc/ironic/ironic.conf.
-    ironic::drivers::ssh::libvirt_uri: 'qemu:///session'


### PR DESCRIPTION
The SSH driver was removed in the Pike release, setting ironic::drivers::ssh::libvirt_uri is "dead" code.

The driver is gone, the puppet class does not exist ...