### PR TITLE
Add static routes to netConfig to support scenario A

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -35,6 +35,11 @@
     file: ospdo.yaml
   when: ospdo_src| bool
 
+- name: Override netconfig_networks if netconfig_networks_override is defined
+  ansible.builtin.set_fact:
+    netconfig_networks: "{{ netconfig_networks_override }}"
+  when: netconfig_networks_override is defined
+
 - name: ensure IPAM is configured
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
Adopting a workload using scenario A (different subnet ranges between wallaby CP and next-gen CP) wont succeed if netConfig doesn't have the routes to reach old CP.

Relates: [OSPRH-7544](https://issues.redhat.com//browse/OSPRH-7544)