### PR TITLE
ovn: Always set replicas=3 for ovn dbs

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -321,9 +321,11 @@ ifeval::["{OpenStackPreviousInstaller}" != "director_operator"]
         replicas: 0
       ovnDBCluster:
         ovndbcluster-nb:
+          replicas: 3
           dbType: NB
           networkAttachment: internalapi
         ovndbcluster-sb:
+          replicas: 3
           dbType: SB
           networkAttachment: internalapi
 endif::[]
@@ -336,9 +338,11 @@ ifeval::["{OpenStackPreviousInstaller}" == "director_operator"]
         replicas: 0
       ovnDBCluster:
         ovndbcluster-nb:
+          replicas: 3
           dbType: NB
           networkAttachment: <networkAttachment_name>
         ovndbcluster-sb:
+          replicas: 3
           dbType: SB
           networkAttachment: <networkAttachment_name>
 endif::[]

--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -176,10 +176,12 @@ spec:
     template:
       ovnDBCluster:
         ovndbcluster-nb:
+          replicas: 3
           dbType: NB
           storageRequest: 10G
           networkAttachment: internalapi
         ovndbcluster-sb:
+          replicas: 3
           dbType: SB
           storageRequest: 10G
           networkAttachment: internalapi

--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -108,9 +108,11 @@ spec:
         replicas: 0
       ovnDBCluster:
         ovndbcluster-nb:
+          replicas: 3
           dbType: NB
           networkAttachment: internalapi
         ovndbcluster-sb:
+          replicas: 3
           dbType: SB
           networkAttachment: internalapi
 

--- a/tests/roles/backend_services/templates/openstack_control_plane_ospdo.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane_ospdo.j2
@@ -102,11 +102,13 @@ spec:
     template:
       ovnDBCluster:
         ovndbcluster-nb:
+          replicas: 3
           dbType: NB
           storageClass: {{ ospdo_storage_class.stdout }}
           storageRequest: 10G
           networkAttachment: internalapi{{ osp18_ns_suffix }}
         ovndbcluster-sb:
+          replicas: 3
           storageClass: {{ ospdo_storage_class.stdout }}
           dbType: SB
           storageRequest: 10G

--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -10,10 +10,12 @@ ovs_db_patch: |
       template:
         ovnDBCluster:
           ovndbcluster-nb:
+            replicas: 3
             dbType: NB
             storageRequest: 10G
             networkAttachment: internalapi
           ovndbcluster-sb:
+            replicas: 3
             dbType: SB
             storageRequest: 10G
             networkAttachment: internalapi


### PR DESCRIPTION
The expected configuration should always be multi-member raft cluster.