### PR TITLE
Fix post processing process for ping test.

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -7,7 +7,7 @@ ping_test: false
 # ~/src/github.com/openstack-k8s-operators/data-plane-adoption/tests/playbooks
 # Collected in
 # /controller/data-plane-adoption-tests-repo/data-plane-adoption/tests/logs
-ping_test_log_file: ../logs/ping_results.log
+ping_test_log_file: ../logs/ping_results.txt
 stop_ping_script: ../stop_ping.sh
 # max cut in seconds
 ping_test_loss_threshold: 0

--- a/tests/roles/development_environment/templates/stop_ping.sh.j2
+++ b/tests/roles/development_environment/templates/stop_ping.sh.j2
@@ -23,6 +23,7 @@ function get_cut_time()
 function convert_ping_result_date()
 {
     local ping_file="${1:?'Provide a file'}"
+    local ping_file_hr="${ping_file%.*}"-hr.txt
     awk -F'[][]' \
     '{if (NF>1) {
         cmd="date -d @"$2" +\"%Y-%m-%d %H:%M:%S.%3N %Z\"";
@@ -30,7 +31,8 @@ function convert_ping_result_date()
         close(cmd);
         $2="[" date "]";
         }
-      print $0; }' "${ping_file}" > "${ping_file%.*}"-hr.log
+      print $0; }' "${ping_file}" > "${ping_file_hr}"
+    chmod 0664 "${ping_file_hr}"
 }
 
 # kill the ping process
@@ -39,6 +41,9 @@ kill -s INT $(/usr/sbin/pidof ping)
 # print the ping results
 PING_RESULT_LOG={{ ping_test_log_file }}
 tail -2 $PING_RESULT_LOG
+
+# Make sure the log files are readable by every user.
+chmod 0664 "${PING_RESULT_LOG}"
 
 # if only one packet is lost, test succeeded, avoid false positive.
 TRANSMITTED=$(grep 'packet loss' $PING_RESULT_LOG | sed 's/^\([0-9]*\) packets transmitted,.*/\1/')


### PR DESCRIPTION
We have certain post processes that parse all the file that ends in
`.log` in the adoption `log` directory.  It expects an Ansible log
format.

So in order to not confuse that process, the ping files are renamed to
end with `.txt`.

Furthermore, for some reason, the files were not readable by that
process. Even if now they will be excluded from the processing, it's
best if they are world readable.