### PR TITLE
fixed broken link

### DIFF
--- a/docs_user/modules/proc_migrating-the-rgw-backends.adoc
+++ b/docs_user/modules/proc_migrating-the-rgw-backends.adoc
@@ -167,4 +167,4 @@ global   basic rgw_keystone_url  http://172.16.1.111:5000
 [ceph: root@controller-0 /]# ceph config set global rgw_keystone_url http://<keystone_endpoint>:5000
 ----
 +
-* Replace `<keystone_endpoint>` with the {identity_service_first_ref} internal endpoint of the service that is deployed in the `OpenStackControlPlane` CR when you adopt the {identity_service}.  For more information, see xref: adopting-the-identity-service_adopt-control-plane[Adopting the {identity_service}].
+* Replace `<keystone_endpoint>` with the {identity_service_first_ref} internal endpoint of the service that is deployed in the `OpenStackControlPlane` CR when you adopt the {identity_service}. For more information, see xref:adopting-the-identity-service_adopt-control-plane[Adopting the {identity_service}].


### PR DESCRIPTION
There was a typo in a cross-reference, so the link did not render correctly in the docs.