### PR TITLE
Create separate VM/FIP for ping test

### DIFF
--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -95,6 +95,18 @@ ${BASH_ALIASES[openstack]} server show test || {
     ${BASH_ALIASES[openstack]} server add floating ip test 192.168.122.20
 }
 
+if [ "$PING_TEST_VM" = "true" ]; then
+    # Create a floating IP
+    ${BASH_ALIASES[openstack]} floating ip show 192.168.122.21 || \
+        ${BASH_ALIASES[openstack]} floating ip create public --floating-ip-address 192.168.122.21
+
+    # Create a test-ping instance
+    ${BASH_ALIASES[openstack]} server show test-ping || {
+      ${BASH_ALIASES[openstack]} server create --flavor m1.small --image cirros --nic net-id=private test-ping --wait
+      ${BASH_ALIASES[openstack]} server add floating ip test-ping 192.168.122.21
+    }
+fi
+
 # Create security groups
 ${BASH_ALIASES[openstack]} security group rule list --protocol icmp --ingress -f json | grep -q '"IP Range": "0.0.0.0/0"' || \
     ${BASH_ALIASES[openstack]} security group rule create --protocol icmp --ingress --icmp-type -1 $(${BASH_ALIASES[openstack]} security group list --project admin -f value -c ID)

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -12,6 +12,7 @@
       export CINDER_BACKUP_BACKEND_CONFIGURED={{ cinder_backup_backend_configured | string | lower }}
       export ENROLL_BMAAS_IRONIC_NODES={{ enroll_ironic_bmaas_nodes | string | lower }}
       export PRE_LAUNCH_IRONIC_RESTART_CHRONY={{ pre_launch_ironic_restart_chrony | string | lower }}
+      export PING_TEST_VM={{ ping_test | string | lower }}
       {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
 
 - name: Start and setup ping test
@@ -21,7 +22,7 @@
   block:
     - name: Start the ping test to the VM instance.
       vars:
-        fip: 192.168.122.20
+        fip: 192.168.122.21
       ansible.builtin.shell:
         cmd: |
           ping -D {{ fip }} &> {{ ping_test_log_file }} &


### PR DESCRIPTION
Ping test is using the same vm used during nova
vm stop/start verification and that makes the ping test to fail.
We should not use the same vm for ping test.
With this patch we create a dedicated vm/fip
when ping test is enabled.

Related-Issue: #OSPRH-12246