### PR TITLE
[docs] Fix NTP_SERVER setting

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -114,10 +114,10 @@ cat << EOF > /tmp/addtional_nets.json
 EOF
 export EDPM_COMPUTE_ADDITIONAL_NETWORKS=$(jq -c . /tmp/addtional_nets.json)
 export STANDALONE_COMPUTE_DRIVER=ironic
-export NTP_SERVER=pool.ntp.org  # Only necessary if not on the RedHat network ...
 export EDPM_COMPUTE_CEPH_ENABLED=false  # Optional
 export EDPM_COMPUTE_CEPH_NOVA=false # Optional
 export EDPM_COMPUTE_SRIOV_ENABLED=false # Without this the standalone deploy fails when compute driver is ironic.
+export NTP_SERVER=<ntp server>  # Default pool.ntp.org do not work in RedHat network, set this var as per the environment
 ----
 
 [Note]


### PR DESCRIPTION
The default ntp server pool.ntp.org do not work with RH Network, Fix doc so user set it as per the environment. It was correct until [1].

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/826