### PR TITLE
Uni01alpha ironic inspect subnet ranges

### DIFF
--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -85,8 +85,8 @@ parameter_defaults:
   # this value 'uni01alpha'.
   IronicInspectorSubnets:
     osp-controller-uni01alpha-0:
-      - ip_range: 172.20.0.210,172.20.0.219
+      - ip_range: 172.20.1.210,172.20.1.219
     osp-controller-uni01alpha-1:
-      - ip_range: 172.20.0.220,172.20.0.229
+      - ip_range: 172.20.1.220,172.20.1.229
     osp-controller-uni01alpha-2:
-      - ip_range: 172.20.0.230,172.20.0.239
+      - ip_range: 172.20.1.230,172.20.1.239

--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -79,3 +79,14 @@ parameter_defaults:
         host_routes: []
         name: ctlplane-subnet
         ip_version: 4
+  IronicInspectorInterface: br-baremetal
+  # Since we need predictable node names to be able to set this paremeter,
+  # it a requirement to set the ci-framework parameter cifmw_run_id with
+  # this value 'uni01alpha'.
+  IronicInspectorSubnets:
+    osp-controller-uni01alpha-0:
+      - ip_range: 172.20.0.210,172.20.0.219
+    osp-controller-uni01alpha-1:
+      - ip_range: 172.20.0.220,172.20.0.229
+    osp-controller-uni01alpha-2:
+      - ip_range: 172.20.0.230,172.20.0.239

--- a/scenarios/uni01alpha/network_data.yaml.j2
+++ b/scenarios/uni01alpha/network_data.yaml.j2
@@ -55,5 +55,5 @@
     ironic_subnet:
       ip_subnet: 172.20.0.0/24
       allocation_pools:
-        - start: 172.20.0.200
-          end: 172.20.0.250
+        - start: 172.20.0.150
+          end: 172.20.0.200

--- a/scenarios/uni01alpha/network_data.yaml.j2
+++ b/scenarios/uni01alpha/network_data.yaml.j2
@@ -53,7 +53,7 @@
   dns_domain: ironic.{{ cloud_domain }}.
   subnets:
     ironic_subnet:
-      ip_subnet: 172.20.0.0/24
+      ip_subnet: 172.20.1.0/24
       allocation_pools:
-        - start: 172.20.0.150
-          end: 172.20.0.200
+        - start: 172.20.1.150
+          end: 172.20.1.200


### PR DESCRIPTION
This is using static hostnames to give separate ranges for the 3 OSP controllers. To have the predictable node name the ci-framework must run with a static "run_id" i.e `cifmw_run_id: uni01alpha` must be set in the scenario env.
