### PR TITLE
Add checks to make the cinder services more reliable

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -14,11 +14,10 @@
   retries: 60
   delay: 2
 
-# Ignoring "-o pipefail" to avoid errors in grep which are non-fatal
 - name: Get cinder-backup down services
   ansible.builtin.shell: |
+    {{ shell_header }}
     {{ oc_header }}
-    set -eux
     oc exec -t openstackclient -- openstack volume service list --service cinder-backup -c Host -f value
   register: backup_down_services
 
@@ -29,11 +28,10 @@
     oc exec -t cinder-api-0 -c cinder-api -- cinder-manage service remove cinder-backup "{{ item }}"
   loop: "{{ backup_down_services.stdout_lines }}"
 
-# Ignoring "-o pipefail" to avoid errors in grep which are non-fatal
 - name: Get cinder-scheduler down services
   ansible.builtin.shell: |
+    {{ shell_header }}
     {{ oc_header }}
-    set -eux
     oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler -c Host -f value
   register: scheduler_down_services
 
@@ -96,7 +94,6 @@
     {{ shell_header }}
     {{ oc_header }}
     alias openstack="oc exec -t openstackclient -- openstack"
-
     ${BASH_ALIASES[openstack]} endpoint list | grep cinder
     ${BASH_ALIASES[openstack]} volume type list
   register: cinder_responding_result

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -137,4 +137,4 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc exec -it cinder-scheduler-0 -- cinder-manage db online_data_migrations
+    oc exec -t cinder-api-0 -c cinder-api -- cinder-manage db online_data_migrations

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -14,6 +14,18 @@
   retries: 60
   delay: 2
 
+- name: check that Cinder is reachable and its endpoints are defined
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    alias openstack="oc exec -t openstackclient -- openstack"
+    ${BASH_ALIASES[openstack]} endpoint list | grep cinder
+    ${BASH_ALIASES[openstack]} volume type list
+  register: cinder_responding_result
+  until: cinder_responding_result is success
+  retries: 60
+  delay: 2
+
 - name: Get cinder-backup down services
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -88,18 +100,6 @@
   when: cinder_volume_backend | default('') != '' or cinder_backup_backend | default('') != ''
   ansible.builtin.pause:
      seconds: 90
-
-- name: check that Cinder is reachable and its endpoints are defined
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
-    ${BASH_ALIASES[openstack]} endpoint list | grep cinder
-    ${BASH_ALIASES[openstack]} volume type list
-  register: cinder_responding_result
-  until: cinder_responding_result is success
-  retries: 60
-  delay: 2
 
 - name: wait for Cinder volume to be up and ready
   when: cinder_volume_backend != ''

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -101,6 +101,16 @@
   ansible.builtin.pause:
      seconds: 90
 
+- name: wait for Cinder scheduler to be up and ready
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler | grep ' up '
+  register: cinder_scheduler_running_result
+  until: cinder_scheduler_running_result is success
+  retries: 5
+  delay: 2
+
 - name: wait for Cinder volume to be up and ready
   when: cinder_volume_backend != ''
   ansible.builtin.shell: |

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -105,7 +105,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler | grep ' up '
+    oc exec -t openstackclient -- openstack volume service list --service cinder-scheduler -c State -f value | grep 'up'
   register: cinder_scheduler_running_result
   until: cinder_scheduler_running_result is success
   retries: 5
@@ -116,7 +116,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc exec -t openstackclient -- openstack volume service list --service cinder-volume | grep ' up '
+    oc exec -t openstackclient -- openstack volume service list --service cinder-volume -c State -f value | grep 'up'
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 5
@@ -127,7 +127,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc exec -t openstackclient -- openstack volume service list --service cinder-backup | grep ' up '
+    oc exec -t openstackclient -- openstack volume service list --service cinder-backup -c State -f value | grep 'up'
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 5


### PR DESCRIPTION
This PR has 5 commits:
1. use shell_header instead of custom 'set -eux' command
2. Move the cinder endpoint check to beginning (before fetching old services)
3. Wait for cinder-scheduler to report 'up' in cinder services DB
4. Run the online data migration from cinder-api (to be consistent)
5. update the service 'up' check to use raw strings instead of grepping from OSC output

Jira: https://issues.redhat.com/browse/OSPCIX-564