### PR TITLE
Add call to mysql_upgrade when mysqlcheck fails for OSPCIX-521

### DIFF
--- a/tests/roles/get_services_configuration/tasks/main.yaml
+++ b/tests/roles/get_services_configuration/tasks/main.yaml
@@ -29,8 +29,18 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
-    export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(oc run mariadb-client ${MARIADB_CLIENT_ANNOTATIONS} -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
-      mysqlcheck --all-databases -h "${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" | grep -v OK)
+    run_mysqlcheck() {
+      export PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK=$(oc run mariadb-client ${MARIADB_CLIENT_ANNOTATIONS} -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+        mysqlcheck --all-databases -h "${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}" | grep -v OK)
+    }
+    run_mysqlcheck
+    if [ "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK" != "" ]; then
+      # Try mysql_upgrade to fix mysqlcheck failure
+      MYSQL_UPGRADE=$(oc run mariadb-client ${MARIADB_CLIENT_ANNOTATIONS} -q --image ${MARIADB_IMAGE} -i --rm --restart=Never -- \
+      mysql_upgrade -v -h "${SOURCE_MARIADB_IP}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD}")
+      # rerun mysqlcheck to check if problem is resolved
+      run_mysqlcheck
+    fi
     echo "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
   failed_when: _mysqlnok_check.stdout != ''
   register: _mysqlnok_check


### PR DESCRIPTION
 Add call to mysql_upgrade when mysqlcheck fails for OSPCIX-521

As discussed in related-bug, the mysqlcheck fails and running
mysql_upgrade fixes it.

Related-Bug: https://issues.redhat.com/browse/OSPCIX-521