### PR TITLE
Ironic API override internal service to ctlplane

### DIFF
--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -15,9 +15,9 @@ ironic_patch: |
               internal:
                 metadata:
                   annotations:
-                    metallb.universe.tf/address-pool: internalapi
-                    metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
+                    metallb.universe.tf/address-pool: ctlplane
+                    metallb.universe.tf/allow-shared-ip: ctlplane
+                    metallb.universe.tf/loadBalancerIPs: {{ ctlplane_prefix | default('192.168.122') }}.80
                 spec:
                   type: LoadBalancer
         ironicConductors:


### PR DESCRIPTION
The uni01alpha uses ctlplane network for the Ironic internal endpoints.

This change switches to use the ctlplane in the ironic_adoption roles default ironic_patch to match.