### PR TITLE
Add missing backups pool with profile rbd

### DIFF
--- a/tests/roles/ceph_backend_configuration/tasks/main.yaml
+++ b/tests/roles/ceph_backend_configuration/tasks/main.yaml
@@ -12,7 +12,7 @@
     {{ shell_header }}
     {{ oc_header }}
     CEPH_SSH="{{ controller1_ssh }}"
-    CEPH_CAPS="mgr 'allow *' mon 'allow r, profile rbd' osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, allow rw pool manila_data'"
+    CEPH_CAPS="mgr 'allow *' mon 'allow r, profile rbd' osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, profile rbd pool=backups, allow rw pool manila_data'"
     OSP_KEYRING="client.openstack"
     CEPH_ADM=$($CEPH_SSH "cephadm shell -- ceph auth caps $OSP_KEYRING $CEPH_CAPS")
 


### PR DESCRIPTION
When `Manila` is part of the deployment, we need to enable access to `manila_data` pool from the previous deployment (`TripleO`). However, we missed `backups` pool to the command, which may cause issues to the `cinder-backup` service when is enabled.