### PR TITLE
Fix: Cleanup old cinder services

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -19,7 +19,7 @@
   ansible.builtin.shell: |
     {{ oc_header }}
     set -eux
-    oc exec -t openstackclient -- openstack volume service list --service cinder-backup -f value | grep "down" | awk '{ print $2 }'
+    oc exec -t openstackclient -- openstack volume service list --service cinder-backup -c Host -f value
   register: backup_down_services
 
 - name: Remove old cinder-backup service
@@ -34,7 +34,7 @@
   ansible.builtin.shell: |
     {{ oc_header }}
     set -eux
-    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler -f value | grep "down" | awk '{ print $2 }'
+    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler -c Host -f value
   register: scheduler_down_services
 
 - name: Remove old cinder-scheduler service


### PR DESCRIPTION
Somehow the services are not being captured with the volume service list while grepping for the "down" services.
One possibility is that the services were in "up" state when we migrated the DB from 17.1 -> 18 and it takes time to update the DB to report them as "down" meanwhile we are attempting the removal.
The straightforward way would be to cleanup all old cinder-scheduler and cinder-backup service entries since we haven't deployed the RHOSO services for cinder yet.

+------------------+------------------------+------+---------+-------+----------------------------+
| Binary           | Host                   | Zone | Status  | State | Updated At                 |
+------------------+------------------------+------+---------+-------+----------------------------+
| cinder-scheduler | standalone.localdomain | nova | enabled | down  | 2024-11-13T14:21:59.000000 |
| cinder-backup    | standalone.localdomain | nova | enabled | down  | 2024-11-13T14:21:59.000000 |
| cinder-volume    | hostgroup@tripleo_ceph | nova | enabled | up    | 2024-11-13T15:34:40.000000 |
| cinder-scheduler | cinder-scheduler-0     | nova | enabled | up    | 2024-11-13T15:34:45.000000 |
| cinder-backup    | cinder-backup-0        | nova | enabled | up    | 2024-11-13T15:34:48.000000 |
+------------------+------------------------+------+---------+-------+----------------------------+