### PR TITLE
Ceph adoption dashboard port change

### DIFF
--- a/tests/roles/ceph_migrate/tasks/firewall.yaml
+++ b/tests/roles/ceph_migrate/tasks/firewall.yaml
@@ -53,8 +53,8 @@
         block: |
            # 100 ceph_alertmanager {'dport': [9093]}
            add rule inet filter TRIPLEO_INPUT tcp dport { 9093 } ct state new counter accept comment "100 ceph_alertmanager"
-           # 100 ceph_dashboard {'dport': [8444]}
-           add rule inet filter TRIPLEO_INPUT tcp dport { 8444 } ct state new counter accept comment "100 ceph_dashboard"
+           # 100 ceph_dashboard {'dport': [8443]}
+           add rule inet filter TRIPLEO_INPUT tcp dport { 8443 } ct state new counter accept comment "100 ceph_dashboard"
            # 100 ceph_grafana {'dport': [3100]}
            add rule inet filter TRIPLEO_INPUT tcp dport { 3100 } ct state new counter accept comment "100 ceph_grafana"
            # 100 ceph_prometheus {'dport': [9092]}

--- a/tests/roles/ceph_migrate/tasks/monitoring.yaml
+++ b/tests/roles/ceph_migrate/tasks/monitoring.yaml
@@ -5,6 +5,25 @@
     ceph_fsid: "{{ mon_dump.fsid }}"
     ceph_cluster: ceph
 
+- name: Set ceph-mgr dashboard port configuration
+  # cephadm runs w/ root privileges
+  become: true
+  block:
+    - name: Set the dashboard port
+      ansible.builtin.command: |
+        {{ ceph_cli }} config set mgr mgr/dashboard/server_port 8443
+      changed_when: false
+    - name: Set the dashboard ssl port
+      ansible.builtin.command: |
+        {{ ceph_cli }} config set mgr mgr/dashboard/ssl_server_port 8443
+      changed_when: false
+    - name: Disable mgr dashboard module (restart)
+      ansible.builtin.command: |
+        {{ ceph_cli }} mgr module disable dashboard
+    - name: Enable mgr dashboard module (restart)
+      ansible.builtin.command: |
+        {{ ceph_cli }} mgr module enable dashboard
+
 # - Expand labels to the whole hostmap
 - name: Apply Monitoring label to the overcloud nodes
   ansible.builtin.import_tasks: labels.yaml


### PR DESCRIPTION
This patch updates dashboard port to 8443 in firewall rules and ceph-mgr config during ceph migration.
JIRA: https://issues.redhat.com/browse/OSPRH-14628