### PR TITLE
Enable Ceph dashboard in unigamma

### DIFF
--- a/scenarios/hci.yaml
+++ b/scenarios/hci.yaml
@@ -55,6 +55,7 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/cephadm/ceph-mds.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/cephadm/ceph-dashboard.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/services/barbican.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/barbican-backend-simple-crypto.yaml"
     network_data_file: "hci/network_data.yaml.j2"


### PR DESCRIPTION
Unigamma lands in a Ceph configuration that includes ceph dashboard and the associated monitoring stack. This patch enables the Ceph dashboard in the TripleO scenario so we can cover the monitoring stack migration.