### PR TITLE
Fix Octavia SSH adoption doc

### DIFF
--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -24,7 +24,7 @@ $ CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed 's/^ssh/scp/g')
 include::../../tests/roles/octavia_adoption/tasks/octavia_certs.yaml[lines="7..83",indent=0]
 ----
 
-. Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}:
+. Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}. Replace `{{ octavia_ssh_pubkey_path }}` with the path that was configured using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment (the default is `/etc/octavia/ssh/octavia_id_rsa`):
 +
 ----
 include::../../tests/roles/octavia_adoption/tasks/octavia_ssh.yaml[lines="7..20",indent=0]

--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -24,10 +24,17 @@ $ CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed 's/^ssh/scp/g')
 include::../../tests/roles/octavia_adoption/tasks/octavia_certs.yaml[lines="7..83",indent=0]
 ----
 
-. Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}. Replace `{{ octavia_ssh_pubkey_path }}` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa`:
+. Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}:
 +
 ----
 include::../../tests/roles/octavia_adoption/tasks/octavia_ssh.yaml[lines="7..20",indent=0]
+----
++
+Replace `{{ octavia_ssh_pubkey_path }}` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa` as shown in this example:
++
+----
+parameter_defaults:
+    OctaviaAmphoraSshKeyFile: /etc/octavia/ssh/octavia_id_rsa
 ----
 
 . To isolate the management network, add the network interface for the VLAN base interface:

--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -27,10 +27,23 @@ include::../../tests/roles/octavia_adoption/tasks/octavia_certs.yaml[lines="7..8
 . Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}:
 +
 ----
-include::../../tests/roles/octavia_adoption/tasks/octavia_ssh.yaml[lines="7..20",indent=0]
+    ${CONTROLLER1_SCP}:<octavia_ssh_pubkey_path> $HOME/octavia_sshkey.pub
+
+    # Install new data in k8s
+    oc apply -f - <<EOF
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: octavia-ssh-pubkey
+      namespace: openstack
+    data:
+      key: $(cat $HOME/octavia_sshkey.pub)
+    EOF
+
+    rm -f $HOME/octavia_sshkey.pub
 ----
 +
-Replace `{{ octavia_ssh_pubkey_path }}` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa` as shown in this example:
+Replace `<octavia_ssh_pubkey_path>` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa`. For example:
 +
 ----
 parameter_defaults:

--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -24,7 +24,7 @@ $ CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed 's/^ssh/scp/g')
 include::../../tests/roles/octavia_adoption/tasks/octavia_certs.yaml[lines="7..83",indent=0]
 ----
 
-. Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}. Replace `{{ octavia_ssh_pubkey_path }}` with the path that was configured using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment (the default is `/etc/octavia/ssh/octavia_id_rsa`):
+. Optional: Copy the existing public SSH key that you can use for connecting to the amphorae and install it into {OpenShiftShort}. Replace `{{ octavia_ssh_pubkey_path }}` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa`:
 +
 ----
 include::../../tests/roles/octavia_adoption/tasks/octavia_ssh.yaml[lines="7..20",indent=0]

--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -43,7 +43,7 @@ include::../../tests/roles/octavia_adoption/tasks/octavia_certs.yaml[lines="7..8
     rm -f $HOME/octavia_sshkey.pub
 ----
 +
-Replace `<octavia_ssh_pubkey_path>` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa`. For example:
+* Replace `<octavia_ssh_pubkey_path>` with the path that you configured by using the `OctaviaAmphoraSshKeyFile` parameter in the previous deployment. The default path is `/etc/octavia/ssh/octavia_id_rsa`. For example:
 +
 ----
 parameter_defaults:


### PR DESCRIPTION
The documentation was not clear about the SSH key path in the old deployment.