### PR TITLE
nova_adoption: ironic, FFU patch remove optional

### DIFF
--- a/tests/roles/nova_adoption/defaults/main.yaml
+++ b/tests/roles/nova_adoption/defaults/main.yaml
@@ -1,4 +1,5 @@
 ironic_adoption: false
+ironic_adoption_remove_ffu_workaround_patch: true
 # Libvirt backends: ceph or local
 nova_libvirt_backend: local
 

--- a/tests/roles/nova_adoption/tasks/nova_ironic.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_ironic.yaml
@@ -9,6 +9,7 @@
     file: wait.yaml
 
 - name: Remove FFU workarounds
+  when: ironic_adoption_remove_ffu_workaround_patch is true
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}


### PR DESCRIPTION
When adopting an environment with both ironic and libvirt the FFU workaround should not be removed using `nova_adoption` phase. Add an option to allow disabling the removal.

Removing the FFU workaround made sense when the initial ironic adoption was implemented, because at that time a standalone OSP was used and it did not have libvirt/dataplane.