### PR TITLE
Add conditions on ironic node enroll and chrony restart

### DIFF
--- a/tests/playbooks/test_with_ironic.yaml
+++ b/tests/playbooks/test_with_ironic.yaml
@@ -26,6 +26,7 @@
   vars:
     ironic_adoption: true
     nova_libvirt_backend: local
+    prelaunch_test_instance_script: pre_launch_ironic.bash
   roles:
     - role: development_environment
     - role: backend_services

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -24,3 +24,5 @@ supported_backup_backends: []
 # override var for openstack command to use on the source cloud
 openstack_command: >-
   ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no {{ source_osp_ssh_user }}@{{ standalone_ip | default(edpm_node_ip) }} OS_CLOUD={{ os_cloud_name }} openstack
+enroll_ironic_bmaas_nodes: true
+pre_launch_ironic_restart_chrony: true

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -10,6 +10,8 @@
       export OPENSTACK_COMMAND="{{ openstack_command }}"
       export CINDER_VOLUME_BACKEND_CONFIGURED={{ cinder_volume_backend_configured | string | lower }}
       export CINDER_BACKUP_BACKEND_CONFIGURED={{ cinder_backup_backend_configured | string | lower }}
+      export ENROLL_BMAAS_IRONIC_NODES={{ enroll_ironic_bmaas_nodes | string | lower }}
+      export PRE_LAUNCH_IRONIC_RESTART_CHRONY={{ pre_launch_ironic_restart_chrony | string | lower }}
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
 
 - name: Start and setup ping test


### PR DESCRIPTION
The node enroll is depending on install_yamls makefile targets, these cannot be used when adopting ci-framework deployed virtual infrastructure.

Also add a condition on the chrony restart which is required when a snapshot of standalone OSP VM.

Jira: OSPRH-12093