### PR TITLE
Add ping test framework to test_minimal.

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -78,3 +78,6 @@
     - role: dataplane_adoption
       tags:
         - dataplane_adoption
+
+- name: Stop the ping test
+  import_playbook: _stop_ping_test.yaml


### PR DESCRIPTION
Now that the ping test is deactivated by default we can add the
necessary bits in `test_minimal.yaml` as well.

Activation will be done on a job by job basis.