### PR TITLE
added known issues module

### DIFF
--- a/docs_user/assemblies/assembly_rhoso-180-adoption-overview.adoc
+++ b/docs_user/assemblies/assembly_rhoso-180-adoption-overview.adoc
@@ -17,6 +17,8 @@ before you adopt your main environment.
 
 include::../modules/con_adoption-limitations.adoc[leveloffset=+1]
 
+include::../modules/con_known-issues-adoption.adoc[leveloffset=+1]
+
 include::../modules/con_adoption-prerequisites.adoc[leveloffset=+1]
 
 include::../modules/con_adoption-guidelines.adoc[leveloffset=+1]

--- a/docs_user/modules/con_known-issues-adoption.adoc
+++ b/docs_user/modules/con_known-issues-adoption.adoc
@@ -9,4 +9,3 @@ Review the following known issues that might affect a successful adoption:
 Red Hat has not verified a process for adoption of a {rhos_prev_long} ({OpenStackShort}) {rhos_prev_ver} environment where Controller and Networker roles are composed together on Controller nodes. If your {OpenStackShort} {rhos_prev_ver} environment does use combined Controller/Networker roles on the Controller nodes, the documented adoption process will not produce the expected results.
 
 Adoption of {OpenStackShort} {rhos_prev_ver} environments that use dedicated Networker nodes has been verified to work as documented.
-

--- a/docs_user/modules/con_known-issues-adoption.adoc
+++ b/docs_user/modules/con_known-issues-adoption.adoc
@@ -1,0 +1,12 @@
+[id="known-issues-adoption_{context}"]
+
+= Known issues
+
+Review the following known issues that might affect a successful adoption:
+
+.Adoption of combined Controller/Networker nodes not verified
+
+Red Hat has not verified a process for adoption of a {rhos_prev_long} ({OpenStackShort}) {rhos_prev_ver} environment where Controller and Networker roles are composed together on Controller nodes. If your {OpenStackShort} {rhos_prev_ver} environment does use combined Controller/Networker roles on the Controller nodes, the documented adoption process will not produce the expected results.
+
+Adoption of {OpenStackShort} {rhos_prev_ver} environments that use dedicated Networker nodes has been verified to work as documented.
+


### PR DESCRIPTION
I added the release notes text in [1] as a known issue under a new "Known issues" heading in the Adoption limitations section of the adoption guide. I added this change upstream in a separate module. I created a doc ticket for that: https://issues.redhat.com/browse/RHOSPDOC-2116

I'll copy the new module downstream after it's merged upstream and remove the known issue from the Adoption limitations section.

[1] https://issues.redhat.com/browse/OSPRH-11301