### PR TITLE
Refactor documentation for enabling TLS-e during controlplane creation

### DIFF
--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -126,68 +126,8 @@ $ oc set data secret/osp-secret "OctaviaPassword=$OCTAVIA_PASSWORD"
 $ oc set data secret/osp-secret "PlacementPassword=$PLACEMENT_PASSWORD"
 $ oc set data secret/osp-secret "SwiftPassword=$SWIFT_PASSWORD"
 ----
-
-. If you enabled TLS-e in your {OpenStackShort} environment, in the `spec:tls` section, set the `enabled` parameter to `true`:
-+
-[source,yaml]
-----
-apiVersion: core.openstack.org/v1beta1
-kind: OpenStackControlPlane
-metadata:
-  name: openstack
-spec:
-  tls:
-    podLevel:
-      enabled: true
-      internal:
-        ca:
-          customIssuer: rootca-internal
-      libvirt:
-        ca:
-          customIssuer: rootca-internal
-      ovn:
-        ca:
-          customIssuer: rootca-internal
-    ingress:
-      ca:
-        customIssuer: rootca-internal
-      enabled: true
-----
-
-. If you did not enable TLS-e, in the `spec:tls` section, set the `enabled` parameter to `false`:
-+
-[source,yaml]
-----
-apiVersion: core.openstack.org/v1beta1
-kind: OpenStackControlPlane
-metadata:
-  name: openstack
-spec:
-  tls:
-    podLevel:
-      enabled: false
-    ingress:
-      enabled: false
-----
-
 . Deploy the `OpenStackControlPlane` CR. Ensure that you only enable the DNS, Galera, Memcached, and RabbitMQ services. All other services must
 be disabled:
-+
-[NOTE]
-====
-If you use IPv6, change the load balancer IPs to the IPs in your environment:
-----
-...
-metallb.universe.tf/allow-shared-ip: ctlplane
-metallb.universe.tf/loadBalancerIPs: fd00:aaaa::80
-...
-metallb.universe.tf/address-pool: internalapi
-metallb.universe.tf/loadBalancerIPs: fd00:bbbb::85
-...
-metallb.universe.tf/address-pool: internalapi
-metallb.universe.tf/loadBalancerIPs: fd00:bbbb::86
-----
-====
 +
 [source,shell]
 ----
@@ -227,7 +167,6 @@ endif::[]
           metadata:
             annotations:
 ifeval::["{build_variant}" != "ospdo"]
-
               metallb.universe.tf/address-pool: ctlplane
               metallb.universe.tf/allow-shared-ip: ctlplane
               metallb.universe.tf/loadBalancerIPs: 192.168.122.80
@@ -401,6 +340,12 @@ endif::[]
   telemetry:
     enabled: false
 
+  tls:
+    podLevel:
+      enabled: false
+    ingress:
+      enabled: false
+
   swift:
     enabled: false
     template:
@@ -426,6 +371,47 @@ endif::[]
 This example provides the required infrastructure database and messaging services for 3 Compute cells
 named `cell1`, `cell2`, and `cell3`. Adjust the names, counts, IP addresses, and numbers,
 such as for `replicas`, `storage`, or `storageRequest`, as needed.
+
+[NOTE]
+====
+If you use IPv6, change the load balancer IPs to the IPs in your environment:
+----
+...
+metallb.universe.tf/allow-shared-ip: ctlplane
+metallb.universe.tf/loadBalancerIPs: fd00:aaaa::80
+...
+metallb.universe.tf/address-pool: internalapi
+metallb.universe.tf/loadBalancerIPs: fd00:bbbb::85
+...
+metallb.universe.tf/address-pool: internalapi
+metallb.universe.tf/loadBalancerIPs: fd00:bbbb::86
+----
+====
+
+[NOTE]
+====
+If you enabled TLS-e in your {OpenStackShort} environment, in the `spec:tls` section set `tls` to the following:
+----
+spec:
+  ...
+  tls:
+    podLevel:
+      enabled: true
+      internal:
+        ca:
+          customIssuer: rootca-internal
+      libvirt:
+        ca:
+          customIssuer: rootca-internal
+      ovn:
+        ca:
+          customIssuer: rootca-internal
+    ingress:
+      ca:
+        customIssuer: rootca-internal
+      enabled: true
+----
+====
 
 .Verification
 


### PR DESCRIPTION
Add tlse spec with disabled tlse to example controlplane CR and
document in note how tlse can be enabled if source OSP has TLS-e enabled.
This is in sync with test suite and EDPM adoption part, where we have
tlse disabled and document what to do to enable it.


Resolves: [OSPRH-14786](https://issues.redhat.com//browse/OSPRH-14786)