### PR TITLE
Bump Rabbit PVC to 3Gi

### DIFF
--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -128,7 +128,7 @@ spec:
     templates:
       rabbitmq:
         persistence:
-          storage: 1Gi
+          storage: 3Gi
         override:
           service:
             metadata:
@@ -139,7 +139,7 @@ spec:
               type: LoadBalancer
       rabbitmq-cell1:
         persistence:
-          storage: 1Gi
+          storage: 3Gi
         override:
           service:
             metadata:


### PR DESCRIPTION
When trying to adopt I got this error from keystone-bootsrap:
```
  ERROR oslo.messaging._drivers.impl_rabbit
  [None req-42d74477-bbaf-4d0d-ad3b-3d310ef65cb1 - - - - - -]
    The broker has blocked the connection: connection blocked,
    see broker logs
```

In the RabbitMQ logs I see:
```
[info] <0.394.0> Enabling free disk space monitoring
[info] <0.394.0> Disk free limit set to 2000MB
[info] <0.394.0> Free disk space is insufficient. Free bytes: 965124096. Limit: 2000000000
[warning] <0.390.0> disk resource limit alarm set on node 'rabbit@rabbitmq-server-0.rabbitmq-nodes.openstack'.
[warning] <0.390.0>
[warning] <0.390.0> **********************************************************
[warning] <0.390.0> *** Publishers will be blocked until this alarm clears ***
[warning] <0.390.0> **********************************************************
[warning] <0.390.0>
```

If the Disk free limit is 2000MB we need to allocate > 2000MB.