### PR TITLE
Add Barbican to OSP17.1 scenarios tested for adoption

### DIFF
--- a/scenarios/hci.yaml
+++ b/scenarios/hci.yaml
@@ -55,6 +55,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/cephadm/ceph-mds.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/services/barbican.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/barbican-backend-simple-crypto.yaml"
     network_data_file: "hci/network_data.yaml.j2"
     vips_data_file: "hci/vips_data.yaml"
     roles_file: "hci/roles.yaml"

--- a/scenarios/hci/config_download.yaml
+++ b/scenarios/hci/config_download.yaml
@@ -47,6 +47,7 @@ parameter_defaults:
   ComputeExtraConfig:
     nova::compute::libvirt::services::libvirt_virt_type: qemu
     nova::compute::libvirt::virt_type: qemu
+  BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni01alpha.yaml
+++ b/scenarios/uni01alpha.yaml
@@ -55,6 +55,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/services/ironic-overcloud.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/services/ironic-inspector.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/services/barbican.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/barbican-backend-simple-crypto.yaml"
     network_data_file: "uni01alpha/network_data.yaml.j2"
     vips_data_file: "uni01alpha/vips_data.yaml"
     roles_file: "uni01alpha/roles.yaml"

--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -46,6 +46,7 @@ parameter_defaults:
   ComputeExtraConfig:
     nova::compute::libvirt::services::libvirt_virt_type: qemu
     nova::compute::libvirt::virt_type: qemu
+  BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman


### PR DESCRIPTION
Add Barbican to all already existing OSP17.1 adoption scenarios. 
Barbican needs to be enabled by default in any future scenario.