### PR TITLE
Increase storage request for galera

### DIFF
--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -77,11 +77,11 @@ spec:
       openstack:
         secret: osp-secret
         replicas: 1
-        storageRequest: 500M
+        storageRequest: 1Gi
       openstack-cell1:
         secret: osp-secret
         replicas: 1
-        storageRequest: 500M
+        storageRequest: 1Gi
 
   memcached:
     enabled: true


### PR DESCRIPTION
Testing unigamma with lvms storage class, keystone adoption fails with
'no space left on device'. After increasing the galera storage request,
the adoption procedure continues.
