### PR TITLE
[18.0-fr2] Remove instructions for base64-encoding where not applicable

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -248,7 +248,7 @@ $ oc create secret generic subscription-manager \
 --from-literal rhc_auth='{"login": {"username": "<subscription_manager_username>", "password": "<subscription_manager_password>"}}'
 ----
 +
-* Replace `<subscription_manager_username>` with the applicable user name.
+* Replace `<subscription_manager_username>` with the applicable username.
 * Replace `<subscription_manager_password>` with the applicable password.
 
 . Create a secret for the Red Hat registry:


### PR DESCRIPTION
(cherry picked from commit 8a323d3dd5b4cd09db2d411db8c119db2c059e8e)