### PR TITLE
Don't use/verify Cinder capabilities if no backend

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -229,9 +229,13 @@ Create a test VM instance with a test volume attachement:
 [,bash]
 ----
 cd ~/data-plane-adoption
+export CINDER_VOLUME_BACKEND_CONFIGURED=true <1>
+export CINDER_BACKUP_BACKEND_CONFIGURED=true
 OS_CLOUD_IP=192.168.122.100 OS_CLOUD_NAME=standalone \
     bash tests/roles/development_environment/files/pre_launch.bash
 ----
+<1> Use `CINDER_*_BACKEND_CONFIGURED=false`, if Cinder Volume or Backup services' storage backends have been not configured for the source cloud,
+or won't be configured for the target cloud. That might be a valid case for some developement setups, but not for a production scenarios.
 
 This also creates a test Cinder volume, a backup from it, and a snapshot of it.
 

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -1,3 +1,7 @@
+# Supported storage backends for Cinder of the target cloud
+# must match those configured for the source cloud
+supported_backup_backends: []
+supported_volume_backends: []
 netconfig_networks:
   - name: ctlplane
     dnsDomain: ctlplane.example.com

--- a/tests/roles/dataplane_adoption/tasks/cinder_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/cinder_verify.yaml
@@ -4,22 +4,26 @@
     osc_header: |
       alias openstack="oc exec -t openstackclient -- openstack"
 
-- name: Verify that the volumes have correct name, status and size
-  when: prelaunch_test_instance|bool
+- name: Verify that the volumes and snapshots have correct name, status and size
+  when:
+    - prelaunch_test_instance|bool
+    - cinder_volume_backend in supported_volume_backends
   ansible.builtin.shell: |
     {{ osc_header }}
     ${BASH_ALIASES[openstack]} volume list -c Name -c Status -c Size -f value | grep "disk in-use 1"
     ${BASH_ALIASES[openstack]} volume list -c Name -c Status -c Size -f value | grep "boot-volume in-use 1"
+    ${BASH_ALIASES[openstack]} volume snapshot list -c Name -c Status -c Size -f value | grep "snapshot available 1"
   register: cinder_verify_volumes
   until: cinder_verify_volumes is success
   retries: 10
   delay: 2
 
-- name: verify the snapshot and backup of disk volume
-  when: prelaunch_test_instance|bool
+- name: verify the backup of disk volume
+  when:
+    - prelaunch_test_instance|bool
+    - cinder_backup_backend in supported_backup_backends
   ansible.builtin.shell: |
     {{ osc_header }}
-    ${BASH_ALIASES[openstack]} volume snapshot list -c Name -c Status -c Size -f value | grep "snapshot available 1"
     ${BASH_ALIASES[openstack]} volume backup list -c Name -c Status -c Size -f value | grep "backup available 1"
   register: cinder_verify_resources
   until: cinder_verify_resources is success

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -4,6 +4,10 @@ edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 run_pre_adoption_validation: true
 os_cloud_name: standalone
 source_osp_ssh_user: root
+# Supported storage backends for Cinder of the source cloud
+# must match those configured for the target cloud
+supported_volume_backends: []
+supported_backup_backends: []
 # override var for openstack command to use on the source cloud
 openstack_command: >-
   ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no {{ source_osp_ssh_user }}@{{ standalone_ip | default(edpm_node_ip) }} OS_CLOUD={{ os_cloud_name }} openstack

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -1,10 +1,15 @@
 - name: pre-launch test VM instance
   no_log: "{{ use_no_log }}"
   when: prelaunch_test_instance|bool
+  vars:
+    cinder_volume_backend_configured: "{{  cinder_volume_backend in supported_volume_backends }}"
+    cinder_backup_backend_configured: "{{  cinder_backup_backend in supported_backup_backends }}"
   ansible.builtin.shell:
     cmd: |
       {{ shell_header }}
       export OPENSTACK_COMMAND="{{ openstack_command }}"
+      export CINDER_VOLUME_BACKEND_CONFIGURED={{ cinder_volume_backend_configured | string | lower }}
+      export CINDER_BACKUP_BACKEND_CONFIGURED={{ cinder_backup_backend_configured | string | lower }}
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
 
 - name: creates Barbican secret

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -56,6 +56,19 @@ ironic_adoption: false
 # Run pre-adoption validation before the deploying
 run_pre_adoption_validation: true
 
+# Supported storage backends for Cinder
+supported_volume_backends: #CUSTOMIZE_THIS
+  - ceph
+  - iscsi
+  - nfs
+  - fc
+
+supported_backup_backends: #CUSTOMIZE_THIS
+  - ceph
+  - s3
+  - nfs
+  - swift
+
 # Whether the adopted node will host compute services
 compute_adoption: true
 


### PR DESCRIPTION
Cinder volume and backup should have supported storage backends
configured in order to use and verify volumes/snapshots with a
test VM that we start before adoption.

When the volume backend is not supported, do not attach volumes
and do not create snapshots for the test/bfv VMs.

When the backup backend is not supported, do not create volumes
backups.

Neither verify, if those are still present post-adoption.

Depends-on: https://review.rdoproject.org/r/c/rdo-jobs/+/55084