### PR TITLE
Fix Swift migration tests and remove fixed IP

### DIFF
--- a/docs_user/modules/proc_migrating-object-storage-data-to-rhoso-nodes.adoc
+++ b/docs_user/modules/proc_migrating-object-storage-data-to-rhoso-nodes.adoc
@@ -63,16 +63,17 @@ $ oc wait pods --for condition=Ready -l component=swift-storage
 . From the current rings, get the storage management IP addresses of the nodes to drain:
 +
 ----
-$ oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-ring-builder object.builder' | tail -n +7 | awk '{print $4}' | sort -u
+$ oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-ring-builder object.builder search _' | tail -n +2 | awk '{print $4}' | sort -u
+
 ----
 +
 The output looks similar to the following:
 +
 ----
-172.20.0.100:6200
-swift-storage-0.swift-storage.openstack.svc:6200
-swift-storage-1.swift-storage.openstack.svc:6200
-swift-storage-2.swift-storage.openstack.svc:6200
+172.20.0.100
+swift-storage-0.swift-storage.openstack.svc
+swift-storage-1.swift-storage.openstack.svc
+swift-storage-2.swift-storage.openstack.svc
 ----
 
 . Drain the old nodes. In the following example, the old node `172.20.0.100` is drained:

--- a/tests/roles/swift_migration/tasks/main.yaml
+++ b/tests/roles/swift_migration/tasks/main.yaml
@@ -1,3 +1,9 @@
+- name: Get list of current Swift storage node IPs
+  ansible.builtin.shell: |
+    {{ oc_header }}
+    oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get > /dev/null 2>&1 ; swift-ring-builder object.builder search _ | tail -n +2 | awk "{print \$4}" | sort -u'
+  register: swift_node_list_result
+
 - name: setup nameserver on standalone node
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -29,7 +35,9 @@
     {{ oc_header }}
     oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c '
     swift-ring-tool get
-    swift-ring-tool drain 172.20.0.100
+    while read -r node; do
+      swift-ring-tool drain ${node}
+    done <<< "{{ swift_node_list_result.stdout }}"
     swift-ring-tool forced_rebalance
     swift-ring-tool push'
 
@@ -104,6 +112,8 @@
     CONTROLLER1_SSH="{{ controller1_ssh }}"
     oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c '
     swift-ring-tool get
-    swift-ring-tool remove 172.20.0.100
+    while read -r node; do
+      swift-ring-tool drain ${node}
+    done <<< "{{ swift_node_list_result.stdout }}"
     swift-ring-tool rebalance
     swift-ring-tool push'


### PR DESCRIPTION
The fixed IP is valid for CRC/standalone testing, however it is most likely not for any other deployments. Instead of using a fixed IP getting the IPs of the former storage nodes before adding PVCs will cover many more cases.