### PR TITLE
Fix oc exec in ovn adoption tasks

### DIFF
--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -263,9 +263,8 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc exec ovsdbserver-nb-0 ovn-nbctl show
-    oc exec ovsdbserver-sb-0 ovn-sbctl show
-
+    oc exec ovsdbserver-nb-0 -- ovn-nbctl show
+    oc exec ovsdbserver-sb-0 -- ovn-sbctl show
   register: ovn_show_responding_result
 
 - name: stop old ovn ovsdb services


### PR DESCRIPTION
Working on [1] the job failed as

```
TASK [ovn_adoption : list briefs from OVN NB and SB databases] *****************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "set -euxo pipefail\n\n\n\noc exec ovsdbserver-nb-0 ovn-nbctl show\noc exec ovsdbserver-sb-0 ovn-sbctl show\n", "delta": "0:00:00.140923", "end": "2025-02-25 10:22:26.293579", "msg": "non-zero return code", "rc": 1, "start": "2025-02-25 10:22:26.152656", "stderr": "+ oc exec ovsdbserver-nb-0 ovn-nbctl show\nerror: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead\nSee 'oc exec -h' for help and examples", "stderr_lines": ["+ oc exec ovsdbserver-nb-0 ovn-nbctl show", "error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead", "See 'oc exec -h' for help and examples"], "stdout": "", "stdout_lines": []}
```

This patch fixes ovn adoption as stated in failure

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/816/