### PR TITLE
Fixed incorrect grep in octavia adoption

### DIFF
--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -53,11 +53,11 @@ parameter_defaults:
 . To isolate the management network, add the network interface for the VLAN base interface:
 +
 ----
-$ oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | while read; do
+$ oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
 interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
-(echo $interfaces | grep -w -q "octbr|enp6s0.24") || \
+(echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
         oc patch -n openstack nncp $REPLY --type json --patch '
 [{
     "op": "add",

--- a/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
@@ -3,11 +3,11 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | while read; do
+    oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
     interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
-    (echo $interfaces | grep -w -q "octbr|enp6s0.24") || \
+    (echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
             oc patch -n openstack nncp $REPLY --type json --patch '
     [{
         "op": "add",


### PR DESCRIPTION
Use "\\|" instead of "|" in grep, previous regexp didn't work as expected because grep considers "octbr|enp6s0.24" as a full-string.

It fixes a bug if the octavia bridge and interface are already present in the NNCP, this NNCP might have been patched again with a different configuration.

JIRA: [OSPCIX-747](https://issues.redhat.com//browse/OSPCIX-747)