### PR TITLE
Disable pcp_cleanup by default

### DIFF
--- a/tests/roles/pcp_cleanup/defaults/main.yaml
+++ b/tests/roles/pcp_cleanup/defaults/main.yaml
@@ -1,5 +1,5 @@
 # Whether the cleanup should be run or not.
-pcp_cleanup_enabled: true
+pcp_cleanup_enabled: false
 
 # Whether 'make crc_storage_cleanup' + 'make crc_storage' should be
 # run before running the test suite.


### PR DESCRIPTION
pcp_cleanup_enabled should be set to false by default. In most jobs there are no remains of podified deployment as we do greenfield deployment, not re-using enviroment.