### PR TITLE
Adjust external network to match HCI greenfield

### DIFF
--- a/scenarios/hci/network_data.yaml.j2
+++ b/scenarios/hci/network_data.yaml.j2
@@ -56,5 +56,5 @@
   subnets:
     external_subnet:
       vlan: 44
-      ip_subnet: '172.21.0.0/24'
-      allocation_pools: [{'start': '172.21.0.120', 'end': '172.21.0.250'}]
+      ip_subnet: '10.0.0.0/24'
+      allocation_pools: [{'start': '10.0.0.150', 'end': '10.0.0.250'}]


### PR DESCRIPTION
OSP17.1 external network should mathc external network defined for RHOSO18 greenfield[1]

Depends-On:https://github.com/openstack-k8s-operators/ci-framework/pull/2662

[1]https://github.com/openstack-k8s-operators/architecture/blob/e5a762d0fc0217efb98c7b603ea2466d0e66cebd/examples/va/hci/control-plane/nncp/values.yaml#L165