### PR TITLE
adoption uni01alpha - ironic ServiceNetMap

### DIFF
--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -10,6 +10,7 @@ resource_registry:
   OS::TripleO::Controller::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
   OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
   OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::Controller::Ports::IronicPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_ironic.yaml
   OS::TripleO::Networker::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
   OS::TripleO::Networker::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
   OS::TripleO::Services::CeilometerAgentCentral: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-central-container-puppet.yaml
@@ -96,3 +97,7 @@ parameter_defaults:
       - ip_range: 172.20.1.220,172.20.1.229
     osp-controller-uni01alpha-2:
       - ip_range: 172.20.1.230,172.20.1.239
+  ServiceNetMap:
+    IronicApiNetwork: ironic
+    IronicNetwork: ironic
+    IronicInspectorNetwork: ironic

--- a/scenarios/uni01alpha/network_data.yaml.j2
+++ b/scenarios/uni01alpha/network_data.yaml.j2
@@ -49,7 +49,8 @@
 
 - name: Ironic
   mtu: 1500
-  name_lower: Ironic
+  vip: true
+  name_lower: ironic
   dns_domain: ironic.{{ cloud_domain }}.
   subnets:
     ironic_subnet:

--- a/scenarios/uni01alpha/roles.yaml
+++ b/scenarios/uni01alpha/roles.yaml
@@ -20,6 +20,8 @@
       subnet: storage_subnet
     Tenant:
       subnet: tenant_subnet
+    Ironic:
+      subnet: ironic_subnet
   # For systems with both IPv4 and IPv6, you may specify a gateway network for
   # each, such as ['ControlPlane', 'External']
   default_route_networks: ['ControlPlane']

--- a/scenarios/uni01alpha/vips_data.yaml
+++ b/scenarios/uni01alpha/vips_data.yaml
@@ -12,3 +12,7 @@
   ip_address: 192.168.122.100
   subnet: ctlplane-subnet
   dns_name: overcloud
+- name: ironic_vip
+  network: ironic
+  ip_address: 172.20.1.99
+  subnet: ironic_subnet


### PR DESCRIPTION
Set the ServiceNetMap overrides for the ironic service.

Also make the name_lower for the ironic network all lowercase.