### PR TITLE
doc maintenance updates

### DIFF
--- a/docs_user/adoption-attributes.adoc
+++ b/docs_user/adoption-attributes.adoc
@@ -12,7 +12,7 @@ ifeval::["{build}" != "downstream"]
 :OpenShiftShort: OCP
 :ocp_curr_ver: 4.16
 :rhos_curr_ver: Antelope
-:rhos_prev_ver: 
+:rhos_prev_ver:
 :rhos_z_stream: 0
 :rhel_curr_ver: 9.4
 :rhel_prev_ver: 9.2

--- a/docs_user/adoption-attributes.adoc
+++ b/docs_user/adoption-attributes.adoc
@@ -12,7 +12,7 @@ ifeval::["{build}" != "downstream"]
 :OpenShiftShort: OCP
 :ocp_curr_ver: 4.16
 :rhos_curr_ver: Antelope
-:rhos_prev_ver: Wallaby
+:rhos_prev_ver: 
 :rhos_z_stream: 0
 :rhel_curr_ver: 9.4
 :rhel_prev_ver: 9.2

--- a/docs_user/assemblies/assembly_red-hat-ceph-storage-prerequisites.adoc
+++ b/docs_user/assemblies/assembly_red-hat-ceph-storage-prerequisites.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 
 Before you migrate your {Ceph} cluster daemons from your Controller nodes, complete the following tasks in your {rhos_prev_long} {rhos_prev_ver} environment:
 
-* Upgrade your {Ceph} cluster to release {CephVernum}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/{rhos_prev_ver}/html-single/framework_for_upgrades_16.2_to_17.1/index#assembly_ceph-6-to-7_upgrade_post-upgrade-external-ceph[Upgrading Red Hat Ceph Storage 6 to 7] in _Framework for upgrades (16.2 to 17.1)_.
+* Upgrade your {Ceph} cluster to release {CephVernum}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html-single/framework_for_upgrades_16.2_to_17.1/index#assembly_ceph-6-to-7_upgrade_post-upgrade-external-ceph[Upgrading Red Hat Ceph Storage 6 to 7] in _Framework for upgrades (16.2 to 17.1)_.
 * Your {Ceph} {CephVernum} deployment is managed by `cephadm`.
 * The undercloud is still available, and the nodes and networks are managed by {OpenStackPreviousInstaller}.
 * If you use an externally deployed {Ceph} cluster, you must recreate a `ceph-nfs` cluster in the target nodes as well as propogate the `StorageNFS` network.

--- a/docs_user/modules/con_adoption-prerequisites.adoc
+++ b/docs_user/modules/con_adoption-prerequisites.adoc
@@ -19,18 +19,18 @@ Planning information::
 Back-up information::
 
 * Back up your {rhos_prev_long} ({OpenStackShort}) {rhos_prev_ver} environment by using one of the following options:
-** The Relax-and-Recover tool. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/{rhos_prev_ver}/html/backing_up_and_restoring_the_undercloud_and_control_plane_nodes/assembly_backing-up-the-undercloud-and-the-control-plane-nodes-using-the-relax-and-recover-tool_br-undercloud-ctlplane[Backing up the undercloud and the control plane nodes by using the Relax-and-Recover tool] in _Backing up and restoring the undercloud and control plane nodes_.
-** The Snapshot and Revert tool. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/{rhos_prev_ver}/html/backing_up_and_restoring_the_undercloud_and_control_plane_nodes/assembly_snapshot-and-revert-appendix_snapshot-and-revert-appendix[Backing up your Red Hat OpenStack Platform cluster by using the Snapshot and Revert tool] in _Backing up and restoring the undercloud and control plane nodes_.
+** The Relax-and-Recover tool. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/backing_up_and_restoring_the_undercloud_and_control_plane_nodes/assembly_backing-up-the-undercloud-and-the-control-plane-nodes-using-the-relax-and-recover-tool_br-undercloud-ctlplane[Backing up the undercloud and the control plane nodes by using the Relax-and-Recover tool] in _Backing up and restoring the undercloud and control plane nodes_.
+** The Snapshot and Revert tool. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/backing_up_and_restoring_the_undercloud_and_control_plane_nodes/assembly_snapshot-and-revert-appendix_snapshot-and-revert-appendix[Backing up your Red Hat OpenStack Platform cluster by using the Snapshot and Revert tool] in _Backing up and restoring the undercloud and control plane nodes_.
 ** A third-party backup and recovery tool. For more information about certified backup and recovery tools, see the link:https://catalog.redhat.com/[Red Hat Ecosystem Catalog].
 * Back up the configuration files from the {OpenStackShort} services and {OpenStackPreviousInstaller} on your file system. For more information, see xref:pulling-configuration-from-tripleo-deployment_adopt-control-plane[Pulling the configuration from a {OpenStackPreviousInstaller} deployment].
 
 Compute::
 
-* Upgrade your Compute nodes to Red Hat Enterprise Linux {rhel_prev_ver}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/{rhos_prev_ver}/html-single/framework_for_upgrades_16.2_to_17.1/index#upgrading-compute-nodes_upgrading-the-compute-node-operating-system[Upgrading all Compute nodes to RHEL 9.2] in _Framework for upgrades (16.2 to 17.1)_.
+* Upgrade your Compute nodes to Red Hat Enterprise Linux {rhel_prev_ver}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html-single/framework_for_upgrades_16.2_to_17.1/index#upgrading-compute-nodes_upgrading-the-compute-node-operating-system[Upgrading all Compute nodes to RHEL 9.2] in _Framework for upgrades (16.2 to 17.1)_.
 
 ML2/OVS::
 
-* If you use the Modular Layer 2 plug-in with Open vSwitch mechanism driver (ML2/OVS), migrate it to the Modular Layer 2 plug-in with Open Virtual Networking (ML2/OVN) mechanism driver. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/{rhos_prev_ver}/html/migrating_to_the_ovn_mechanism_driver/index[Migrating to the OVN mechanism driver].
+* If you use the Modular Layer 2 plug-in with Open vSwitch mechanism driver (ML2/OVS), migrate it to the Modular Layer 2 plug-in with Open Virtual Networking (ML2/OVN) mechanism driver. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/migrating_to_the_ovn_mechanism_driver/index[Migrating to the OVN mechanism driver].
 
 Tools::
 


### PR DESCRIPTION
Removed {rhos_prev_ver} attribute from links because they were not rendering correctly upstream.
Removed references to "Wallaby" upstream.