### PR TITLE
Per-role NeutronBridgeMappings - uni01alpha scenario

### DIFF
--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -83,11 +83,11 @@ parameter_defaults:
         ip_version: 4
   NeutronFlatNetworks:
     - datacentre
-    - baremetal
+    - ironic
   ControllerParameters:
     NeutronBridgeMappings:
       - datacentre:br-ex
-      - baremetal:br-baremetal
+      - ironic:br-baremetal
   NetworkerParameters:
     NeutronBridgeMappings:
       - datacentre:br-ex

--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -84,9 +84,16 @@ parameter_defaults:
   NeutronFlatNetworks:
     - datacentre
     - baremetal
-  NeutronBridgeMappings:
-    - datacentre:br-ex
-    - baremetal:br-baremetal
+  ControllerParameters:
+    NeutronBridgeMappings:
+      - datacentre:br-ex
+      - baremetal:br-baremetal
+  NetworkerParameters:
+    NeutronBridgeMappings:
+      - datacentre:br-ex
+  ComputeParameters:
+    NeutronBridgeMappings:
+      - datacentre:br-ex
   IronicInspectorInterface: br-baremetal
   # Since we need predictable node names to be able to set this paremeter,
   # it a requirement to set the ci-framework parameter cifmw_run_id with

--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -34,7 +34,7 @@ ovn_nic_mapping_patch: |
       template:
         ovnController:
           nicMappings:
-            baremetal: baremetal
+            ironic: baremetal
 
 dpa_dir: "../.."
 dpa_tests_dir: "{{ dpa_dir }}/tests"


### PR DESCRIPTION
Controllers, Computes and Networker nodes are not connected to the same physical networks in the uni01alpha scenario. Only controllers have the `br-baremetal` interface.

This change set's NeutronBridgeMappings per-role so that configuration on the nodes in different roles match the attached interfaces.