### PR TITLE
Enable dhcp agent notification

### DIFF
--- a/docs_user/modules/proc_adopting-the-networking-service.adoc
+++ b/docs_user/modules/proc_adopting-the-networking-service.adoc
@@ -50,6 +50,21 @@ spec:
 '
 ----
 
+* Note: If neutron-dhcp-agent was used in the OSP-17.1 deployment and should still be used after adoption, please enable also dhcp_agent_notification for neutron-api service.
+This can be done with patch:
++
+----
+$ oc patch openstackcontrolplane openstack --type=merge --patch '
+spec:
+  neutron:
+    template:
+      customServiceConfig: |
+        [DEFAULT]
+        dhcp_agent_notification = True
+'
+----
+
+
 .Verification
 
 * Inspect the resulting {networking_service} pods:

--- a/tests/roles/neutron_adoption/defaults/main.yaml
+++ b/tests/roles/neutron_adoption/defaults/main.yaml
@@ -6,6 +6,9 @@ neutron_config_patch: |
       apiOverride:
         route: {}
       template:
+        customServiceConfig: |
+          [DEFAULT]
+          dhcp_agent_notification = True
         override:
           service:
             internal:


### PR DESCRIPTION
For testing purpose in adoption job in order to test dhcp agent