### PR TITLE
uni01alpha ironic clean metadata only

### DIFF
--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -109,3 +109,4 @@ parameter_defaults:
     IronicApiNetwork: ironic
     IronicNetwork: ironic
     IronicInspectorNetwork: ironic
+  IronicCleaningDiskErase: metadata


### PR DESCRIPTION
Set THT parameter IronicCleaningDiskErase to 'metadata', by default it is doing full erase wich can take quite a bit of time.