### PR TITLE
Use multiple DNS solvers for DNSMasq CR

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -216,6 +216,7 @@ spec:
       cinderVolumes: {}
 
   dns:
+    enabled: true
     template:
       override:
         service:
@@ -227,7 +228,7 @@ spec:
           spec:
             type: LoadBalancer
       options:
-      - key: server
+      - key: server <2>
         values:
         - 192.168.122.1
       replicas: 1
@@ -349,6 +350,9 @@ EOF
 ----
 +
 <1> Select an existing storage class in your {OpenShiftShort} cluster.
+<2> Adjust the dnsmasq server entries as needed. In order to access MetalLB resources on OCP control plane,
+including messaging and database services, you should provide IP addresses of OCP master nodes.
+For external, or other resources on the intranet, you may want to provide additional IP addresses for datacentre DNS resolvers.
 
 .Verification
 

--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -16,4 +16,7 @@ heat_password: ''
 heat_auth_encryption_key: ''
 swift_password: ''
 dns_lb_ip: 192.168.122.80
+# CRC IP for openstack control plane resources hosted on Kubernetes
+upstream_dns: 192.168.122.10
+# hypervisor, or another external DNS resolver IP
 dns_server_ip: 192.168.122.1

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -114,15 +114,6 @@
     - rabbitmq-server-0
     - rabbitmq-cell1-server-0
 
-- name: Patch openstack upstream dns server to set the correct value for the environment
-  when: upstream_dns is defined
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    crname=$(oc get openstackcontrolplane -o name)
-    oc patch ${crname} --type json \
-      -p='[{"op": "replace", "path": "/spec/dns/template/options", "value": [{"key": "server", "values": ["{{ upstream_dns }}"]}]}]'
-
 - name: Patch rabbitmq resources for lower resource consumption
   changed_when: false
   ansible.builtin.shell: |

--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -22,6 +22,7 @@ spec:
       cinderVolumes: {}
 
   dns:
+    enabled: true
     template:
       override:
         service:
@@ -33,6 +34,9 @@ spec:
           spec:
             type: LoadBalancer
       options:
+      - key: server
+        values:
+        - {{ upstream_dns }}
       - key: server
         values:
         - {{ dns_server_ip }}


### PR DESCRIPTION
Align different methods of specifying and overriding DNS resolvers.

No longer patch openstack CR by replacing dns server record to set the correct value for the environment. Instead, define server entries for dnsmasq, when creating oscp/openstack CR.

Use upstream_dns var to provide a 1st entry there, which defaults to CRC machine IP.
After this change, we no longer need to hack it in ci-framework for adoption testing infra setup:

https://github.com/openstack-k8s-operators/ci-framework/blob/ bc7fc12d0a60b44fc34a89aff08765b5e9cdc8c0/hooks/playbooks/fetch _compute_facts.yml#L102

Use dns_server_ip to provide a 2nd entry, which defaults to a hypervisor IP (assuming CRC is running there as a VM).

By using both server entries, make sure that resolving of OCP hosted and external resources always work for EDPM nodes.

This also enables adoption CI jobs to start configuring network on EDPM nodes, as soon as os-net-config allows applying DNS server in resolv.conf without restarting network bridges. Real deployments will always configure EDPM nodes' network and we should do the same in CI jobs, instead of providing that via infra setup in CI-only roles.

Update docs to explain use cases for multiple DNS servers.