### PR TITLE
ospdo adoption backend services var update

### DIFF
--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -29,5 +29,5 @@ ospdo_src: false
 # rhoso namespace
 rhoso_namespace: "openstack"
 # director operator namespace
-org_namespace: "ospdo_openstack"
+org_namespace: "openstack"
 # adoption repo default location


### PR DESCRIPTION
update default backend_services org_namespace

continuation of : https://github.com/openstack-k8s-operators/data-plane-adoption/pull/689
with a minor var update

