### PR TITLE
Add nftables rules to the TripleO CephStorage nodes

### DIFF
--- a/tests/roles/ceph_migrate/defaults/main.yml
+++ b/tests/roles/ceph_migrate/defaults/main.yml
@@ -30,10 +30,15 @@ ceph_timeout: 30
 # updated
 ceph_wait_mon_timeout: 10
 ceph_keep_mon_ipaddr: true
-ceph_firewall: false
-firewall_path:
+
+# firewall section
+ceph_firewall_enabled: false
+ceph_iptables_path:
   - "/etc/sysconfig/iptables"
   - "/etc/sysconfig/ip6tables"
+ceph_nftables_path:
+  - "/etc/nftables/tripleo-rules.nft"
+ceph_firewall_type: nftables
 
 # DEFAULT Ceph Reef container images
 ceph_haproxy_container_image: "quay.io/ceph/haproxy:2.3"

--- a/tests/roles/ceph_migrate/tasks/firewall.yaml
+++ b/tests/roles/ceph_migrate/tasks/firewall.yaml
@@ -10,29 +10,75 @@
     - iptables
     - nftables
 
-- name: Ceph Migration - Build the list of src and target nodes
-  delegate_to: "{{ node }}"
-  become: true
-  ansible.builtin.blockinfile:
-    marker_begin: "BEGIN ceph firewall rules"
-    marker_end: "END ceph firewall rules"
-    path: "{{ item }}"
-    block: |
-      -A INPUT -p tcp -m tcp --dport 8080 -m conntrack --ctstate NEW -m comment --comment "100 ceph_rgw ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 8090 -m conntrack --ctstate NEW -m comment --comment "101 ceph_rgw ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 8989 -m conntrack --ctstate NEW -m comment --comment "102 ceph_rgw ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 3300 -m conntrack --ctstate NEW -m comment --comment "110 ceph_mon ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 6789 -m conntrack --ctstate NEW -m comment --comment "111 ceph_mon ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 2049 -m conntrack --ctstate NEW -m comment --comment "111 ceph_nfs ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 12049 -m conntrack --ctstate NEW -m comment --comment "111 ceph_nfs_backend ipv4" -j ACCEPT
-      -A INPUT -p tcp -m tcp --dport 6800:7300 -m conntrack --ctstate NEW -m comment --comment "112 ceph_mds_mgr ipv4" -j ACCEPT
-  loop: "{{ firewall_path }}"
+- name: Manage Ceph iptables rules
+  when: ceph_firewall_type == "iptables"
+  block:
+    - name: Ceph Migration - Apply the Ceph cluster rules (iptables)
+      delegate_to: "{{ node }}"
+      become: true
+      ansible.builtin.blockinfile:
+        marker_begin: "BEGIN ceph firewall rules"
+        marker_end: "END ceph firewall rules"
+        path: "{{ item }}"
+        block: |
+          -A INPUT -p tcp -m tcp --dport 8080 -m conntrack --ctstate NEW -m comment --comment "100 ceph_rgw ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 8090 -m conntrack --ctstate NEW -m comment --comment "101 ceph_rgw ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 8989 -m conntrack --ctstate NEW -m comment --comment "102 ceph_rgw ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 3300 -m conntrack --ctstate NEW -m comment --comment "110 ceph_mon ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 6789 -m conntrack --ctstate NEW -m comment --comment "111 ceph_mon ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 2049 -m conntrack --ctstate NEW -m comment --comment "111 ceph_nfs ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 12049 -m conntrack --ctstate NEW -m comment --comment "111 ceph_nfs_backend ipv4" -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 6800:7300 -m conntrack --ctstate NEW -m comment --comment "112 ceph_mds_mgr ipv4" -j ACCEPT
+      loop: "{{ ceph_iptables_path }}"
 
-- name: Ensure firewall is enabled/started
-  when: ceph_firewall | bool | default(false)
-  delegate_to: "{{ node }}"
-  become: true
-  ansible.builtin.systemd:
-    name: iptables
-    state: restarted
-    enabled: true
+    - name: Ensure firewall is enabled/started - iptables
+      when: ceph_firewall_enabled | bool | default(false)
+      delegate_to: "{{ node }}"
+      become: true
+      ansible.builtin.systemd:
+        name: iptables
+        state: restarted
+        enabled: true
+
+- name: Manage Ceph nftables rules
+  when: ceph_firewall_type == "nftables"
+  block:
+    - name: Ceph Migration - Apply the Ceph cluster rules (nftables)
+      delegate_to: "{{ node }}"
+      become: true
+      ansible.builtin.blockinfile:
+        marker_begin: "BEGIN ceph firewall rules"
+        marker_end: "END ceph firewall rules"
+        path: "{{ ceph_nftables_path }}"
+        block: |
+           # 100 ceph_alertmanager {'dport': [9093]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 9093 } ct state new counter accept comment "100 ceph_alertmanager"
+           # 100 ceph_dashboard {'dport': [8444]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 8444 } ct state new counter accept comment "100 ceph_dashboard"
+           # 100 ceph_grafana {'dport': [3100]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 3100 } ct state new counter accept comment "100 ceph_grafana"
+           # 100 ceph_prometheus {'dport': [9092]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 9092 } ct state new counter accept comment "100 ceph_prometheus"
+           # 100 ceph_rgw {'dport': ['8080']}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 8080 } ct state new counter accept comment "100 ceph_rgw"
+           # 110 ceph_mon {'dport': [6789, 3300, '9100']}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 6789,3300,9100 } ct state new counter accept comment "110 ceph_mon"
+           # 112 ceph_mds {'dport': ['6800-7300', '9100']}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 6800-7300,9100 } ct state new counter accept comment "112 ceph_mds"
+           # 113 ceph_mgr {'dport': ['6800-7300', 8444]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 6800-7300,8444 } ct state new counter accept comment "113 ceph_mgr"
+           # 120 ceph_nfs {'dport': ['12049', '2049']}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 2049 } ct state new counter accept comment "120 ceph_nfs"
+           # 122 ceph rgw {'dport': ['8080', '8080', '9100']}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 8080,8080,9100 } ct state new counter accept comment "122 ceph rgw"
+           # 123 ceph_dashboard {'dport': [3100, 9090, 9092, 9093, 9094, 9100, 9283]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 3100,9090,9092,9093,9094,9100,9283 } ct state new counter accept comment "123 ceph_dashboard"
+
+    - name: Ensure firewall is enabled/started - nftables
+      when: ceph_firewall_enabled | bool | default(false)
+      delegate_to: "{{ node }}"
+      become: true
+      ansible.builtin.systemd:
+        name: nftables
+        state: restarted
+        enabled: true


### PR DESCRIPTION
During the `Ceph` migration, `iptables` or `nftables` rules should be properly set. In `TripleO` (17.1.4) there's a switch from `iptables` to `nftables`, and this patch updates the role implementation to manage those rules as well.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/955