### PR TITLE
test_with_ironic use get_services_configuration

### DIFF
--- a/tests/playbooks/test_with_ironic.yaml
+++ b/tests/playbooks/test_with_ironic.yaml
@@ -30,7 +30,7 @@
   roles:
     - role: development_environment
     - role: backend_services
-    - role: pull_openstack_configuration
+    - role: get_services_configuration
     - role: stop_openstack_services
     - role: mariadb_copy
     - role: ovn_adoption


### PR DESCRIPTION
The mariadb_copy role depends on `.source_cloud_exported_variables_*` which is created by `get_services_configuration`. Change the test with ironic playbook to use the `get_services_configuration` role instead of the `pull_openstack_configuration` role.