### PR TITLE
Set alias openstack in pre_launch_ironic.bash

### DIFF
--- a/tests/roles/development_environment/files/pre_launch_ironic.bash
+++ b/tests/roles/development_environment/files/pre_launch_ironic.bash
@@ -1,5 +1,7 @@
 set -e
 
+alias openstack="$OPENSTACK_COMMAND"
+
 function wait_node_state() {
   local node_state=$1
   local retries=50


### PR DESCRIPTION
The alias set up was moved from the ansible.builtin.shell tasks, to the pre_launch bash scipts in #592. The pre_launch_ironic.bash script was not updated.