### PR TITLE
uni01alpha - neutron conf + ironic post oc hook

### DIFF
--- a/scenarios/uni01alpha.yaml
+++ b/scenarios/uni01alpha.yaml
@@ -63,3 +63,7 @@ stacks:
       - osp-computes
       - osp-controllers
       - osp-networkers
+    post_oc_run:
+      - name: Ironic post overcloud deploy
+        type: playbook
+        source: adoption_ironic_post_oc.yml

--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -79,6 +79,12 @@ parameter_defaults:
         host_routes: []
         name: ctlplane-subnet
         ip_version: 4
+  NeutronFlatNetworks:
+    - datacentre
+    - baremetal
+  NeutronBridgeMappings:
+    - datacentre:br-ex
+    - baremetal:br-baremetal
   IronicInspectorInterface: br-baremetal
   # Since we need predictable node names to be able to set this paremeter,
   # it a requirement to set the ci-framework parameter cifmw_run_id with


### PR DESCRIPTION
Set neutron config - NeutronFlatNetworks and NeutronBridgeMappings.

Run Ironic post overcloud deploy hook after deploying OSP 17.1.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2602

JIRA: OSPRH-12423