### PR TITLE
Cinder: Set default volume type

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -4,6 +4,20 @@
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch '{{ cinder_scheduler_api_patch }}'
 
+- name: Get the default volume type from 17.1
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    CONTROLLER1_SSH="{{ controller1_ssh }}"
+    $CONTROLLER1_SSH "python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf'); print(c['DEFAULT']['default_volume_type'])\""
+  register: default_type
+
+- name: Patch the default volume type in openstackcontrolplane CR
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge -p '{"spec":{"cinder":{"template":{"customServiceConfig":"[DEFAULT]\ndefault_volume_type = \"{{ default_type.stdout }}\" \n"}}}}'
+
 - name: Deploy cinder-volume if necessary
   when: cinder_volume_backend | default('') != ''
   ansible.builtin.include_tasks: volume_backend.yaml


### PR DESCRIPTION
In the standalone 17.1 deployment, we set the default volume
type for the deployment.
The same type is not set in RHOSO deployment hence we see
failures in some jobs[1].
To mitigate this issue, we fetch the ``default_volume_type``
field from 17.1 deployment's cinder.conf and patch it in
the openstackcontrolplane CRs cinder section.

[1] https://logserver.rdoproject.org/28/55128/1/check/periodic-adoption-multinode-to-crc-no-ceph/f3e425b/controller/ci-framework-data/tests/test_operator/tempest-tests/stestr_results.html