### PR TITLE
Create libvirt-secret to when TLS-e is enabled

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -148,6 +148,30 @@ oc get secret nova-migration-ssh-key || oc create secret generic nova-migration-
 rm -f id*
 cd -
 ----
++
+
+. If TLS Everywhere is enabled, set LIBVIRT_PASSWORD to match the existing {OpenStackShort} deployment password:
++
+----
+declare -A TRIPLEO_PASSWORDS
+TRIPLEO_PASSWORDS[default]="$HOME/overcloud-passwords.yaml"
+LIBVIRT_PASSWORD=$(cat ${TRIPLEO_PASSWORDS[default]} | grep ' LibvirtTLSPassword:' | awk -F ': ' '{ print $2; }')
+LIBVIRT_PASSWORD_BASE64=$(echo -n "$LIBVIRT_PASSWORD" | base64)
+----
+* Create libvirt-secret when TLS-e is enabled.
+[source,yaml]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: libvirt-secret
+  namespace: openstack
+type: Opaque
+data:
+  LibvirtPassword: ${LIBVIRT_PASSWORD_BASE64}
+EOF
+----
 
 . If you use a local storage back end for libvirt, create a `nova-compute-extra-config` service to remove pre-fast-forward workarounds and configure Compute services to use a local storage back end:
 +

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -4,6 +4,7 @@ supported_backup_backends: []
 supported_volume_backends: []
 edpm_networker_deploy: false
 configure_ipam: true
+libvirt_password: ''
 netconfig_networks:
   - name: ctlplane
     dnsDomain: ctlplane.example.com

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -92,6 +92,25 @@
     rm -f id*
     cd -
 
+- name: create libvirt-secret
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+        name: libvirt-secret
+        namespace: {{ rhoso_namespace }}
+    type: Opaque
+    data:
+      LibvirtPassword: {{ libvirt_password | b64encode }}
+    EOF
+  when:
+    - not ospdo_src| bool
+    - libvirt_password | length > 0
+
 - name: create a Nova Compute Extra Config service (no ceph backend in use)
   when:
     - compute_adoption|bool

--- a/tests/secrets.sample.yaml
+++ b/tests/secrets.sample.yaml
@@ -29,6 +29,7 @@ nova_password: "{{ lookup('file', tripleo_passwords['default']) | from_yaml | co
 octavia_password: "{{ lookup('file', tripleo_passwords['default']) | from_yaml | community.general.json_query('*.OctaviaPassword') | first }}"
 placement_password: "{{ lookup('file', tripleo_passwords['default']) | from_yaml | community.general.json_query('*.PlacementPassword') | first }}"
 swift_password: "{{ lookup('file', tripleo_passwords['default']) | from_yaml | community.general.json_query('*.SwiftPassword') | first }}"
+libvirt_password: "{{ lookup('file', tripleo_passwords['default']) | from_yaml | community.general.json_query('*.LibvirtTLSPassword') | first }}"
 
 # FreeIPA SSH connection strings for importing the CA certificate and key
 ipa_ssh: "ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 podman exec -ti freeipa-server-container"


### PR DESCRIPTION
When TLS-e is on libvirt requires authentication. This patch describes how to extract LIBVIRT_PASSWORD from file and create a secret with the same password on EDPM node when TLS-e is enabled

Closes-Bug: [OSPRH-13479](https://issues.redhat.com//browse/OSPRH-13479)