### PR TITLE
Block storage: correct steps order

### DIFF
--- a/docs_user/modules/proc_adopting-the-block-storage-service.adoc
+++ b/docs_user/modules/proc_adopting-the-block-storage-service.adoc
@@ -21,7 +21,7 @@ $CONTROLLER1_SSH cat /var/lib/config-data/puppet-generated/cinder/etc/cinder/cin
 
 .Procedure
 
-. Create a new file, for example, `cinder.patch`, and apply the configuration:
+. Create a new file, for example, `cinder_api.patch`, and apply the configuration:
 +
 ----
 $ oc patch openstackcontrolplane openstack --type=merge --patch-file=<patch_name>
@@ -29,7 +29,7 @@ $ oc patch openstackcontrolplane openstack --type=merge --patch-file=<patch_name
 +
 * Replace `<patch_name>` with the name of your patch file.
 +
-The following example shows a `cinder.patch` file for an RBD deployment:
+The following example shows a `cinder_api.patch` file:
 +
 [source,yaml]
 ----
@@ -75,6 +75,61 @@ spec:
           [DEFAULT]
           default_volume_type=tripleo
       cinderScheduler:
+        replicas: 0
+      cinderBackup:
+        networkAttachments:
+        - storage
+        replicas: 0
+      cinderVolumes:
+        ceph:
+          networkAttachments:
+          - storage
+          replicas: 0
+----
+
+. Retrieve the list of the previous scheduler and backup services:
++
+----
+$ openstack volume service list
+
++------------------+------------------------+------+---------+-------+----------------------------+
+| Binary           | Host                   | Zone | Status  | State | Updated At                 |
++------------------+------------------------+------+---------+-------+----------------------------+
+| cinder-scheduler | standalone.localdomain | nova | enabled | down  | 2024-11-04T17:47:14.000000 |
+| cinder-backup    | standalone.localdomain | nova | enabled | down  | 2024-11-04T17:47:14.000000 |
+| cinder-volume    | hostgroup@tripleo_ceph | nova | enabled | down  | 2024-11-04T17:47:14.000000 |
++------------------+------------------------+------+---------+-------+----------------------------+
+----
+
+. Remove services for hosts that are in the `down` state:
++
+----
+$ oc exec -t cinder-api-0 -c cinder-api -- cinder-manage service remove <service_binary> <service_host>
+----
++
+* Replace `<service_binary>` with the name of the binary, for example, `cinder-backup`.
+* Replace `<service_host>` with the host name, for example, `cinder-backup-0`.
++
+
+. Deploy the scheduler, backup and volume services.
++
+* Create another file, for example, `cinder_services.patch`, and apply the configuration.
++
+----
+$ oc patch openstackcontrolplane openstack --type=merge --patch-file=<patch_name>
+----
++
+* Replace `<patch_name>` with the name of your patch file.
++
+* The following example shows a `cinder_services.patch` file for an RBD deployment:
++
+[source,yaml]
+----
+spec:
+  cinder:
+    enabled: true
+    template:
+      cinderScheduler:
         replicas: 1
       cinderBackup:
         networkAttachments:
@@ -103,7 +158,7 @@ spec:
             report_discard_supported=True
 ----
 
-. Retrieve the list of the previous scheduler and backup services:
+. Check if all the services are up and running.
 +
 ----
 $ openstack volume service list
@@ -111,22 +166,11 @@ $ openstack volume service list
 +------------------+------------------------+------+---------+-------+----------------------------+
 | Binary           | Host                   | Zone | Status  | State | Updated At                 |
 +------------------+------------------------+------+---------+-------+----------------------------+
-| cinder-backup    | standalone.localdomain | nova | enabled | down  | 2023-06-28T11:00:59.000000 |
-| cinder-scheduler | standalone.localdomain | nova | enabled | down  | 2023-06-28T11:00:29.000000 |
 | cinder-volume    | hostgroup@tripleo_ceph | nova | enabled | up    | 2023-06-28T17:00:03.000000 |
 | cinder-scheduler | cinder-scheduler-0     | nova | enabled | up    | 2023-06-28T17:00:02.000000 |
 | cinder-backup    | cinder-backup-0        | nova | enabled | up    | 2023-06-28T17:00:01.000000 |
 +------------------+------------------------+------+---------+-------+----------------------------+
 ----
-
-. Remove services for hosts that are in the `down` state:
-+
-----
-$ oc exec -it cinder-scheduler-0 -- cinder-manage service remove <service_binary> <service_host>
-----
-+
-* Replace `<service_binary>` with the name of the binary, for example, `cinder-backup`.
-* Replace `<service_host>` with the host name, for example, `cinder-backup-0`.
 
 . Apply the DB data migrations:
 +

--- a/tests/roles/cinder_adoption/defaults/main.yaml
+++ b/tests/roles/cinder_adoption/defaults/main.yaml
@@ -3,7 +3,7 @@
 cinder_volume_backend: ""
 cinder_backup_backend: ""
 
