### PR TITLE
Optional Octavia SSH adoption test

### DIFF
--- a/tests/roles/octavia_adoption/defaults/main.yaml
+++ b/tests/roles/octavia_adoption/defaults/main.yaml
@@ -1,4 +1,5 @@
 octavia_ssh_pubkey_path: /root/.ssh/id_ecdsa.pub
 octavia_ssh_path: /tmp/octavia-ssl
+run_octavia_ssh_adoption: true
 # rhoso namespace
 rhoso_namespace: "openstack"

--- a/tests/roles/octavia_adoption/tasks/octavia_ssh.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_ssh.yaml
@@ -18,3 +18,4 @@
     EOF
 
     rm -f $HOME/octavia_sshkey.pub
+  when: "run_octavia_ssh_adoption|bool"


### PR DESCRIPTION
Octavia SSH key adoption is an optional step and should not block verification. Currently this test does not work in downstream CI.