### PR TITLE
Change IP of undercloud VIP to not overlap with overcloud VIP

### DIFF
--- a/scenarios/hci.yaml
+++ b/scenarios/hci.yaml
@@ -21,7 +21,7 @@ undercloud:
       value: false
   undercloud_parameters_override: "hci/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "hci/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.99
+  ctlplane_vip: 192.168.122.98
 cloud_domain: "localdomain"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for


### PR DESCRIPTION
There is IP overlap in hci scenario which prevents communication from undercloud to overcloud VIP.
This overlap blocks running tempest started from undercloud against overcloud cloud.


Related: [OSPRH-10686](https://issues.redhat.com//browse/OSPRH-10686)

Previous IP is used in https://github.com/openstack-k8s-operators/data-plane-adoption/blob/6afb8d5086f98cc5c7ecbe50b31283938a91e1d2/scenarios/hci/vips_data.yaml#L20 