### PR TITLE
Add tag to allow skipping os diff task

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -235,6 +235,7 @@
     EOF
 
 - name: check ovs external-ids with os-diff before deployment
+  tags: pull_openstack_configuration
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
added a missing tag to allow skipping os-diff in dataplane adoption