### PR TITLE
Neutron-sriov-nic-agent agent enablement on edpm is optional and disabled

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -150,7 +150,7 @@ edpm_network_config_template: |
 neutron_physical_bridge_name: br-ctlplane
 neutron_public_interface_name: "{{ dataplane_public_iface | default('eth0') }}"
 edpm_sshd_allowed_ranges: "{{ ['192.168.122.0/24'] if dataplane_os_net_config_set_route|default(true)|bool else ['0.0.0.0/0'] }}"
-edpm_neutron_sriov_agent_enabled: true
+edpm_neutron_sriov_agent_enabled: false
 edpm_neutron_dhcp_agent_enabled: true
 nova_libvirt_backend: local
 skip_patching_ansibleee_csv: false


### PR DESCRIPTION
edpm_neutron_sriov_agent_enabled should be set to false by default. It is optional step in documentation and should only required when agents are running on OSP deployment.