-cinder_scheduler_api_patch: |
+cinder_api_patch: |
   spec:
     cinder:
       enabled: true
@@ -24,6 +24,9 @@ cinder_scheduler_api_patch: |
                     metallb.universe.tf/loadBalancerIPs: 172.17.0.80
                 spec:
                   type: LoadBalancer
+        cinderScheduler:
+          # Avoid deploying scheduler until we clean up old services
+          replicas: 0
         cinderBackup:
           networkAttachments:
           - storage
@@ -33,6 +36,14 @@ cinder_scheduler_api_patch: |
             networkAttachments:
             - storage
             replicas: 0 # no volumes by default
+
+cinder_scheduler_patch: |
+  spec:
+    cinder:
+      enabled: true
+      template:
+        cinderScheduler:
+          replicas: 1
 
 cinder_volume_backend_patch: |
   spec:

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -1,8 +1,14 @@
-- name: deploy podified Cinder scheduler and API
+- name: deploy podified Cinder API
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch '{{ cinder_scheduler_api_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ cinder_api_patch }}'
+
+- name: deploy podified Cinder scheduler
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ cinder_scheduler_patch }}'
 
 - name: Get the default volume type from 17.1
   ansible.builtin.shell: |

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -4,6 +4,46 @@
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch '{{ cinder_api_patch }}'
 
+- name: wait for Cinder API to start up
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc wait pod --for condition=Ready -l component=cinder-api
+  register: cinder_api_running
+  until: cinder_api_running is success
+  retries: 60
+  delay: 2
+
+# Ignoring "-o pipefail" to avoid errors in grep which are non-fatal
+- name: Get cinder-backup down services
+  ansible.builtin.shell: |
+    {{ oc_header }}
+    set -eux
+    oc exec -t openstackclient -- openstack volume service list --service cinder-backup -f value | grep "down" | awk '{ print $2 }'
+  register: backup_down_services
+
+- name: Remove old cinder-backup service
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t cinder-api-0 -c cinder-api -- cinder-manage service remove cinder-backup "{{ item }}"
+  loop: "{{ backup_down_services.stdout_lines }}"
+
+# Ignoring "-o pipefail" to avoid errors in grep which are non-fatal
+- name: Get cinder-scheduler down services
+  ansible.builtin.shell: |
+    {{ oc_header }}
+    set -eux
+    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler -f value | grep "down" | awk '{ print $2 }'
+  register: scheduler_down_services
+
+- name: Remove old cinder-scheduler service
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t cinder-api-0 -c cinder-api -- cinder-manage service remove cinder-scheduler "{{ item }}"
+  loop: "{{ scheduler_down_services.stdout_lines }}"
+
 - name: deploy podified Cinder scheduler
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -37,7 +77,6 @@
     {{ shell_header }}
     {{ oc_header }}
     oc wait pod --for condition=Ready -l component=cinder-scheduler
-    oc wait pod --for condition=Ready -l component=cinder-api
     [ -z "{{ cinder_volume_backend }}" ] || oc wait pod --for condition=Ready -l component=cinder-volume
     [ -z "{{ cinder_backup_backend }}" ] || oc wait pod --for condition=Ready -l component=cinder-backup
   register: cinder_running_result
@@ -86,36 +125,6 @@
   until: cinder_running_result is success
   retries: 5
   delay: 2
-
-- name: Get cinder-backup down services
-  when: cinder_backup_backend != ''
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc exec -t openstackclient -- openstack volume service list --service cinder-backup --sort-column "Updated At" -c Host -f value | head -n -1
-  register: backup_down_services
-
-- name: Remove old cinder-backup service
-  when: cinder_backup_backend != ''
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc exec -t cinder-scheduler-0 -- cinder-manage service remove cinder-backup "{{ item }}"
-  loop: "{{ backup_down_services.stdout_lines }}"
-
-- name: Get cinder-scheduler down services
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler --sort-column "Updated At" -c Host -f value | head -n -1
-  register: scheduler_down_services
-
-- name: Remove old cinder-scheduler service
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc exec -t cinder-scheduler-0 -- cinder-manage service remove cinder-scheduler "{{ item }}"
-  loop: "{{ scheduler_down_services.stdout_lines }}"
 
 - name: Cinder online data migrations
   ansible.builtin.shell: |


### PR DESCRIPTION
To deploy block storage service i.e. cinder, we should first remove
the service entries from old deployments to avoid any issues in
the new RHOSO deployment.

For that we need to rewrite the steps to:

1. Deploy cinder-api pod
2. List all scheduler and backup services from old deployment
3. Remove the old scheduler and backup services
4. Deploy scheduler, volume and backup services
5. Perform DB migration

This will ensure that our RHOSO deployment is fresh and does not
contain traces of errors from services of old deployment.