### PR TITLE
Setting skip_patching_ansibleee_csv to true

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -151,7 +151,7 @@ edpm_sshd_allowed_ranges: "{{ ['192.168.122.0/24'] if dataplane_os_net_config_se
 edpm_neutron_sriov_agent_enabled: true
 edpm_neutron_dhcp_agent_enabled: true
 nova_libvirt_backend: local
-skip_patching_ansibleee_csv: false
+skip_patching_ansibleee_csv: true
 # OS Diff automation steps
 os_diff_dir: tmp/os-diff
 os_diff_data_dir: tmp/os-diff


### PR DESCRIPTION
Setting skip_patching_ansibleee_csv to true as edpm-ansible is stable and does not need to be patched frequently anymore.
This will stop patching the ansibleeImage and we will get the desired downstream version of openstack-ansibleee-runner image
Related to https://issues.redhat.com/browse/OSPRH-10704 