### PR TITLE
Hugepages test vm

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -140,6 +140,13 @@ To use OSP 17.1 content to deploy TripleO Standalone, follow the
 https://url.corp.redhat.com/devel-rhoso-adoption[guide for setting up downstream content]
 for `make standalone`.
 
+[,bash]
+----
+cd ~/install_yamls/devsetup
+EDPM_CONFIGURE_HUGEPAGES=false make standalone <1>
+----
+<1> To configure the host for a simplistic hugepages setup, set `EDPM_CONFIGURE_HUGEPAGES=true`.
+
 === Snapshot/revert
 
 When the deployment of the Standalone OpenStack is finished, it's a
@@ -213,12 +220,14 @@ Create a test VM instance with a test volume attachement:
 cd ~/data-plane-adoption
 export CINDER_VOLUME_BACKEND_CONFIGURED=true <1>
 export CINDER_BACKUP_BACKEND_CONFIGURED=true
+export EDPM_CONFIGURE_HUGEPAGES=false <2>
 export OPENSTACK_COMMAND="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=standalone openstack"
 OS_CLOUD_IP=192.168.122.100 OS_CLOUD_NAME=standalone \
     bash tests/roles/development_environment/files/pre_launch.bash
 ----
 <1> Use `CINDER_*_BACKEND_CONFIGURED=false`, if Cinder Volume or Backup services' storage backends have been not configured for the source cloud,
 or won't be configured for the target cloud. That might be a valid case for some developement setups, but not for a production scenarios.
+<2> To configure the host for a simplistic hugepages setup `EDPM_CONFIGURE_HUGEPAGES=true`. To apply kernel args, you will need to reboot the standalone host after deployment completed.
 
 This also creates a test Cinder volume, a backup from it, and a snapshot of it.
 

--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -414,12 +414,18 @@ endif::[]
         # Do not attempt OVS major upgrades here
         edpm_ovs_packages:
         - openvswitch3.3
+        edpm_default_mounts: <4>
+          - path: /dev/hugepages<size>
+            opts: pagesize=<size>
+            fstype: hugetlbfs
+            group: hugetlbfs
 EOF
 ----
 +
 <1> If TLS Everywhere is enabled, change `spec:tlsEnabled` to `true`.
 <2> If your deployment has a custom DNS Domain, modify the `spec:nodes:[NODE NAME]:hostName` to use fqdn for the node.
 <3> Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
+<4> If you need to configure hugepages, adjust `<size>`. To configure multi-sized hugepages, create more items in the list. Note that the mount points must match the source cloud configuration.
 
 . Ensure that you use the same `ovn-controller` settings in the `OpenStackDataPlaneNodeSet` CR that you used in the {compute_service} nodes before adoption. This configuration is stored in the `external_ids` column in the `Open_vSwitch` table in the Open vSwitch database:
 +

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -270,6 +270,14 @@ dataplane_cr: |
           edpm_ovs_packages:
           - openvswitch3.3
 
+          {% if use_hugepages|bool +%}
+          edpm_default_mounts:
+            - path: /dev/hugepages2M
+              opts: pagesize=2M
+              fstype: hugetlbfs
+              group: hugetlbfs
+          {%+ endif +%}
+
           # ovn-controller settings
           edpm_ovn_bridge_mappings: ["datacentre:{{ neutron_physical_bridge_name }}"]
           edpm_ovn_bridge: br-int

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -17,6 +17,7 @@ edpm_privatekey_path: ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 run_pre_adoption_validation: true
 os_cloud_name: standalone
 source_osp_ssh_user: root
+use_hugepages: false
 # Supported storage backends for Cinder of the source cloud
 # must match those configured for the target cloud
 supported_volume_backends: []

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -72,6 +72,9 @@ ${BASH_ALIASES[openstack]} image show cirros || \
 # Create flavor
 ${BASH_ALIASES[openstack]} flavor show m1.small || \
     ${BASH_ALIASES[openstack]} flavor create --ram 512 --vcpus 1 --disk 1 --ephemeral 1 m1.small
+if [ "${EDPM_CONFIGURE_HUGEPAGES:-false}" = "true" ] ; then
+    ${BASH_ALIASES[openstack]} flavor set m1.small --property hw:mem_page_size=2MB
+fi
 
 # Create networks
 ${BASH_ALIASES[openstack]} network show private || ${BASH_ALIASES[openstack]} network create private --share

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -8,6 +8,7 @@
     cmd: |
       {{ shell_header }}
       export OPENSTACK_COMMAND="{{ openstack_command }}"
+      export EDPM_CONFIGURE_HUGEPAGES={{ use_hugepages | string | lower }}
       export CINDER_VOLUME_BACKEND_CONFIGURED={{ cinder_volume_backend_configured | string | lower }}
       export CINDER_BACKUP_BACKEND_CONFIGURED={{ cinder_backup_backend_configured | string | lower }}
       export ENROLL_BMAAS_IRONIC_NODES={{ enroll_ironic_bmaas_nodes | string | lower }}

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -71,6 +71,7 @@ supported_backup_backends: #CUSTOMIZE_THIS
 
 # Whether the adopted node will host compute services
 compute_adoption: true
+use_hugepages: false
 
 # Where perform or not telemetry installation during adoption
 telemetry_adoption: true


### PR DESCRIPTION
Launch the test VM off a hugepages-enabled flavor, if requested so.
Also configure edpm node templates to use the matching configuration.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/938

Jira: #[OSPRH-10611](https://issues.redhat.com/browse/OSPRH-10611)