### PR TITLE
Change status of pvs from Released to Available

### DIFF
--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -28,6 +28,11 @@
       oc delete ${secret} -n openstack;
     done
 
+    # Make pvs available if they are released
+    oc get pv -o json | jq -r '.items[] | select(.status.phase == "Released") | .metadata.name' | \
+      xargs -I{} oc patch pv {} --type='merge' -p '{"spec":{"claimRef": null}}'
+
+    # Delete IT certificates
     oc delete --ignore-not-found issuer rootca-internal
     oc delete --ignore-not-found secret rootca-internal
 


### PR DESCRIPTION
During clean up we should change status to available and rely on reclaim policies of pvs. If pv policy is Delete so all data will be deleted. This helps not to produces tons of "Released" pvs on recurrent reinstallation processes of RHOSO

Related-Bug: [OSPRH-13619](https://issues.redhat.com//browse/OSPRH-13619)