### PR TITLE
CI changes backport 18.0 fr1 

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: tools
+  namespace: openstack-k8s-operators
+  tag: ci-build-root-golang-1.21-sdk-1.31

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,5 @@
 name: Build Docs
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
 name: Linting
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,17 @@
+---
+name: Manage stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: |
+            This PR is stale because it has been for over 15 days with no activity.
+            Remove stale label or comment or this PR will be closed in 7 days.
+          days-before-pr-stale: 15
+          days-before-pr-close: 7

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,6 +1,6 @@
 ---
 name: Manage stale PRs
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '30 1 * * *'
 

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,13 @@
+---
+extends: default
+ignore:
+  - '*.md'
+  - 'zuul.d/'
+
+rules:
+  line-length:
+    max: 256
+    level: warning
+  document-start: disable
+  comments: disable
+  comments-indentation: disable

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,19 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - jistr
+  - archana203
+  - ciecierski
+  - frenzyfriday
+  - holser
+  - sathlan
+
+reviewers:
+  - archana203
+  - ciecierski
+  - fao89
+  - frenzyfriday
+  - holser
+  - jistr
+  - klgill
+  - pinikomarov
+  - sathlan


### PR DESCRIPTION
This PR backports https://github.com/openstack-k8s-operators/data-plane-adoption/pull/681 and https://github.com/openstack-k8s-operators/data-plane-adoption/pull/741 to unblock cheery-pick bot on 18.0-fr1 branch