### PR TITLE
Run the online data migrations from cinder-api

### DIFF
--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -130,4 +130,4 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc exec -it cinder-scheduler-0 -- cinder-manage db online_data_migrations
+    oc exec -t cinder-api-0 -c cinder-api -- cinder-manage db online_data_migrations


### PR DESCRIPTION
We currently have a mix of using cinder-api and cinder-scheduler pods/containers to run cinder-manage commands whereas it should be better to be consistent.
This patch updates the online data migrations task to be run by cinder-api.

(cherry picked from commit 39e5aa9bf472a17f253043a189b55ece6d01eab2)