### PR TITLE
Fix Swift ring update race condition

### DIFF
--- a/docs_user/modules/proc_migrating-object-storage-data-to-rhoso-nodes.adoc
+++ b/docs_user/modules/proc_migrating-object-storage-data-to-rhoso-nodes.adoc
@@ -54,10 +54,11 @@ $ oc patch openstackcontrolplane openstack --type=merge -p='{"spec":{"swift":{"t
 +
 This command creates three storage instances on the {rhocp_long} cluster that use Persistent Volume Claims.
 
-. Wait until all three pods are running:
+. Wait until all three pods are running and the rings include the new devices:
 +
 ----
 $ oc wait pods --for condition=Ready -l component=swift-storage
+$ oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-ring-builder object.builder search --device pv'
 ----
 
 . From the current rings, get the storage management IP addresses of the nodes to drain:

--- a/tests/roles/swift_migration/tasks/main.yaml
+++ b/tests/roles/swift_migration/tasks/main.yaml
@@ -30,6 +30,11 @@
   retries: 60
   delay: 2
 
+- name: wait until ring configmap includes new pv devices
+  ansible.builtin.shell: |
+    {{ oc_header }}
+    timeout 900s bash -c 'until oc debug --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c "swift-ring-tool get && swift-ring-builder object.builder search --device pv" ; do sleep 60; done'
+
 - name: set standalone node weight to 0 in swift rings
   ansible.builtin.shell: |
     {{ oc_header }}


### PR DESCRIPTION
The adoption role checks if the requested storage pods are up and running, but not if the rings have been updated yet and include the newly added pvs.

PVs get added by the swift-ring-rebalance job after the storage pods are up and running. However, at the same time the adoption playbook continues, also modifying the rings - which might include the new pvs or not. Changes might also be overwritten either by the rebalance job or the adoption task, resulting in a ring that uses the wrong device weights.

At the end old devices won't be drained properly.

This patch adds a check to ensure the new pvs have been added before continuing, ensuring that the rings include the expected pvs.

Jira: [OSPCIX-711](https://issues.redhat.com//browse/OSPCIX-711)