### PR TITLE
Make ironic network name configurable

### DIFF
--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -1,6 +1,7 @@
 ---
 storage_class_name: local-storage
 dns_server_provisioning_ip: 192.168.122.80
+ironic_network: baremetal
 ironic_patch: |
   spec:
     ironic:
@@ -23,8 +24,8 @@ ironic_patch: |
         ironicConductors:
         - replicas: 1
           networkAttachments:
-          - baremetal
-          provisionNetwork: baremetal
+          - {{ ironic_network }}
+          provisionNetwork: {{ ironic_network }}
           storageRequest: 10G
           storageClass: {{ storage_class_name }}
           customServiceConfig: |
@@ -37,9 +38,9 @@ ironic_patch: |
             automated_clean=true
         ironicInspector:
           replicas: 1
-          inspectionNetwork: baremetal
+          inspectionNetwork: {{ ironic_network }}
           networkAttachments:
-          - baremetal
+          - {{ ironic_network }}
           dhcpRanges:
           - name: inspector-0
             cidr: 172.20.1.0/24

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -71,6 +71,9 @@ auth_url: http://keystone-public-openstack.apps-crc.testing
 # Set this to true if adopting the ironic services (ironic + ironic-inspector + nova w/compute-ironic)
 ironic_adoption: false
 
+# Name of network used in ironic spec networkAttachments and provisionNetwork
+ironic_network: baremetal
+
 # Run pre-adoption validation before the deploying
 run_pre_adoption_validation: true
 


### PR DESCRIPTION
In the `ironic_adoption` role use a variable for the name of the `networkAttachment` and `provisioningNetwork` values. In the standalone proceudre `baremetal` was used, with uni01alpha we want `ironic`.