### PR TITLE
Increase cinder timeout to 180 sec

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -11,7 +11,7 @@
     oc wait pod --for condition=Ready -l component=cinder-api
   register: cinder_api_running
   until: cinder_api_running is success
-  retries: 60
+  retries: 90
   delay: 2
 
 # Ignoring "-o pipefail" to avoid errors in grep which are non-fatal


### PR DESCRIPTION
RHEV job utilizes VMs that are a bit slower. Usually the job fails as

TASK [cinder_adoption : wait for Cinder pods to start up] **********************
Wednesday 13 November 2024  20:28:00 +0000 (0:00:00.071)       0:18:59.868 ****
FAILED - RETRYING: [localhost]: wait for Cinder pods to start up (60 retries left).
...
FAILED - RETRYING: [localhost]: wait for Cinder pods to start up (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 60, "changed": true, "cmd": "set -euxo pipefail\n\nexport KUBECONFIG=~/adoption/kubeconfig\n\noc wait pod --for condition=Ready -l component=cinder-scheduler\noc wait pod --for condition=Ready -l component=cinder-api\n[ -z \"\" ] || oc wait pod --for condition=Ready -l component=cinder-volume\n[ -z \"\" ] || oc wait pod --for condition=Ready -l component=cinder-backup\n", "delta": "0:00:00.216386", "end": "2024-11-13 20:30:29.983085", "msg": "non-zero return code", "rc": 1, "start": "2024-11-13 20:30:29.766699", "stderr": "+ export KUBECONFIG=/home/stack/adoption/kubeconfig\n+ KUBECONFIG=/home/stack/adoption/kubeconfig\n+ oc wait pod --for condition=Ready -l component=cinder-scheduler\nerror: no matching resources found", "stderr_lines": ["+ export KUBECONFIG=/home/stack/adoption/kubeconfig", "+ KUBECONFIG=/home/stack/adoption/kubeconfig", "+ oc wait pod --for condition=Ready -l component=cinder-scheduler", "error: no matching resources found"], "stdout": "", "stdout_lines": []}

This patch increases timeout that should be enough in most of cases even on slow envs. This reduces the chance of failure significantly.