### PR TITLE
Do not fail when adoption is performed using Ceph Reef

### DIFF
--- a/tests/roles/ceph_migrate/tasks/ceph_validate.yaml
+++ b/tests/roles/ceph_migrate/tasks/ceph_validate.yaml
@@ -52,6 +52,7 @@
       when: pct | float < 100
 
 - name: Validate the Ceph Cluster release
+  when: check_ceph_release | default(false) | bool
   block:
     - name: MonMap
       ansible.builtin.debug:
@@ -60,8 +61,8 @@
 
     - name: ansible.builtin.fail if Ceph <= Quincy
       ansible.builtin.fail:
-        msg: "Ceph version is <= Reef"
-      when: ceph.monmap.min_mon_release_name != "quincy"
+        msg: "Ceph version is != Reef"
+      when: ceph.monmap.min_mon_release_name != "reef"
 
 - name: Mons are in quorum
   block:


### PR DESCRIPTION
Ceph `Quincy` was used to develop the migration procedure. 
However, as per the official documentation, `Reef` is the required version. 
This patch allows to perform the `Ceph` migration with `Reef`, and it adds a boolean to eventually skip this release validation in case we need to test a version != from `Reef` (this is mostly used for previous versions).

Jira: https://issues.redhat.com/browse/OSPRH-7886