### PR TITLE
Add missing ceph-hci-pre alongside ceph-client

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -478,6 +478,7 @@ endif::[]
     - configure-network
     - validate-network
     - install-os
+    - ceph-hci-pre
     - configure-os
     - ssh-known-hosts
     - run-os


### PR DESCRIPTION
In the architecture repo, before the ceph-client service, there is always a block of EDPM services:

- install-os
- ceph-hci-pre
- configure-os

Add missing ceph-hci-pre to the list.