### PR TITLE
Enable stale PR auto cleaning

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,17 @@
+---
+name: Manage stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: |
+            This PR is stale because it has been for over 15 days with no activity.
+            Remove stale label or comment or this PR will be closed in 7 days.
+          days-before-pr-stale: 15
+          days-before-pr-close: 7


### PR DESCRIPTION
If a PR is open for more than 15 days without any activity, the bot will send a gentle reminder.

If nothing moves during the next 7 days, the bot will close the PR.

The same stale-pr workflow was introduced in ci-framework