### PR TITLE
Update con_adoption prerequisites for compute nodes

### DIFF
--- a/docs_user/modules/con_adoption-prerequisites.adoc
+++ b/docs_user/modules/con_adoption-prerequisites.adoc
@@ -28,7 +28,12 @@ Compute::
 
 * Upgrade your Compute nodes to Red Hat Enterprise Linux {rhel_prev_ver}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html-single/framework_for_upgrades_16.2_to_17.1/index#upgrading-compute-nodes_upgrading-the-compute-node-operating-system[Upgrading all Compute nodes to RHEL 9.2] in _Framework for upgrades (16.2 to 17.1)_.
 * Perform a minor update to the latest {OpenStackShort} version. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/performing_a_minor_update_of_red_hat_openstack_platform/index[Performing a minor update of Red Hat OpenStack Platform].
-* If the `systemd-container` package is not installed on your Compute hosts, reboot all hypervisors one by one to install the `systemd-container` package. To avoid interrupting your workloads during the reboot, live migrate virtual machine instances before rebooting a node. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/performing_a_minor_update_of_red_hat_openstack_platform/assembly_rebooting-the-overcloud_keeping-updated#proc_rebooting-compute-nodes_rebooting-the-overcloud[Rebooting Compute nodes] in _Performing a minor update of Red Hat OpenStack Platform_.
+* If the `systemd-container` package is not installed on your Compute hosts, install it via the following command and reboot all hypervisors one by one to activate the `systemd-container` package. To avoid interrupting your workloads during the reboot, live migrate virtual machine instances before rebooting a node. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/performing_a_minor_update_of_red_hat_openstack_platform/assembly_rebooting-the-overcloud_keeping-updated#proc_rebooting-compute-nodes_rebooting-the-overcloud[Rebooting Compute nodes] in _Performing a minor update of Red Hat OpenStack Platform_.
+
+[source, shell]
+----
+sudo dnf -y install systemd-container
+----
 
 ML2/OVS::
 


### PR DESCRIPTION
The instructions to install systemd-container package are missing.

Closes: https://issues.redhat.com/browse/OSPRH-14308