### PR TITLE
[ovn_adoption] Add Ignore not found in cleanup handler

### DIFF
--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -238,8 +238,8 @@ Running OVN gateways on {OpenShiftShort} nodes might be prone to data plane down
 . Delete the `ovn-data` helper pod and the temporary `PersistentVolumeClaim` that is used to store OVN database backup files:
 +
 ----
-$ oc delete pod ovn-copy-data
-$ oc delete pvc ovn-data
+$ oc delete --ignore-not-found=true pod ovn-copy-data
+$ oc delete --ignore-not-found=true pvc ovn-data
 ----
 +
 [NOTE]

--- a/tests/roles/ovn_adoption/handlers/main.yaml
+++ b/tests/roles/ovn_adoption/handlers/main.yaml
@@ -2,7 +2,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc delete pod -n {{ org_namespace }} ovn-copy-data
-    oc delete certificate -n {{ org_namespace }} ovn-data-cert
-    oc delete secret -n {{ org_namespace }} ovn-data-cert
-    {% if storage_reclaim_policy.lower() == "delete" %}oc delete pvc -n {{ org_namespace }} ovn-data{% endif %}
+    oc delete --ignore-not-found=true pod -n {{ org_namespace }} ovn-copy-data
+    oc delete --ignore-not-found=true certificate -n {{ org_namespace }} ovn-data-cert
+    oc delete --ignore-not-found=true secret -n {{ org_namespace }} ovn-data-cert
+    {% if storage_reclaim_policy.lower() == "delete" %}oc delete pvc --ignore-not-found=true -n {{ org_namespace }} ovn-data{% endif %}


### PR DESCRIPTION
During rollback role these are cleaned so ovn_adoption handler fails as the resources already cleaned up, adding ignore-not-found for these.