### PR TITLE
Add Ceph post configuration section

### DIFF
--- a/docs_user/assemblies/assembly_migrating-ceph-cluster.adoc
+++ b/docs_user/assemblies/assembly_migrating-ceph-cluster.adoc
@@ -37,5 +37,7 @@ include::assembly_migrating-ceph-rgw.adoc[leveloffset=+1]
 
 include::assembly_migrating-ceph-rbd.adoc[leveloffset=+1]
 
+include::../modules/proc_migrating-ceph-post.adoc[leveloffset=+1]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/docs_user/modules/proc_migrating-ceph-post.adoc
+++ b/docs_user/modules/proc_migrating-ceph-post.adoc
@@ -1,0 +1,27 @@
+[id="updating-the-cluster-dashboard-configuration_{context}"]
+
+= Updating the {CephCluster} cluster Ceph Dashboard configuration
+
+If the Ceph Dashboard is part of the enabled Ceph Manager modules, you need to
+reconfigure the failover settings.
+
+. Regenerate the following {Ceph} configuration keys to point to the right
+  `mgr` container:
++
+----
+mgr    advanced  mgr/dashboard/controller-0.ycokob/server_addr  172.17.3.33
+mgr    advanced  mgr/dashboard/controller-1.lmzpuc/server_addr  172.17.3.147
+mgr    advanced  mgr/dashboard/controller-2.xpdgfl/server_addr  172.17.3.138
+----
++
+----
+$ sudo cephadm shell
+$ ceph orch ps | awk '/mgr./ {print $1}'
+----
+
+. For each retrieved `mgr` daemon, update the corresponding entry in the {Ceph}
+  configuration:
++
+----
+$ ceph config set mgr mgr/dashboard/<>/server_addr/<ip addr>
+----

--- a/docs_user/modules/proc_migrating-mon-from-controller-nodes-verification.adoc
+++ b/docs_user/modules/proc_migrating-mon-from-controller-nodes-verification.adoc
@@ -6,13 +6,21 @@ After you finish migrating your Ceph Monitor daemons to the target nodes, verify
 
 .Procedure
 
-* Verify that the {CephCluster} cluster is healthy:
+. Verify that the {CephCluster} cluster is healthy:
 +
 ----
-[ceph: root@oc0-controller-0 specs]# ceph -s
+$ ceph -s
   cluster:
     id:     f6ec3ebe-26f7-56c8-985d-eb974e8e08e3
     health: HEALTH_OK
 ...
 ...
+----
+
+. Verify that the {CephCluster} mons are running with the old IP addresses. SSH
+  into the target nodes and verify that the Ceph Monitor daemons are bound to
+  the expected IP and port:
++
+----
+$ netstat -tulpn | grep 3300
 ----


### PR DESCRIPTION
This patch adds the Ceph post migration procedure. At the moment the only thing that should be reconfigured is the Ceph Dashboard failover, but this guide might be extended according to the feedback we receive from the field.
The post-rbd verification is also improved to verify mons are running using the old IP addresses.