### PR TITLE
Add noop job to jobs-layout

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -3,6 +3,7 @@
     name: openstack-k8s-operators/data-plane-adoption
     github-check:
       jobs:
+        - noop
         - adoption-standalone-to-crc-ceph
         - adoption-standalone-to-crc-no-ceph
         - adoption-docs-preview


### PR DESCRIPTION
In order to get proper feedback from the rdoproject.org/github-check, the noop job is added. This job should be kicked even if other jobs are not started as irrelevant-files are detected in change. Without noop job rdoproject.org/github-check is hanging with [waiting for status to be reported message](https://github.com/openstack-k8s-operators/data-plane-adoption/pull/681).