### PR TITLE
Use a more generic rc check in os-diff tasks

### DIFF
--- a/tests/roles/pull_openstack_configuration/tasks/os_diff_pull_config.yaml
+++ b/tests/roles/pull_openstack_configuration/tasks/os_diff_pull_config.yaml
@@ -9,7 +9,7 @@
   become: true
   ansible.builtin.shell: |
     dnf -y install golang
-  when: go_version_res.rc == 1
+  when: go_version_res.rc != 0
 
 - name: Clone os-diff to install it from source.
   failed_when: false


### PR DESCRIPTION
Instead of checking for a rc of 1, check if it's not 0. For some reason,
while testing unigamma, the task to check for go fails with a rc of 2,
which fails the tests because it skips the task to install go, even though
it's not installed.
