### PR TITLE
Execute the volume type command with sudo

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -9,7 +9,7 @@
     {{ shell_header }}
     {{ oc_header }}
     CONTROLLER1_SSH="{{ controller1_ssh }}"
-    $CONTROLLER1_SSH "python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf'); print(c['DEFAULT']['default_volume_type'])\""
+    $CONTROLLER1_SSH "sudo python3 -c \"import configparser; c = configparser.ConfigParser(); c.read('/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf'); print(c['DEFAULT']['default_volume_type'])\""
   register: default_type
 
 - name: Patch the default volume type in openstackcontrolplane CR


### PR DESCRIPTION
RHEV is using stack user to ssh the controller nodes. Adding sudo to execute the command for fetching the default volume type from cinder.conf.