### PR TITLE
Add more services and tags to test_with_ironic.yaml

### DIFF
--- a/tests/playbooks/test_with_ironic.yaml
+++ b/tests/playbooks/test_with_ironic.yaml
@@ -29,17 +29,77 @@
     prelaunch_test_instance_script: pre_launch_ironic.bash
   roles:
     - role: development_environment
+      tags:
+        - development_environment
+    - role: tls_adoption
+      tags:
+        - tls_adoption
+      when: enable_tlse|default(false)
     - role: backend_services
+      tags:
+        - backend_services
     - role: get_services_configuration
+      tags:
+        - get_services_configuration
     - role: stop_openstack_services
+      tags:
+        - stop_openstack_services
     - role: mariadb_copy
+      tags:
+        - mariadb_copy
     - role: ovn_adoption
+      tags:
+        - ovn_adoption
     - role: keystone_adoption
+      tags:
+        - keystone_adoption
+    - role: barbican_adoption
+      tags:
+        - barbican_adoption
     - role: neutron_adoption
+      tags:
+        - neutron_adoption
     - role: swift_adoption
+      tags:
+        - swift_adoption
+    - role: cinder_adoption
+      tags:
+        - cinder_adoption
     - role: glance_adoption
+      tags:
+        - glance_adoption
     - role: ironic_adoption
+      tags:
+        - ironic_adoption
     - role: placement_adoption
+      tags:
+        - placement_adoption
     - role: nova_adoption
+      tags:
+        - nova_adoption
     - role: octavia_adoption
+      tags:
+        - octavia_adoption
+    - role: horizon_adoption
+      tags:
+        - horizon_adoption
+    - role: heat_adoption
+      tags:
+        - heat_adoption
+    - role: telemetry_adoption
+      tags:
+        - telemetry_adoption
+      when: telemetry_adoption|default(true)
+    - role: autoscaling_adoption
+      tags:
+        - autoscaling_adoption
+      when: telemetry_adoption|default(true)
     - role: stop_remaining_services
+    - role: pull_openstack_configuration
+      tags:
+        - pull_openstack_configuration
+      when: dataplane_adoption|default(false)
+    - role: dataplane_adoption
+      tags:
+        - dataplane_adoption
+      when: dataplane_adoption|default(false)


### PR DESCRIPTION
When adopting uni01alpha it will include more services compared to what was initially included in test_with_ironic.yaml. This change adds these services and adds tag's and some when conditions.

NOTE, the dataplane_adoption defaults to false. Adoption fails at this stage in my testing due to the cell layout. A follow up to change how cells are configured should change the default.