### PR TITLE
Add make openstack_init to adoption docs

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -321,6 +321,7 @@ cd ..  # back to install_yamls
 make crc_storage
 make input
 make openstack
+make openstack_init
 ----
 
 '''

--- a/docs_user/modules/proc_preparing-RHOSO-for-director-operator-adoption.adoc
+++ b/docs_user/modules/proc_preparing-RHOSO-for-director-operator-adoption.adoc
@@ -312,6 +312,7 @@ $ oc get secret tripleo-passwords -n $OSPDO_NAMESPACE -o json | jq -r '.data["tr
 $ git clone https://github.com/openstack-k8s-operators/install_yamls.git
 cd install_yamls
 BMO_SETUP=false NETWORK_ISOLATION=false NAMESPACE=${RHOSO18_NAMESPACE} make openstack
+BMO_SETUP=false NETWORK_ISOLATION=false NAMESPACE=${RHOSO18_NAMESPACE} make openstack_init
 BMO_SETUP=false NETWORK_ISOLATION=false make metallb
 ----
 


### PR DESCRIPTION
This recently needed step is not present on adoption docs.
(Added in https://github.com/openstack-k8s-operators/install_yamls/commit/7cdfc5f1fbc996514d3d128a4f908f2c992d903d)