### PR TITLE
DNM: TMP hack to skip heat adoption and not block CI

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -58,9 +58,6 @@
     - role: horizon_adoption
       tags:
         - horizon_adoption
-    - role: heat_adoption
-      tags:
-        - heat_adoption
     - role: telemetry_adoption
       tags:
         - telemetry_adoption

--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -63,9 +63,6 @@
     - role: horizon_adoption
       tags:
         - horizon_adoption
-    - role: heat_adoption
-      tags:
-        - heat_adoption
     - role: telemetry_adoption
       tags:
         - telemetry_adoption


### PR DESCRIPTION
Due to [1], tihs DNM change is supposed to help me to check if the rdo-jobs change [2] works.

[1] https://logserver.rdoproject.org/28/55128/6/check/periodic-adoption-multinode-to-crc-no-ceph/b7b429b/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/pods/heat-engine-fc7b4d4d-gs4j8/logs/heat-engine.log

[2] 