### PR TITLE
Bump Cirros version to 0.6.3

### DIFF
--- a/docs_user/modules/proc_adopting-image-service-with-nfs-backend.adoc
+++ b/docs_user/modules/proc_adopting-image-service-with-nfs-backend.adoc
@@ -165,11 +165,11 @@ sh-5.1# mount
 $ oc rsh openstackclient
 $ openstack image list
 
-sh-5.1$  curl -L -o /tmp/cirros-0.5.2-x86_64-disk.img http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
+sh-5.1$  curl -L -o /tmp/cirros-0.6.3-x86_64-disk.img http://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img
 ...
 ...
 
-sh-5.1$ openstack image create --container-format bare --disk-format raw --file /tmp/cirros-0.5.2-x86_64-disk.img cirros
+sh-5.1$ openstack image create --container-format bare --disk-format raw --file /tmp/cirros-0.6.3-x86_64-disk.img cirros
 ...
 ...
 

--- a/docs_user/modules/proc_verifying-the-image-service-adoption.adoc
+++ b/docs_user/modules/proc_verifying-the-image-service-adoption.adoc
@@ -68,9 +68,9 @@ ifeval::["{build}" != "downstream"]
 +
 ----
 (openstack)$ alias openstack="oc exec -t openstackclient -- openstack"
-(openstack)$ curl -L -o /tmp/cirros-0.5.2-x86_64-disk.img http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
-    qemu-img convert -O raw /tmp/cirros-0.5.2-x86_64-disk.img /tmp/cirros-0.5.2-x86_64-disk.img.raw
-    openstack image create --container-format bare --disk-format raw --file /tmp/cirros-0.5.2-x86_64-disk.img.raw cirros2
+(openstack)$ curl -L -o /tmp/cirros-0.6.3-x86_64-disk.img http://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img
+    qemu-img convert -O raw /tmp/cirros-0.6.3-x86_64-disk.img /tmp/cirros-0.6.3-x86_64-disk.img.raw
+    openstack image create --container-format bare --disk-format raw --file /tmp/cirros-0.6.3-x86_64-disk.img.raw cirros2
     openstack image list
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed

--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -56,8 +56,8 @@ function create_bfv_volume() {
 }
 
 # Create Image
-IMG=cirros-0.5.2-x86_64-disk.img
-URL=http://download.cirros-cloud.net/0.5.2/$IMG
+IMG=cirros-0.6.3-x86_64-disk.img
+URL=http://download.cirros-cloud.net/0.6.3/$IMG
 DISK_FORMAT=qcow2
 RAW=$IMG
 curl -L -# $URL > /tmp/$IMG


### PR DESCRIPTION
Cirros 0.5.2 has an issue upon ssh connection to the node due to ssh ciph libraries incompatibilities. When you try to access cirros it fails as

(default) [ospng@node data-plane-adoption]$ ssh cirros@192.168.122.20 Connection closed by 192.168.122.20 port 22

This bug is described at [1]. This patch bumps Cirros version so developers can access test workload before and after adoption for testing.

[1] https://access.redhat.com/solutions/7046656