### PR TITLE
Fix pre-commit config and ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,7 @@
 profile: production
 exclude_paths:
+    - .venv/
+    - .github/ # Not Ansible, just YAML
     - mkdocs.yml
     - docs/
     - tests/config/
@@ -12,6 +14,7 @@ skip_list:
     - name[casing] # do we want that one for consistency? maybe?
     - no-changed-when # any point adding changed_when: false in all our shell?
     - command-instead-of-shell
+    - jinja[spacing]  # We don't really want to get that one. Too picky
 strict: false
 quiet: false
 verbosity: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
     hooks:
       - id: ansible-lint
         entry: env ANSIBLE_ROLES_PATH=./tests/roles:$ANSIBLE_ROLES_PATH ANSIBLE_LIBRARY=./tests/plugins/modules:$ANSIBLE_LIBRARY ansible-lint
+        additional_dependencies:
+          - jmespath
   - repo: https://github.com/openstack-dev/bashate.git
     rev: 2.1.1
     hooks:


### PR DESCRIPTION
Add skip jinja spacing error detection in ansible-lint linting Add missing jmespath dependecies required by ansible-lint to lint tasks using json filter.

Jira: [OSPRH-11188](https://issues.redhat.com//browse/OSPRH-11188)