### PR TITLE
Revert "Multi-cell adoption"

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -182,104 +182,6 @@ https://openstack-k8s-operators.github.io/data-plane-adoption/dev/#_reset_the_en
 
 '''
 
-== Deploying TripleO With Multiple Cells
-
-A TripleO Standalone setup creates only a single Nova v2 cell, with a combined controller and compute services on it.
-In order to deploy multiple compute cells for adoption testing (without Ceph), create a 5 VMs, with the following requirements met:
-
-* Named `edpm-compute-0` .. `edpm-compute-4`.
-* Running RHEL 9.2, with RHOSP 17.1 repositories configured.
-* Can login via SSH without a password as the root user, from the hypervisor host.
-* User `zuul` is created, and can sudo without a password, and login via SSH without a password, from the hypervisor host.
-* User `zuul` can login to `edpm-compute-1`, `edpm-compute-2`, `edpm-compute-3`, `edpm-compute-4` nodes via SSH without a password, from the `edpm-compute-0` node,
-by using the generated `/home/zuul/.ssh/id_rsa` private key.
-* RedHat registry credentials are exported on the hypervisor host.
-
-Adjust the following commands for a repositories configuration tool of your choice:
-
-[,bash]
-----
-export RH_REGISTRY_USER="<insert your registry.redhat.io user>"
-export RH_REGISTRY_PWD="<insert your registry.redhat.io password>"
-
-DEFAULT_CELL_NAME="cell3" <1>
-RENAMED_CELLS="cell1 cell2 $DEFAULT_CELL_NAME"
-
-cd ~/install_yamls/devsetup
-cat <<EOF > /tmp/osp17_repos
-# Use a tool of your choice:
-# 1. Rhos-release example steps are only available from the internal RedHat network
-# ... skipping download and install steps ...
-# sudo rhos-release -x
-# sudo rhos-release 17.1
-
-# 2. Subscription-manager example steps require an active registration
-# subscription-manager release --set=9.2
-# subscription-manager repos --disable=*
-# sudo subscription-manager repos \
-#   --enable=rhel-9-for-x86_64-baseos-eus-rpms \
-#   --enable=rhel-9-for-x86_64-appstream-eus-rpms \
-#   --enable=rhel-9-for-x86_64-highavailability-eus-rpms \
-#   --enable=openstack-17.1-for-rhel-9-x86_64-rpms \
-#   --enable=rhceph-6-tools-for-rhel-9-x86_64-rpms \
-#   --enable=fast-datapath-for-rhel-9-x86_64-rpms
-
-# firstboot commands
-sudo dnf install -y git curl wget podman python3-tripleoclient openvswitch3.1 NetworkManager-initscripts-updown \
-sudo dnf install -y util-linux cephadm driverctl lvm2 jq nftables iptables-nft openstack-heat-agents \
-  os-net-config python3-libselinux python3-pyyaml rsync tmpwatch sysstat iproute-tc
-sudo dnf install -y puppet-tripleo puppet-headless
-sudo dnf install -y openstack-selinux
-EOF
-
-export CENTOS_9_STREAM_URL=<insert url to rhel-guest-image-9.2.x86_64.qcow2>
-export NTP_SERVER=<insert ntp server of your choice>
-
-export MANILA_ENABLED=false
-export EDPM_COMPUTE_CEPH_ENABLED=false
-export EDPM_COMPUTE_CEPH_NOVA=false
-export EDPM_COMPUTE_CELLS=3
-
-export STANDALONE_EXTRA_CMD="bash -c 'echo \"$RH_REGISTRY_PWD\" > ~/authfile; chmod 0600 ~/authfile; sudo dnf install -y podman; sudo /bin/podman login registry.redhat.io -u \"$RH_REGISTRY_USER\" --password-stdin < ~/authfile'"
-export EDPM_FIRSTBOOT_EXTRA=/tmp/osp17_repos
-export EDPM_TOTAL_NODES=1
-export SKIP_TRIPLEO_REPOS=false
-export EDPM_COMPUTE_NETWORK_IP=192.168.122.1
-export HOST_PRIMARY_RESOLV_CONF_ENTRY=192.168.122.1
-export BASE_DISK_FILENAME="rhel-9-base.qcow2"
-
-EDPM_COMPUTE_SUFFIX=0 IP=192.168.122.100 EDPM_COMPUTE_DISK_SIZE=10 EDPM_COMPUTE_RAM=9 EDPM_COMPUTE_VCPUS=2 make edpm_compute
-EDPM_COMPUTE_SUFFIX=1 IP=192.168.122.103 EDPM_COMPUTE_DISK_SIZE=17 EDPM_COMPUTE_RAM=12 EDPM_COMPUTE_VCPUS=4 make edpm_compute
-EDPM_COMPUTE_SUFFIX=2 IP=192.168.122.106 EDPM_COMPUTE_DISK_SIZE=14 EDPM_COMPUTE_RAM=12 EDPM_COMPUTE_VCPUS=4 make edpm_compute
-EDPM_COMPUTE_SUFFIX=3 IP=192.168.122.107 EDPM_COMPUTE_DISK_SIZE=12 EDPM_COMPUTE_RAM=4 EDPM_COMPUTE_VCPUS=2 make edpm_compute
-EDPM_COMPUTE_SUFFIX=4 IP=192.168.122.109 EDPM_COMPUTE_DISK_SIZE=16 EDPM_COMPUTE_RAM=12 EDPM_COMPUTE_VCPUS=4 make edpm_compute
-
-for n in 0 3 6 7 9; do
-    # w/a bad packages installation, if done by firstboot - resulting in rpm -V check failures in tripleo-ansible
-    ssh -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        root@192.168.122.10${n} dnf install -y openstack-selinux ';' \
-        dnf reinstall -y openstack-selinux
-    ssh -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        root@192.168.122.10${n} useradd --create-home --shell /bin/bash --groups root zuul ';' \
-        mkdir -p /home/zuul/.ssh
-    scp -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.10${n}:/home/zuul/.ssh/id_rsa
-    ssh -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        root@192.168.122.10${n} ssh-keygen -yf /home/zuul/.ssh/id_rsa '>' /home/zuul/.ssh/id_rsa.pub
-    ssh -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        root@192.168.122.10${n} cp /root/.ssh/authorized_keys /home/zuul/.ssh/authorized_keys
-    ssh -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        root@192.168.122.10${n} chown zuul: /home/zuul/.ssh/*
-    ssh -o StrictHostKeyChecking=false -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa \
-        root@192.168.122.10${n} echo "zuul ALL=NOPASSWD:ALL" '>' /etc/sudoers.d/zuul
-done
-
-make tripleo_deploy
-
-for n in 0 1 2 3 4; do make standalone_snapshot EDPM_COMPUTE_SUFFIX=$n; done
-----
-<1> The source cloud 'default' cell takes a new `$DEFAULT_CELL_NAME`. In a multi-cell adoption scenario, it may either retain its original name (`DEFAULT_CELL_NAME=default`), or become renamed into a free for use cell name. Never chose other existing cells names (except 'default') for `DEFAULT_CELL_NAME`.
-
 == Network routing
 
 Route VLAN20 to have access to the MariaDB cluster:
@@ -312,10 +214,8 @@ installing the package and copying the configuration file from the virtual machi
 
 [,bash]
 ----
-OS_CLOUD_NAME=standalone
-alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=$OS_CLOUD_NAME openstack"
+alias openstack="ssh -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 OS_CLOUD=standalone openstack"
 ----
-For a multi-cell environment, set `OS_CLOUD_NAME` to `overcloud`.
 
 === Virtual machine steps
 
@@ -443,28 +343,15 @@ make openstack_init
 
 == Performing the adoption procedure
 
-To simplify the adoption procedure with additional cells, copy and rename the deployment passwords that
+To simplify the adoption procedure, copy the deployment passwords that
 you use in copy the deployment passwords that you use in the
 https://openstack-k8s-operators.github.io/data-plane-adoption/user/#deploying-backend-services_migrating-databases[backend
 services deployment phase of the data plane adoption].
 
-For a single-cell standalone TripleO deployment:
 [,bash]
 ----
-scp -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/root/tripleo-standalone-passwords.yaml ~/overcloud-passwords.yaml
+scp -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/root/tripleo-standalone-passwords.yaml ~/
 ----
-
-Further on, this password is going to be referenced as `TRIPLEO_PASSWORDS[default]` for a `default` cell name, in terms of TripleO.
-
-For a source cloud deployment with multiple stacks, change the above command to these:
-[,bash]
-----
-scp -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa zuul@192.168.122.100:overcloud-deploy/overcloud/overcloud-passwords.yaml ~/
-scp -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa zuul@192.168.122.100:overcloud-deploy/cell1/cell1-passwords.yaml ~/
-scp -i ~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa zuul@192.168.122.100:overcloud-deploy/cell2/cell2-passwords.yaml ~/
-----
-Note that all compute cells of the source cloud always share the same database and messaging passwords.
-On the contrary, a generic split-stack topology allows using different passwords files for its stacks.
 
 The development environment is now set up, you can go to the https://openstack-k8s-operators.github.io/data-plane-adoption/[Adoption
 documentation]
@@ -482,10 +369,8 @@ Delete the data-plane and control-plane resources from the CRC vm
 
 [,bash]
 ----
-for CELL in $(echo $RENAMED_CELLS); do
-  oc delete --ignore-not-found=true --wait=false openstackdataplanedeployment/openstack-$CELL
-  oc delete --ignore-not-found=true --wait=false openstackdataplanedeployment/openstack-nova-compute-ffu-$CELL
-done
+oc delete --ignore-not-found=true --wait=false openstackdataplanedeployment/openstack
+oc delete --ignore-not-found=true --wait=false openstackdataplanedeployment/openstack-nova-compute-ffu
 oc delete --ignore-not-found=true --wait=false openstackcontrolplane/openstack
 oc patch openstackcontrolplane openstack --type=merge --patch '
 metadata:
@@ -504,19 +389,12 @@ oc delete --wait=false pod mariadb-copy-data || true
 oc delete secret osp-secret || true
 ----
 
-Revert the standalone vm(s) to the snapshotted state
+Revert the standalone vm to the snapshotted state
 
 [,bash]
 ----
 cd ~/install_yamls/devsetup
 make standalone_revert
-----
-
-For a multi-cell deployment, change the above command to these:
-[,bash]
-----
-cd ~/install_yamls/devsetup
-for n in 0 1 2 3 4; do make standalone_revert EDPM_COMPUTE_SUFFIX=$n; done
 ----
 
 Clean up and initialize the storage PVs in CRC vm
@@ -525,12 +403,7 @@ Clean up and initialize the storage PVs in CRC vm
 ----
 cd ..
 for i in {1..3}; do make crc_storage_cleanup crc_storage && break || sleep 5; done
-for CELL in $(echo $RENAMED_CELLS); do
-   oc delete pvc mysql-db-openstack-$CELL-galera-0 --ignore-not-found=true
-   oc delete pvc persistence-rabbitmq-$CELL-server-0 --ignore-not-found=true
-done
 ----
-Use indexes like `*-0`, `*-1` based on the replica counts configured in `oscp/openstack` CR.
 
 '''
 

--- a/docs_dev/assemblies/tests.adoc
+++ b/docs_dev/assemblies/tests.adoc
@@ -29,9 +29,7 @@ these variables suit your environment:
  ** `tripleo_passwords`     (for each {OpenStackPreviousInstaller} Heat stack on the source cloud)
  ** `source_galera_members` (for each cell controller on the source cloud)
  ** `source_mariadb_ip`     (for each cell controller on the source cloud)
- ** `edpm_nodes`            (for each cell compute node on the destination)
  ** `edpm_privatekey_path`
- ** `source_ovndb_ip``
  ** `timesync_ntp_servers`
 
 == Running the tests

--- a/docs_user/modules/con_adoption-limitations.adoc
+++ b/docs_user/modules/con_adoption-limitations.adoc
@@ -29,12 +29,12 @@ The following {compute_service_first_ref} features are Technology Previews:
 * AMD SEV
 * Direct download from Rados Block Device (RBD)
 * File-backed memory
-* `Provider.yaml`
 
 .Unsupported features
 
 The adoption process does not support the following features:
 
+* {rhos_prev_long} ({OpenStackShort}) {rhos_prev_ver} multi-cell deployments
 * instanceHA
 * DCN
 * Designate

--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -81,63 +81,20 @@ EOF
 +
 * If `neutron-sriov-nic-agent` is running on your {compute_service} nodes, ensure that the physical device mappings match the values that are defined in the `OpenStackDataPlaneNodeSet` custom resource (CR). For more information, see xref:pulling-configuration-from-tripleo-deployment_adopt-control-plane[Pulling the configuration from a {OpenStackPreviousInstaller} deployment].
 
-* You have defined the shell variables to run the script that runs the upgrade:
+* You have defined the shell variables to run the script that runs the fast-forward upgrade:
 +
 ----
-$ CEPH_FSID=$(oc get secret ceph-conf-files -o json | jq -r '.data."ceph.conf"' | base64 -d | grep fsid | sed -e 's/fsid = //'
+CEPH_FSID=$(oc get secret ceph-conf-files -o json | jq -r '.data."ceph.conf"' | base64 -d | grep fsid | sed -e 's/fsid = //'
 
-$ alias openstack="oc exec -t openstackclient -- openstack"
-
-$ DEFAULT_CELL_NAME="cell3" <1>
-$ RENAMED_CELLS="cell1 cell2 $DEFAULT_CELL_NAME"
-
-$ declare -A COMPUTES_CELL1
-$ export COMPUTES_CELL1=( <2>
-  ["standalone.localdomain"]="192.168.122.100" <3>
-  # ... <4>
-)
-$ declare -A COMPUTES_CELL2
-$ export COMPUTES_CELL2=(
+alias openstack="oc exec -t openstackclient -- openstack"
+declare -A computes
+export computes=(
+  ["standalone.localdomain"]="192.168.122.100"
   # ...
 )
-$ declare -A COMPUTES_CELL3
-$ export COMPUTES_CELL3=(
-  # ... <5>
-)
-# ...
-
-$ declare -A COMPUTES_API_CELL1
-$ export COMPUTES_API_CELL1=( <2>
-  ["standalone.localdomain"]="172.17.0.100"
-  # ...
-)
-# ...
-
-$ NODESETS=""
-$ for CELL in $(echo $RENAMED_CELLS); do
-  ref="COMPUTES_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')"
-  eval names=\${!${ref}[@]}
-  [ -z "$names" ] && continue <6>
-  NODESETS="'openstack-${CELL}', $NODESETS"
-done
-$ NODESETS="[${NODESETS%,*}]"
 ----
 +
-<1> The source cloud `default` cell takes a new `DEFAULT_CELL_NAME` on the destined cloud after adoption.
-In a multi-cell adoption scenario, you may either retain its original name `default`, or create as `cell<X>`, by providing the incremented index of the last cell in the source cloud (which is, by adding a 1 to it).
-<2> For each cell, adjust <["standalone.localdomain"]="x.x.x.x">, and complete `COMPUTES_CELL<X>` and `COMPUTES_API_CELL<X>` data with the names and IP addresses of the {compute_service} nodes connected to the `ctlplane` and `internalapi` networks. Do not specify a real FQDN defined for each network, always use the same host name for each of its connected networks. Providing IP addresses and names of the hosts on remaining networks of the source cloud should be covered the similar way. Or you can adjust the generated files manually as shown below.
-<3> If your deployment has a custom DNS Domain, put it in for FQDN of the nodes. The given values will be used in the dataplane node sets' `spec.nodes.<NODE NAME>.hostName`.
-<4> Assign all {compute_service} nodes from the source cloud `cell1` cell into `COMPUTES_*CELL1`, and so on.
-<5> Assign all {compute_service} nodes from the source cloud `default` cell into `openstack-<X>`,
-where `<X>` is the `DEFAULT_CELL_NAME` environment variable value (here, it equals 'cell3').
-<6> Cells not containing compute nodes will be omitted as no node sets for it should be created.
-
-** When you have deployed the source cloud with only a 'default' cell, and want to rename it during adoption, you should define that instead:
-+
-----
-$ DEFAULT_CELL_NAME="cell1"
-$ RENAMED_CELLS="cell1"
-----
+** Replace `["standalone.localdomain"]="192.168.122.100"` with the name and IP address of the {compute_service} node.
 +
 [NOTE]
 Do not set a value for the `CEPH_FSID` parameter if the local storage back end is configured by the {compute_service} for libvirt. The storage back end must match the source cloud storage back end. You cannot change the storage back end during adoption.
@@ -215,7 +172,7 @@ data:
 EOF
 ----
 
-. Create a configuration map which should become common for all cells. To configure a local storage back end for libvirt:
+. If you use a local storage back end for libvirt, create a `nova-compute-extra-config` service to remove pre-fast-forward workarounds and configure Compute services to use a local storage back end:
 +
 [source,yaml]
 ----
@@ -223,24 +180,35 @@ $ oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-cells-global-config
+  name: nova-extra-config
   namespace: openstack
-data: <1>
-  99-nova-compute-cells-workarounds.conf: | <2>
+data:
+  19-nova-compute-cell1-workarounds.conf: |
     [workarounds]
     disable_compute_service_check_for_ffu=true
 EOF
 ----
 +
-<1> The `data` resources in the `ConfigMap` provides configuration files for all cells.
-<2> There is a requirement to index the <*.conf> files from '03' to '99', based on its precedence.
-Whereis a <99-*.conf> takes top precedence. Indexes below '03' are reserved for internal use.
-
 [NOTE]
-You should never delete, nor overwrite, the cell1's default `nova-extra-config` configuration map assigned to its default dataplane service 'nova'.
-Adopting a live cloud might require other configurations to carry over for Nova EDPM services stored in that configuration map, without overwriting or losing them.
+The secret `nova-cell<X>-compute-config` auto-generates for each
+`cell<X>`. You must specify values for the `nova-cell<X>-compute-config` and `nova-migration-ssh-key` parameters for each custom `OpenStackDataPlaneService` CR that is related to the {compute_service}.
 
-. To configure a Ceph back end for libvirt:
+. If TLS Everywhere is enabled, append the following content to the `OpenStackDataPlaneService` CR:
++
+[source,yaml]
+----
+  tlsCerts:
+    contents:
+      - dnsnames
+      - ips
+    networks:
+      - ctlplane
+    issuer: osp-rootca-issuer-internal
+  caCerts: combined-ca-bundle
+  edpmServiceType: nova
+----
+
+. If you use a Ceph back end for libvirt, create a `nova-compute-extra-config` service to remove pre-fast-forward upgrade workarounds and configure Compute services to use a Ceph back end:
 +
 [source,yaml]
 ----
@@ -248,10 +216,10 @@ $ oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-cells-global-config
+  name: nova-extra-config
   namespace: openstack
 data:
-  99-nova-compute-cells-workarounds.conf: |
+  19-nova-compute-cell1-workarounds.conf: |
     [workarounds]
     disable_compute_service_check_for_ffu=true
   03-ceph-nova.conf: |
@@ -267,78 +235,7 @@ data:
 EOF
 ----
 +
-
-. Create dataplane services for Nova cells to enable pre-upgrade workarounds,
-and to configure the {compute_service} services for a picked storage back end:
-
-+
-[source,yaml]
-----
-for CELL in $(echo $RENAMED_CELLS); do
-  oc apply -f - <<EOF
----
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: nova-$CELL
-spec:
-  dataSources: <1>
-    - secretRef:
-        name: nova-$CELL-compute-config <2>
-    - secretRef:
-        name: nova-migration-ssh-key <3>
-    - configMapRef:
-        name: nova-cells-global-config
-  playbook: osp.edpm.nova
-  caCerts: combined-ca-bundle
-  edpmServiceType: nova
-  containerImageFields:
-  - NovaComputeImage
-  - EdpmIscsidImage
-EOF
-  done
-----
-+
-
-* If TLS Everywhere is enabled, append the following content to the `OpenStackDataPlaneService` CR:
-+
-[source,yaml]
-----
-  tlsCerts:
-    contents:
-      - dnsnames
-      - ips
-    networks:
-      - ctlplane
-    issuer: osp-rootca-issuer-internal
-    edpmRoleServiceName: nova
-  caCerts: combined-ca-bundle
-  edpmServiceType: nova
-----
-+
-<1> To enable a local metadata services for a cell<N>, append a `spec.dataSources.secretRef` to reference
-an additional auto-generated `nova-cell<N>-metadata-neutron-config` secret. According to xref:adopting-the-compute-service_{context}[Adopting the Compute service] guide, you should also set
-`spec.nova.template.cellTemplates.cell<N>.metadataServiceTemplate.enable` in the `OpenStackControlPlane/openstack` CR. You may either configure a single top level metadata, or you should define a per cell metadata for each cell.
-<2> The secret `nova-cell<N>-compute-config` auto-generates for each `cell<N>`.
-<3> You must append the `nova-cell<N>-compute-config` and `nova-migration-ssh-key` references for each custom `OpenStackDataPlaneService` CR that is related to the {compute_service}.
-
-[NOTE]
-For simplicity, we share the same `nova-migration-ssh-key` key across cells. You should use different keys for different cells.
-
-* For simple configuration overrides, we do not need a custom dataplane service. However, to reconfigure the cell `cell1` in general,
-the safest option would be always creating a custom service, and a dedicated configuration map for it.
-
-[NOTE]
-The cell `cell1` is already managed with the default `OpenStackDataPlaneService` called `nova`
-and its `nova-extra-config` configuration map. Do not change the default dataplane service 'nova' definition.
-The changes will be lost, when the {rhos_long} operator becomes updated with OLM.
-
-* When a cell spans multiple node sets, you might want to name the custom `OpenStackDataPlaneService` resources like
-`nova-cell1-nfv` and `nova-cell1-enterprise`. Then the auto-generated configmaps would be named
-`nova-cell1-nfv-extra-config` and `nova-cell1-enterprise-extra-config`.
-
-[NOTE]
-Different configurations for nodes in multiple node sets of the same cell are also supported, albeit not covered in this guide.
+The resources in the `ConfigMap` contain cell-specific configurations.
 
 ifeval::["{build}" == "downstream"]
 . Create a secret for the subscription manager:
@@ -361,58 +258,18 @@ $ oc create secret generic redhat-registry \
 * Replace `<registry_username>` with the applicable username.
 * Replace `<registry_password>` with the applicable password.
 endif::[]
-+
 
-[NOTE]
-The `subscription-manager` secret does not need to be referenced in `OpenStackDataPlaneService`'s `spec.dataSources` data.
-It is already passed in via a node-specific `OpenStackDataPlaneNodeSet` data in `spec.nodeTemplate.ansible.ansibleVarsFrom`.
-
-
-. Create the dataplane node sets definitions for each cell:
-
+. Deploy the `OpenStackDataPlaneNodeSet` CR:
 +
 [source,yaml]
 ----
-$ declare -A names
-$ for CELL in $(echo $RENAMED_CELLS); do
-  ref="COMPUTES_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')"
-  eval names=\${!${ref}[@]}
-  ref_api="COMPUTES_API_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')"
-  [ -z "$names" ] && continue
-  ind=0
-  rm -f computes-$CELL
-  for compute in $names; do
-    ip="${ref}['$compute']"
-    ip_api="${ref_api}['$compute']"
-    cat >> computes-$CELL << EOF
-    ${compute}:
-      hostName: $compute <1>
-      ansible:
-        ansibleHost: $compute
-      networks: <2>
-      - defaultRoute: true
-        fixedIP: ${!ip}
-        name: ctlplane
-        subnetName: subnet1
-      - name: internalapi
-        subnetName: subnet1
-        fixedIP: ${!ip_api}
-      - name: storage
-        subnetName: subnet1
-      - name: tenant
-        subnetName: subnet1
-EOF
-    ind=$(( ind + 1 ))
-  done
-
-  test -f computes-$CELL || continue
-  cat > nodeset-${CELL}.yaml <<EOF
+$ oc apply -f - <<EOF
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-$CELL <3>
+  name: openstack-cell1
 spec:
-  tlsEnabled: false <4>
+  tlsEnabled: false <1>
   networkAttachments:
       - ctlplane
   preProvisioned: true
@@ -430,18 +287,32 @@ endif::[]
     - run-os
     - reboot-os
     - install-certs
+    - libvirt
+    - nova
     - ovn
     - neutron-metadata
-    - libvirt
-    - nova-$CELL
-    - telemetry <5>
+    - telemetry
   env:
     - name: ANSIBLE_CALLBACKS_ENABLED
       value: "profile_tasks"
     - name: ANSIBLE_FORCE_COLOR
       value: "True"
-    - name: ANSIBLE_VERBOSITY
-      value: 3
+  nodes:
+    standalone:
+      hostName: standalone <2>
+      ansible:
+        ansibleHost: ${computes[standalone.localdomain]}
+      networks:
+      - defaultRoute: true
+        fixedIP: ${computes[standalone.localdomain]}
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-adoption-secret
     ansible:
@@ -506,7 +377,7 @@ endif::[]
         #
         # These vars are for the network config templates themselves and are
         # considered EDPM network defaults.
-        neutron_physical_bridge_name: br-ctlplane <6>
+        neutron_physical_bridge_name: br-ctlplane
         neutron_public_interface_name: eth0
 
         # edpm_nodes_validation
@@ -514,7 +385,7 @@ endif::[]
         edpm_nodes_validation_validate_gateway_icmp: false
 
         # edpm ovn-controller configuration
-        edpm_ovn_bridge_mappings: <bridge_mappings> <7>
+        edpm_ovn_bridge_mappings: <bridge_mappings> <3>
         edpm_ovn_bridge: br-int
         edpm_ovn_encap_type: geneve
         ovn_monitor_all: true
@@ -565,99 +436,78 @@ endif::[]
         # Do not attempt OVS major upgrades here
         edpm_ovs_packages:
         - openvswitch3.3
-        edpm_default_mounts: <8>
+        edpm_default_mounts: <4>
           - path: /dev/hugepages<size>
             opts: pagesize=<size>
             fstype: hugetlbfs
             group: hugetlbfs
-  nodes:
 EOF
-  cat computes-$CELL >> nodeset-${CELL}.yaml
-done
 ----
 +
-<1> If your deployment has a custom DNS Domain, modify the `spec:nodes:[NODE NAME]:hostName` to use fqdn for the node.
-<2> The networks composition must match the source cloud configuration to avoid dataplane connectivity downtime. The ctlplane network must come first. The above commands only retain IP addresses for the hosts on `ctlplane` and `internalapi` networks. Complete it the same way for other networks, or update the resulted files manually.
-<3> Use node sets names, like `openstack-cell1`, `openstack-cell2`. Only create node sets for cells containing compute nodes.
-<4> If TLS Everywhere is enabled, change `spec.tlsEnabled` to `true`.
-<5> If not adopting the telemetry services, omit it from the services list.
-<6> The bridge name and other OVN and Neutron specific values must match the source cloud configuration to avoid dataplane connectivity downtime.
-<7> Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
-<8> If you need to configure hugepages, adjust `<size>`. To configure multi-sized hugepages, create more items in the list. Note that the mount points must match the source cloud configuration.
+<1> If TLS Everywhere is enabled, change `spec:tlsEnabled` to `true`.
+<2> If your deployment has a custom DNS Domain, modify the `spec:nodes:[NODE NAME]:hostName` to use fqdn for the node.
+<3> Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
+<4> If you need to configure hugepages, adjust `<size>`. To configure multi-sized hugepages, create more items in the list. Note that the mount points must match the source cloud configuration.
 
-* Ensure that you use the same `ovn-controller` settings in the `OpenStackDataPlaneNodeSet` CR that you used in the {compute_service} nodes before adoption. This configuration is stored in the `external_ids` column in the `Open_vSwitch` table in the Open vSwitch database:
+. Ensure that you use the same `ovn-controller` settings in the `OpenStackDataPlaneNodeSet` CR that you used in the {compute_service} nodes before adoption. This configuration is stored in the `external_ids` column in the `Open_vSwitch` table in the Open vSwitch database:
 +
 ----
-$ ovs-vsctl list Open .
+ovs-vsctl list Open .
 ...
 external_ids        : {hostname=standalone.localdomain, ovn-bridge=br-int, ovn-bridge-mappings=<bridge_mappings>, ovn-chassis-mac-mappings="datacentre:1e:0a:bb:e6:7c:ad", ovn-encap-ip="172.19.0.100", ovn-encap-tos="0", ovn-encap-type=geneve, ovn-match-northd-version=False, ovn-monitor-all=True, ovn-ofctrl-wait-before-clear="8000", ovn-openflow-probe-interval="60", ovn-remote="tcp:ovsdbserver-sb.openstack.svc:6642", ovn-remote-probe-interval="60000", rundir="/var/run/openvswitch", system-id="2eec68e6-aa21-4c95-a868-31aeafc11736"}
 ...
 ----
 +
-Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`
-
-. Deploy the `OpenStackDataPlaneNodeSet` CRs for each Nova compute cell
-+
-----
-$ for CELL in $(echo $RENAMED_CELLS); do
-  test -f nodeset-${CELL}.yaml || continue
-  oc apply -f nodeset-${CELL}.yaml
-done
-----
+* Replace `<bridge_mappings>` with the value of the bridge mappings in your configuration, for example, `"datacentre:br-ctlplane"`.
 
 . If you use a Ceph back end for {block_storage_first_ref}, prepare the adopted data plane workloads:
 +
 [source,yaml]
 ----
-$ for CELL in $(echo $RENAMED_CELLS); do
-  test -f nodeset-${CELL}.yaml || continue
-  oc patch osdpns/openstack-$CELL --type=merge --patch "
-  spec:
-    services:
+$ oc patch osdpns/openstack-cell1 --type=merge --patch "
+spec:
+  services:
 ifeval::["{build}" == "downstream"]
-      - redhat
+    - redhat
 endif::[]
-      - bootstrap
-      - download-cache
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - ssh-known-hosts
-      - run-os
-      - reboot-os
-      - ceph-client
-      - install-certs
-      - ovn
-      - neutron-metadata
-      - libvirt
-      - nova-$CELL
-      - telemetry
-    nodeTemplate:
-      extraMounts:
-      - extraVolType: Ceph
-        volumes:
-        - name: ceph
-          secret:
-            secretName: ceph-conf-files
-        mounts:
-        - name: ceph
-          mountPath: "/etc/ceph"
-          readOnly: true
-  "
-done
+    - bootstrap
+    - download-cache
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - reboot-os
+    - ceph-client
+    - install-certs
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova
+    - telemetry
+  nodeTemplate:
+    extraMounts:
+    - extraVolType: Ceph
+      volumes:
+      - name: ceph
+        secret:
+          secretName: ceph-conf-files
+      mounts:
+      - name: ceph
+        mountPath: "/etc/ceph"
+        readOnly: true
+"
 ----
 +
 [NOTE]
-Ensure that you use the same list of services from the original `OpenStackDataPlaneNodeSet` CR, except for the inserted `ceph-client` and `ceph-hci-pre` services.
+Ensure that you use the same list of services from the original `OpenStackDataPlaneNodeSet` CR, except for the inserted `ceph-client` service.
 
 . Optional: Enable `neutron-sriov-nic-agent` in the `OpenStackDataPlaneNodeSet` CR:
 +
 [source,yaml]
 ----
-$ for CELL in $(echo $RENAMED_CELLS); do
-  test -f nodeset-${CELL}.yaml || continue
-  oc patch openstackdataplanenodeset openstack-$CELL --type='json' --patch='[
+$ oc patch openstackdataplanenodeset openstack-cell1 --type='json' --patch='[
   {
     "op": "add",
     "path": "/spec/services/-",
@@ -674,23 +524,20 @@ $ for CELL in $(echo $RENAMED_CELLS); do
     "op": "add",
     "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors",
     "value": "dummy-dev:standalone.localdomain"
-  }]'
-  done
+  }
+]'
 ----
 
 . Optional: Enable `neutron-dhcp` in the `OpenStackDataPlaneNodeSet` CR:
 +
 [source,yaml]
 ----
-$ for CELL in $(echo $RENAMED_CELLS); do
-  test -f nodeset-${CELL}.yaml || continue
-  oc patch openstackdataplanenodeset openstack-$CELL --type='json' --patch='[
+$ oc patch openstackdataplanenodeset openstack-cell1 --type='json' --patch='[
   {
     "op": "add",
     "path": "/spec/services/-",
     "value": "neutron-dhcp"
   }]'
-done
 ----
 +
 [NOTE]
@@ -736,15 +583,12 @@ kind: OpenStackDataPlaneDeployment
 metadata:
   name: openstack-pre-adoption
 spec:
-  nodeSets: $NODESETS
+  nodeSets:
+  - openstack
   servicesOverride:
   - pre-adoption-validation
 EOF
 ----
-+
-
-[NOTE]
-If you created different migration SSH keys for different OpenStackDataPlaneService CRs, you should also define a separate `OpenStackDataPlaneDeployment` CR for each nodeset (or nodesets) representing a cell.
 
 .. When the validation is finished, confirm that the status of the Ansible EE pods is `Completed`:
 +
@@ -802,7 +646,8 @@ kind: OpenStackDataPlaneDeployment
 metadata:
   name: tripleo-cleanup
 spec:
-  nodeSets: $NODESETS
+  nodeSets:
+  - openstack
   servicesOverride:
   - tripleo-cleanup
 EOF
@@ -818,7 +663,8 @@ kind: OpenStackDataPlaneDeployment
 metadata:
   name: openstack
 spec:
-  nodeSets: $NODESETS
+  nodeSets:
+  - openstack
 EOF
 ----
 +
@@ -838,12 +684,10 @@ $ watch oc get pod -l app=openstackansibleee
 $ oc logs -l app=openstackansibleee -f --max-log-requests 20
 ----
 
-. Wait for the data plane node sets to reach the `Ready` status:
+. Wait for the data plane node set to reach the `Ready` status:
 +
 ----
-$ for CELL in $(echo $RENAMED_CELLS); do
-  oc wait --for condition=Ready osdpns/openstack-$CELL --timeout=30m
-done
+$ oc wait --for condition=Ready osdpns/openstack-cell1 --timeout=30m
 ----
 
 . Verify that the {networking_first_ref} agents are running:
@@ -858,12 +702,6 @@ $ oc exec openstackclient -- openstack network agent list
 | a4f1b584-16f1-4937-b2b0-28102a3f6eaa | OVN Controller agent         | standalone.localdomain |                   | :-)   | UP    | ovn-controller             |
 +--------------------------------------+------------------------------+------------------------+-------------------+-------+-------+----------------------------+
 ----
-
-[NOTE]
-====
-After removing all services on {OpenStackPreviousInstaller} cell controllers, you may decomission those.
-To become new cell compute nodes, you should re-provision decomissioned controllers as new EDPM hosts and add them into node sets of corresponding (or new) cells.
-====
 
 .Next steps
 

--- a/docs_user/modules/proc_adopting-the-compute-service.adoc
+++ b/docs_user/modules/proc_adopting-the-compute-service.adoc
@@ -13,21 +13,8 @@ To adopt the {compute_service_first_ref}, you patch an existing `OpenStackContro
 * You have completed the previous adoption steps.
 * You have defined the following shell variables. Replace the following example values with the values that are correct for your environment:
 ----
-alias openstack="oc exec -t openstackclient -- openstack"
-
-DEFAULT_CELL_NAME="cell3"
-RENAMED_CELLS="cell1 cell2 $DEFAULT_CELL_NAME"
+$ alias openstack="oc exec -t openstackclient -- openstack"
 ----
-+
-The source cloud 'default' cell takes a new `$DEFAULT_CELL_NAME`. In a multi-cell adoption scenario, it may either retain its original name (`DEFAULT_CELL_NAME=default`), or become renamed into a free for use cell name. Never chose other existing cells names (except 'default') for `DEFAULT_CELL_NAME`.
-
-When you have deployed the source cloud with only a 'default' cell, and want to rename it during adoption, you should define that instead:
-+
-----
-DEFAULT_CELL_NAME="cell1"
-RENAMED_CELLS="cell1"
-----
-+
 
 .Procedure
 
@@ -35,40 +22,10 @@ RENAMED_CELLS="cell1"
 +
 [NOTE]
 This procedure assumes that {compute_service} metadata is deployed on the top level and not on each cell level. If the {OpenStackShort} deployment has a per-cell metadata deployment, adjust the following patch as needed. You cannot run the metadata service in `cell0`.
-To enable local cells metadata services, set `spec.nova.template.cellTemplates.cell*.metadataServiceTemplate.enable` in `OpenStackControlPlane` CR.
 +
 [source,yaml]
 ----
-rm -f celltemplates
-for CELL in $(echo $RENAMED_CELLS); do
-  cat >> celltemplates << EOF
-        ${CELL}:
-          hasAPIAccess: true <4>
-          cellDatabaseAccount: nova-$CELL
-          cellDatabaseInstance: openstack-$CELL <1>
-          cellMessageBusInstance: rabbitmq-$CELL <2>
-          metadataServiceTemplate:
-            enabled: false # enable here to run it in a cell instead
-            override:
-                service:
-                  metadata:
-                    annotations:
-                      metallb.universe.tf/address-pool: internalapi
-                      metallb.universe.tf/allow-shared-ip: internalapi
-                      metallb.universe.tf/loadBalancerIPs: 172.17.0.$(( 79 + ${CELL##*cell} ))
-                  spec:
-                    type: LoadBalancer
-            customServiceConfig: |
-              [workarounds]
-              disable_compute_service_check_for_ffu=true
-          conductorServiceTemplate:
-            customServiceConfig: |
-              [workarounds]
-              disable_compute_service_check_for_ffu=true
-EOF
-done
-
-cat > oscp-patch.yaml << EOF
+$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
 spec:
   nova:
     enabled: true
@@ -76,7 +33,6 @@ spec:
       route: {}
     template:
       secret: osp-secret
-      apiDatabaseAccount: nova-api
       apiServiceTemplate:
         override:
           service:
@@ -85,7 +41,7 @@ spec:
                 annotations:
                   metallb.universe.tf/address-pool: internalapi
                   metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80 <3>
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80 <1>
               spec:
                 type: LoadBalancer
         customServiceConfig: |
@@ -111,29 +67,39 @@ spec:
           disable_compute_service_check_for_ffu=true
       cellTemplates:
         cell0:
-          hasAPIAccess: true
-          cellDatabaseAccount: nova-cell0
-          cellDatabaseInstance: openstack
-          cellMessageBusInstance: rabbitmq
           conductorServiceTemplate:
             customServiceConfig: |
               [workarounds]
               disable_compute_service_check_for_ffu=true
-EOF
-cat celltemplates >> oscp-patch.yaml
-oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+        cell1:
+          metadataServiceTemplate:
+            enabled: false # enable here to run it in a cell instead
+            override:
+                service:
+                  metadata:
+                    annotations:
+                      metallb.universe.tf/address-pool: internalapi
+                      metallb.universe.tf/allow-shared-ip: internalapi
+                      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                  spec:
+                    type: LoadBalancer
+            customServiceConfig: |
+              [workarounds]
+              disable_compute_service_check_for_ffu=true
+          conductorServiceTemplate:
+            customServiceConfig: |
+              [workarounds]
+              disable_compute_service_check_for_ffu=true
+'
 ----
 +
-<1> The `cellDatabaseInstance` is the database instance that is used by the cell. The database instance names must match the names defined for OpenStackControlPlane created earlier in xref:deploying-backend-services_{context}[Deploying back-end services].
-<2> The `cellMessageBusInstance` is the message bus instance that is used by the cell. The message bus instance names must match the names defined for OpenStackControlPlane created earlier.
-<3> If you use IPv6, change the load balancer IP to the load balancer IP in your environment, for example, `metallb.universe.tf/loadBalancerIPs: fd00:bbbb::80`.
-<4> In the source cloud, cells are always configured with the main Nova API database "upcall" access. It may be changed per a cell by setting `hasAPIAccess: false`. However, such changes are not recommented during adoption.
+<1> If you use IPv6, change the load balancer IP to the load balancer IP in your environment, for example, `metallb.universe.tf/loadBalancerIPs: fd00:bbbb::80`.
 
-. If you are adopting the {compute_service} with the {bare_metal_first_ref}, append the following `novaComputeTemplates` in the each `cellX` section of the {compute_service} CR patch:
+. If you are adopting the {compute_service} with the {bare_metal_first_ref}, append the following `novaComputeTemplates` in the `cell1` section of the {compute_service} CR patch:
 +
 [source,yaml]
 ----
-        cell<index>:
+        cell1:
           novaComputeTemplates:
             standalone:
               customServiceConfig: |
@@ -141,11 +107,9 @@ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=
                 host = <hostname>
                 [workarounds]
                 disable_compute_service_check_for_ffu=true
-              computeDriver: ironic.IronicDriver
-        ...
 ----
 +
-* Replace `<hostname>` with the hostname of the node that is running the `ironic` Compute driver in the source cloud.
+* Replace <hostname> with the hostname of the node that is running the `ironic` Compute driver in the source cloud.
 
 . Wait for the CRs for the Compute control plane services to be ready:
 +
@@ -155,7 +119,7 @@ $ oc wait --for condition=Ready --timeout=300s Nova/nova
 +
 [NOTE]
 The local Conductor services are started for each cell, while the superconductor runs in `cell0`.
-Note that `disable_compute_service_check_for_ffu` is mandatory for all imported Compute services until the external data plane is imported, and until Compute services are fast-forward upgraded. For more information, see xref:adopting-compute-services-to-the-data-plane_data-plane[Adopting Compute services to the {rhos_acro} data plane] and xref:performing-a-fast-forward-upgrade-on-compute-services_data-plane[Upgrading Compute services].
+Note that `disable_compute_service_check_for_ffu` is mandatory for all imported Compute services until the external data plane is imported, and until Compute services are fast-forward upgraded. For more information, see xref:adopting-compute-services-to-the-data-plane_data-plane[Adopting Compute services to the {rhos_acro} data plane] and xref:performing-a-fast-forward-upgrade-on-compute-services_data-plane[Performing a fast-forward upgrade on Compute services].
 
 .Verification
 
@@ -169,33 +133,24 @@ $ openstack server list
 +
 ** Compare the outputs with the topology-specific configuration in xref:proc_retrieving-topology-specific-service-configuration_migrating-databases[Retrieving topology-specific service configuration].
 
-* Query the superconductor to check that the expected cells exist, and compare it to pre-adoption values:
+* Query the superconductor to check that `cell1` exists, and compare it to pre-adoption values:
 +
 ----
-$ for CELL in $(echo $CELLS); do
-  set +u
-  . ~/.source_cloud_exported_variables_$CELL
-  set -u
-  RCELL=$CELL
-  [ "$CELL" = "default" ] && RCELL=$DEFAULT_CELL_NAME
-
-  echo "comparing $CELL to $RCELL"
-  echo $PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS | grep -F "| $CELL |"
-  oc rsh nova-cell0-conductor-0 nova-manage cell_v2 list_cells | grep -F "| $RCELL |"
-done
+set +u
+. ~/.source_cloud_exported_variables_default
+set -u
+echo $PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS
+oc rsh nova-cell0-conductor-0 nova-manage cell_v2 list_cells | grep -F '| cell1 |'
 ----
 +
-The following changes are expected, for each cell `X`:
+The following changes are expected:
 +
-** The `cellX` `nova` database and username become `nova_cellX`.
-** The `default` cell is renamed to `DEFAULT_CELL_NAME` (it may retain the original name, if there are multiple cells).
-** RabbitMQ transport URL no longer uses `guest`.
+** The `cell1` `nova` database and username become `nova_cell1`.
+** The default cell is renamed to `cell1`.
 ** RabbitMQ transport URL no longer uses `guest`.
 
 [NOTE]
-====
 At this point, the {compute_service} control plane services do not control the existing {compute_service} workloads. The control plane manages the data plane only after the data adoption process is completed. For more information, see xref:adopting-compute-services-to-the-data-plane_data-plane[Adopting Compute services to the {rhos_acro} data plane].
-====
 
 [IMPORTANT]
 To import external Compute services to the {rhos_acro} data plane, you must upgrade them first.

--- a/docs_user/modules/proc_configuring-data-plane-nodes.adoc
+++ b/docs_user/modules/proc_configuring-data-plane-nodes.adoc
@@ -18,7 +18,7 @@ kind: NetConfig
 metadata:
   name: netconfig
 spec:
-  networks: <1>
+  networks:
   - name: internalapi
     dnsDomain: internalapi.example.com
     subnets:
@@ -47,7 +47,6 @@ spec:
       cidr: 172.19.0.0/24
       vlan: 22
 ----
-<1> The networks composition must match the source cloud configuration to avoid dataplane connectivity downtime.
 
 . Optional: In the `NetConfig` CR, list multiple ranges for the `allocationRanges` field to exclude some of the IP addresses, for example, to accommodate IP addresses that are already consumed by the adopted environment:
 +

--- a/docs_user/modules/proc_deploying-backend-services.adoc
+++ b/docs_user/modules/proc_deploying-backend-services.adoc
@@ -289,14 +289,6 @@ endif::[]
         secret: osp-secret
         replicas: 3
         storageRequest: 5G
-      openstack-cell2:
-        secret: osp-secret
-        replicas: 1
-        storageRequest: 5G
-      openstack-cell3:
-        secret: osp-secret
-        replicas: 1
-        storageRequest: 5G
   memcached:
     enabled: true
     templates:
@@ -380,28 +372,6 @@ ifeval::["{build_variant}" == "ospdo"]
 endif::[]
             spec:
               type: LoadBalancer
-      rabbitmq-cell2:
-        persistence:
-          storage: 1G
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.87
-            spec:
-              type: LoadBalancer
-      rabbitmq-cell3:
-        persistence:
-          storage: 1G
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: 172.17.0.88
-            spec:
-              type: LoadBalancer
   telemetry:
     enabled: false
 
@@ -427,16 +397,15 @@ ifeval::["{build_variant}" == "ospdo"]
 
 endif::[]
 
-This example provides the required infrastructure database and messaging services for 3 Compute cells
-named `cell1`, `cell2`, and `cell3`. Adjust the names, counts, IP addresses, and numbers,
-such as for `replicas`, `storage`, or `storageRequest`, as needed.
+This example provides the required infrastructure database and messaging services for 1 Compute cell
+named `cell1`. Adjust the names, counts, IP addresses, and numbers, such as for `replicas`, `storage`, or `storageRequest`, as needed.
 
 .Verification
 
 * Verify that MariaDB and RabbitMQ are running for all defined cells:
 +
 ----
-$ RENAMED_CELLS="cell1 cell2 cell3"
+$ RENAMED_CELLS="cell1"
 $ oc get pod openstack-galera-0 -o jsonpath='{.status.phase}{"\n"}' | grep Running
 $ oc get pod rabbitmq-server-0 -o jsonpath='{.status.phase}{"\n"}' | grep Running
 $ for CELL in $(echo $RENAMED_CELLS); do

--- a/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
+++ b/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
@@ -31,9 +31,9 @@ $ OSPDO_MARIADB_CLIENT_ANNOTATIONS='[{"name": "internalapi-static","ips": ["172.
 $ MARIADB_RUN_OVERRIDES="$OSPDO_MARIADB_CLIENT_ANNOTATIONS"
 endif::[]
 
-$ CELLS="default cell1 cell2" <1>
-$ DEFAULT_CELL_NAME="cell3"
-$ RENAMED_CELLS="cell1 cell2 $DEFAULT_CELL_NAME"
+$ CELLS="default" <1>
+$ DEFAULT_CELL_NAME="cell1"
+$ RENAMED_CELLS="$DEFAULT_CELL_NAME"
 
 $ NAMESPACE="openstack"
 

--- a/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
+++ b/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
@@ -27,7 +27,7 @@ done
 
 .Procedure
 
-. Wait for {compute_service} data plane services version updated for all cells:
+. Wait for cell1 Compute data plane services version to update:
 +
 ----
 $ for CELL in $(echo $RENAMED_CELLS); do
@@ -47,10 +47,17 @@ Review any errors in the nova Compute agent logs on the data plane, and the `nov
 +
 [source,yaml]
 ----
-$ rm -f celltemplates
-$ for CELL in $(echo $RENAMED_CELLS); do
-  cat >> celltemplates << EOF
-        ${CELL}:
+$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
+spec:
+  nova:
+    template:
+      cellTemplates:
+        cell0:
+          conductorServiceTemplate:
+            customServiceConfig: |
+              [workarounds]
+              disable_compute_service_check_for_ffu=false
+        cell1:
           metadataServiceTemplate:
             customServiceConfig: |
               [workarounds]
@@ -59,13 +66,6 @@ $ for CELL in $(echo $RENAMED_CELLS); do
             customServiceConfig: |
               [workarounds]
               disable_compute_service_check_for_ffu=false
-EOF
-done
-
-$ cat > oscp-patch.yaml << EOF
-spec:
-  nova:
-    template:
       apiServiceTemplate:
         customServiceConfig: |
           [workarounds]
@@ -78,39 +78,7 @@ spec:
         customServiceConfig: |
           [workarounds]
           disable_compute_service_check_for_ffu=false
-      cellTemplates:
-        cell0:
-          conductorServiceTemplate:
-            customServiceConfig: |
-              [workarounds]
-              disable_compute_service_check_for_ffu=false
-EOF
-$ cat celltemplates >> oscp-patch.yaml
-----
-+
-
-* If you are adopting the {compute_service} with the {bare_metal_first_ref}, append the following `novaComputeTemplates` in the needed `cell<N>` section(s) of the {compute_service} CR patch:
-+
-[source,yaml]
-----
-        cell<N>:
-          novaComputeTemplates:
-            <hostname>: <1>
-              customServiceConfig: |
-                [DEFAULT]
-                host = <hostname>
-                [workarounds]
-                disable_compute_service_check_for_ffu=true
-              computeDriver: ironic.IronicDriver
-        ...
-----
-+
-<1> Replace `<hostname>` with the hostname of the node that is running the `ironic` Compute driver in the source cloud cell<N>.
-
-. Apply the patch file
-+
-----
-$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+'
 ----
 
 . Wait until the Compute control plane services CRs are ready:
@@ -125,43 +93,49 @@ $ oc wait --for condition=Ready --timeout=300s Nova/nova
 +
 [source,yaml]
 ----
-$ oc patch cm nova-cells-global-config --type=json -p='[{"op": "replace", "path": "/data/99-nova-compute-cells-workarounds.conf", "value": "[workarounds]\n"}]'
-$ for CELL in $(echo $RENAMED_CELLS); do
-  oc get Openstackdataplanenodeset openstack-${CELL} || continue
-  oc apply -f - <<EOF
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nova-extra-config
+  namespace: openstack
+data:
+  20-nova-compute-cell1-workarounds.conf: |
+    [workarounds]
+    disable_compute_service_check_for_ffu=false
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-nova-compute-ffu-$CELL
+  name: openstack-nova-compute-ffu
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-${CELL}
+    - openstack
   servicesOverride:
-    - nova-${CELL}
-backoffLimit: 3
+    - nova
 EOF
-done
 ----
 +
+[NOTE]
+The service included in the `servicesOverride` key must match the name of the service that you included in the `OpenStackDataPlaneNodeSet` CR. For example, if you use a custom service called `nova-custom`, ensure that you add it to the `servicesOverride` key.
 
-. Wait for the Compute data plane services to be ready for all cells:
+. Wait for the Compute data plane services to be ready:
 +
 ----
-$ oc wait --for condition=Ready openstackdataplanedeployments --all --timeout=5m
+$ oc wait --for condition=Ready openstackdataplanedeployment/openstack-nova-compute-ffu --timeout=5m
 ----
 
-. Run Compute database online migrations to complete the upgrade:
+. Run Compute database online migrations to complete the fast-forward upgrade:
 +
 ----
 $ oc exec -it nova-cell0-conductor-0 -- nova-manage db online_data_migrations
-$ for CELL in $(echo $RENAMED_CELLS); do
-  oc exec -it nova-${CELL}-conductor-0 -- nova-manage db online_data_migrations
-done
+$ oc exec -it nova-cell1-conductor-0 -- nova-manage db online_data_migrations
 ----
 
-. Discover Compute hosts in the cells:
+.Verification
+
+. Discover the Compute hosts in the cell:
 +
 ----
 $ oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose

--- a/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
+++ b/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
@@ -25,7 +25,7 @@ $ MARIADB_IMAGE=registry.redhat.io/rhoso/openstack-mariadb-rhel9:18.0
 endif::[]
 $ declare -A TRIPLEO_PASSWORDS
 ifeval::["{build_variant}" != "ospdo"]
-$ CELLS="default cell1 cell2"
+$ CELLS="default"
 $ for CELL in $(echo $CELLS); do
 >    TRIPLEO_PASSWORDS[$CELL]="$PASSWORD_FILE"
 > done

--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -82,15 +82,6 @@ spec:
         secret: osp-secret
         replicas: 1
         storageRequest: 1Gi
-      # TODO(bogdando): iterate based on renamed_cells value in kustomization.yaml
-      openstack-cell2:
-        secret: osp-secret
-        replicas: 1
-        storageRequest: 1Gi
-      openstack-cell3:
-        secret: osp-secret
-        replicas: 1
-        storageRequest: 1Gi
 
   memcached:
     enabled: true
@@ -155,28 +146,6 @@ spec:
               annotations:
                 metallb.universe.tf/address-pool: internalapi
                 metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.86
-            spec:
-              type: LoadBalancer
-      rabbitmq-cell2:
-        persistence:
-          storage: 3Gi
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.87
-            spec:
-              type: LoadBalancer
-      rabbitmq-cell3:
-        persistence:
-          storage: 3Gi
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.88
             spec:
               type: LoadBalancer
   telemetry:

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -32,42 +32,6 @@ cells_env: |
   DEFAULT_CELL_NAME={{ default_cell_name }}
   RENAMED_CELLS="{{ renamed_cells | join(' ') }}"
 
-# Header for osdp nodesets names evaluation
-nodesets_env: |
-  {{ edpm_computes_shell_vars_src }}
-
-  NODESETS=""
-  for CELL in $(echo $RENAMED_CELLS); do
-    ref="COMPUTES_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')"
-    eval names=\${!${ref}[@]}
-    [ -z "$names" ] && continue
-    NODESETS="'openstack-${CELL}', $NODESETS"
-  done
-  NODESETS="[${NODESETS%,*}{% if edpm_nodes_networker is defined %}, 'openstack-networker'{% endif %}]"
-
-nodesets_env_oc: |
-  {{ shell_header }}
-  {{ oc_header }}
-  {{ cells_env }}
-
-  NODESETS=""
-  for CELL in $(echo $RENAMED_CELLS); do
-    oc get Openstackdataplanenodeset openstack-${CELL} || continue
-    NODESETS="'openstack-${CELL}', $NODESETS"
-  done
-  NODESETS="[${NODESETS%,*}]"
-
-# Header for custom nova osdp services names evaluation
-nova_services_env: |
-  {{ shell_header }}
-  {{ cells_env }}
-
-  NOVASERVICES=""
-  for CELL in $(echo $RENAMED_CELLS); do
-    NOVASERVICES="'nova-${CELL}', $NOVASERVICES"
-  done
-  NOVASERVICES="[${NOVASERVICES%,*}]"
-
 # Headers for DB client CLI image
 mariadb_image_env: |
   STORAGE_CLASS={{ storage_class_name }}
@@ -165,27 +129,6 @@ mariadb_copy_shell_vars_dst: |
       PODIFIED_MARIADB_IP[$CELL]=$(oc get svc --selector "mariadb/name=openstack-$CELL" -ojsonpath='{.items[0].spec.clusterIP}')
     fi
   done
-
-# Header for the destination cloud EDPM Nova cell computes FDQN and IP pairs, per a cell
-# NOTE: Assume inernalapi network comes with an index 1. Ignore FQDN on a network to simply bind IPs by a hostname.
-edpm_computes_shell_vars_src: |-
-  {{ shell_header }}
-  {{ cells_env }}
-
-  {% for cell in renamed_cells %}
-  declare -A COMPUTES_{{ cell.upper() }}
-  COMPUTES_{{ cell.upper() }}=(
-    {%- for v in edpm_nodes[cell] | default({}) %}
-    ["{{ edpm_nodes[cell][v].hostName }}"]={{ edpm_nodes[cell][v].ansible.ansibleHost }}
-    {% endfor -%}
-  )
-  declare -A COMPUTES_API_{{ cell.upper() }}
-  COMPUTES_API_{{ cell.upper() }}=(
-    {%- for v in edpm_nodes[cell] | default({}) %}
-    ["{{ edpm_nodes[cell][v].hostName }}"]={{ edpm_nodes[cell][v].networks[1].fixedIP|default("") }}
-    {% endfor -%}
-  )
-  {% endfor %}
 
 pull_openstack_configuration_ssh_shell_vars: |
   CONTROLLER1_SSH="{{ controller1_ssh }}"

--- a/tests/roles/control_plane_rollback/defaults/main.yaml
+++ b/tests/roles/control_plane_rollback/defaults/main.yaml
@@ -1,3 +1,2 @@
-os_cloud_name: standalone
 control_plane_rollback_verify_command: |
   ssh root@{{ standalone_ip }} OS_CLOUD={{ os_cloud_name }} openstack user list

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -160,12 +160,11 @@ os_diff_data_dir: tmp/os-diff
 prelaunch_test_instance: true
 telemetry_adoption: true
 
-# nodes data will be templated in as a separate
 dataplane_cr: |
   apiVersion: dataplane.openstack.org/v1beta1
   kind: OpenStackDataPlaneNodeSet
   metadata:
-    name: openstack-$CELL
+    name: openstack-cell1
   spec:
     tlsEnabled: {{ enable_tlse }}
     networkAttachments:
@@ -186,7 +185,7 @@ dataplane_cr: |
       - neutron-metadata
       {%+ if compute_adoption|bool +%}
       - libvirt
-      - nova-$CELL
+      - nova
       {%+ endif +%}
       {% if telemetry_adoption|bool +%}
       - telemetry
@@ -201,7 +200,8 @@ dataplane_cr: |
       - name: ANSIBLE_SSH_ARGS
         value: "-C -o ControlMaster=auto -o ControlPersist=80s"
       - name: ANSIBLE_VERBOSITY
-        value: "{{ dataplane_verbosity | default ('3') }}"
+        value: "{{ dataplane_verbosity | default ('1') }}"
+    nodes: {{ edpm_nodes["cell1"] | default(edpm_nodes) }}
     nodeTemplate:
       ansibleSSHPrivateKeySecret: {{ ansible_ssh_private_key_secret }}
       ansible:
@@ -288,7 +288,6 @@ dataplane_cr: |
           ovn_monitor_all: true
           edpm_ovn_remote_probe_interval: 60000
           edpm_ovn_ofctrl_wait_before_clear: 8000
-    nodes:
 
 dpa_dir: "../.."
 dpa_tests_dir: "{{ dpa_dir }}/tests"

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -6,7 +6,6 @@
     ceph_backend_configuration_fsid_shell_vars: |
       CEPH_FSID=$(oc get secret ceph-conf-files -o json | jq -r '.data."ceph.conf"' | base64 -d | grep fsid | sed -e 's/fsid = //')
 
-# FIXME: missing docs coverage?
 - name: Patch openstackversion to use image built from source or latest if none is defined
   when: not skip_patching_ansibleee_csv | bool
   no_log: "{{ use_no_log }}"
@@ -112,7 +111,7 @@
     - not ospdo_src| bool
     - libvirt_password | length > 0
 
-- name: create a configuration map which should become common for all cells (local storage back end)
+- name: create a Nova Compute Extra Config service (no ceph backend in use)
   when:
     - compute_adoption|bool
     - ('ceph' not in [nova_libvirt_backend])
@@ -124,15 +123,15 @@
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: nova-cells-global-config
+      name: nova-extra-config
       namespace:  {{ rhoso_namespace }}
     data:
-      99-nova-compute-cells-workarounds.conf: |
+      19-nova-compute-cell1-workarounds.conf: |
         [workarounds]
         disable_compute_service_check_for_ffu=true
     EOF
 
-- name: create a configuration map which should become common for all cells (Ceph storage back end)
+- name: create a Nova Compute Extra Config service (ceph backend in use)
   when:
     - compute_adoption|bool
     - ('ceph' in [nova_libvirt_backend])
@@ -145,10 +144,10 @@
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: nova-cells-global-config
+      name: nova-extra-config
       namespace: {{ rhoso_namespace }}
     data:
-      99-nova-compute-cells-workarounds.conf: |
+      19-nova-compute-cell1-workarounds.conf: |
         [workarounds]
         disable_compute_service_check_for_ffu=true
       03-ceph-nova.conf: |
@@ -163,104 +162,13 @@
         rbd_secret_uuid=$CEPH_FSID
     EOF
 
-- name: create dataplane services for Nova cells to enable pre-upgrade workarounds
-  when:
-    - compute_adoption|bool
+- name: Create OpenStackDataPlaneNodeSet
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
-    {{ oc_header }}
-    {{ cells_env }}
-
-    for CELL in $(echo $RENAMED_CELLS); do
-      oc apply -f - <<EOF
-    ---
-    apiVersion: dataplane.openstack.org/v1beta1
-    kind: OpenStackDataPlaneService
-    metadata:
-      name: nova-$CELL
-    spec:
-      dataSources:
-        - secretRef:
-            name: nova-$CELL-compute-config
-        - secretRef:
-            name: nova-migration-ssh-key
-        - configMapRef:
-            name: nova-cells-global-config
-      playbook: osp.edpm.nova
-      caCerts: combined-ca-bundle
-      edpmServiceType: nova
-      containerImageFields:
-      - NovaComputeImage
-      - EdpmIscsidImage
-    EOF
-    done
-
-# FIXME(bogdando): align docs and tests (nodeTemplate uses jinja2, ansible vars, is fell far behind that we have in docs)
-- name: Create the dataplane node sets definitions for each cell
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ nodesets_env }}
-
-    declare -A names
-    for CELL in $(echo $RENAMED_CELLS); do
-      ref="COMPUTES_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')"
-      eval names=\${!${ref}[@]}
-      ref_api="COMPUTES_API_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')"
-      [ -z "$names" ] && continue
-      ind=0
-      rm -f computes-$CELL
-      for compute in $names; do
-        ip="${ref}['$compute']"
-        ip_api="${ref_api}['$compute']"
-        cat >> computes-$CELL << EOF
-        ${compute}:
-          hostName: $compute
-          ansible:
-            ansibleHost: $compute
-          networks:
-          - defaultRoute: true
-            fixedIP: ${!ip}
-            name: ctlplane
-            subnetName: subnet1
-          - name: internalapi
-            subnetName: subnet1
-            fixedIP: ${!ip_api}
-          - name: storage
-            subnetName: subnet1
-          - name: tenant
-            subnetName: subnet1
-    EOF
-        ind=$(( ind + 1 ))
-      done
-
-      test -f computes-$CELL || continue
-      cat > nodeset-${CELL}.yaml <<EOF
+    cat <<EOF > edpm-crd.yaml
     {{ dataplane_cr}}
     EOF
-      #cat computes-$CELL >> nodeset-${CELL}.yaml
-    done
-  # NOTE(bogdando): omit computes-$CELL insertion as that is a manual operation only needed by docs.
-  # Those files are created here only to provide testing coverage of the commands provided in docs.
-  # Their contents is irrelevant as the real values come from edpm_nodes, by the below task.
-
-- name: update EDPM nodes data in nodes sets of cells
-  no_log: "{{ use_no_log }}"
-  when:
-    - compute_adoption|bool
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {% for cell in renamed_cells %}
-    {% if cell in edpm_nodes %}
-    cat > computes-real-{{ cell }} << EOF
-    {% filter indent(width=4) %}
-        {{ edpm_nodes[cell] | to_yaml(indent=2) }}
-    {% endfilter %}
-    EOF
-    cat computes-real-{{ cell }} >> nodeset-{{ cell }}.yaml
-    {% endif %}
-    {% endfor %}
 
 - name: Create OpenStackDataPlaneNodeSet_networker
   when: edpm_nodes_networker is defined or edpm_networker_deploy
@@ -271,93 +179,71 @@
     {{ networker_cr }}
     EOF
 
-# FIXME: this is different in docs, need to align with tests
-# FIXME(bogdando): get ovs_external_ids.json data for multiple node sets
 - name: check ovs external-ids with os-diff before deployment
-  failed_when: false
   tags: pull_openstack_configuration
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
-    {{ cells_env }}
-    for CELL in $(echo $RENAMED_CELLS); do
-      test -f nodeset-${CELL}.yaml || continue
-      {{ os_diff_dir }}/os-diff diff {{ os_diff_data_dir }}/tripleo/ovs_external_ids/standalone/ovs_external_ids.json nodeset-${CELL}.yaml --crd --service ovs_external_ids -f ${PWD}/{{ os_diff_dir }}/config.yaml
-    done
+    {{ os_diff_dir }}/os-diff diff {{ os_diff_data_dir }}/tripleo/ovs_external_ids/standalone/ovs_external_ids.json edpm-crd.yaml --crd --service ovs_external_ids -f ${PWD}/{{ os_diff_dir }}/config.yaml
 
-- name: deploy the OpenStackDataPlaneNodeSet CRs for each Nova compute cell
+- name: deploy dataplane
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
-
-    for CELL in $(echo $RENAMED_CELLS); do
-      test -f nodeset-${CELL}.yaml || continue
-      oc apply -f nodeset-${CELL}.yaml
-    done
-
+    cat edpm-crd.yaml | oc apply -f -
     {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
     cat edpm-crd-networker.yaml | oc apply -f -
     {%+ endif +%}
 
-# TODO(bogdando): Apply the ceph backend config for Cinder in the original openstack CR, via kustomize perhaps?
-- name: prepare the adopted data plane workloads to use Ceph backend for Cinder, if configured so
+# TODO: Apply the ceph backend config for Cinder in the original openstack CR, via kustomize
+- name: prepare adopted EDPM workloads to use Ceph backend for Cinder, if configured so
   no_log: "{{ use_no_log }}"
   when:
     - compute_adoption|bool
-    - cinder_volume_backend == "ceph" or cinder_backup_backend == "ceph" or ('ceph' in [nova_libvirt_backend])
+    - cinder_volume_backend == "ceph" or cinder_backup_backend == "ceph"
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
+    oc patch osdpns/openstack-cell1 --type=merge --patch "
+    spec:
+      services:
+        - bootstrap
+        - download-cache
+        - configure-network
+        - validate-network
+        - install-os
+        - ceph-hci-pre
+        - configure-os
+        - ssh-known-hosts
+        - run-os
+        - reboot-os
+        - ceph-client
+        - ovn
+        - neutron-metadata
+        - libvirt
+        - nova
+        {% if telemetry_adoption|bool +%}
+        - telemetry
+        {%+ endif +%}
+      nodeTemplate:
+        extraMounts:
+        - extraVolType: Ceph
+          volumes:
+          - name: ceph
+            secret:
+              secretName: ceph-conf-files
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true
+    "
 
-    for CELL in $(echo $RENAMED_CELLS); do
-      test -f nodeset-${CELL}.yaml || continue
-      oc patch osdpns/openstack-$CELL --type=merge --patch "
-      spec:
-        services:
-          - bootstrap
-          - download-cache
-          - configure-network
-          - validate-network
-          - install-os
-          - configure-os
-          - ssh-known-hosts
-          - run-os
-          - reboot-os
-          - install-certs
-          - ceph-client
-          - ovn
-          - neutron-metadata
-          - libvirt
-          - nova-$CELL
-          {% if telemetry_adoption|bool +%}
-          - telemetry
-          {%+ endif +%}
-        nodeTemplate:
-          extraMounts:
-          - extraVolType: Ceph
-            volumes:
-            - name: ceph
-              secret:
-                secretName: ceph-conf-files
-            mounts:
-            - name: ceph
-              mountPath: "/etc/ceph"
-              readOnly: true
-      "
-    done
-
-- name: enable neutron-sriov-nic-agent in the OpenStackDataPlaneNodeSet CR
+- name: set neutron-sriov-nic-agent configuration in the OpenStackDataPlaneNodeSet CR
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
-
-    for CELL in $(echo $RENAMED_CELLS); do
-      test -f nodeset-${CELL}.yaml || continue
-      oc patch openstackdataplanenodeset openstack-$CELL --type='json' --patch='[
+    oc patch openstackdataplanenodeset openstack-cell1 --type='json' --patch='[
       {
         "op": "add",
         "path": "/spec/services/-",
@@ -375,33 +261,27 @@
         "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_agent_SRIOV_NIC_resource_provider_hypervisors",
         "value": ""
       }]'
-    done
   when:
     - edpm_neutron_sriov_agent_enabled|bool
     - compute_adoption|bool
 
-- name: enable neutron-dhcp in the OpenStackDataPlaneNodeSet CR
+- name: set neutron-dhcp configuration in the OpenStackDataPlaneNodeSet CR
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
-
-    for CELL in $(echo $RENAMED_CELLS); do
-      test -f nodeset-${CELL}.yaml || continue
-      oc patch openstackdataplanenodeset openstack-$CELL --type='json' --patch='[
+    oc patch openstackdataplanenodeset openstack-cell1 --type='json' --patch='[
       {
         "op": "add",
         "path": "/spec/services/-",
         "value": "neutron-dhcp"
       }]'
-    done
   when: edpm_neutron_dhcp_agent_enabled|bool
 
-- name: Run the pre-adoption validation
+- name: Run pre-adoption validation
   when: run_pre_adoption_validation|bool
   block:
-    - name: create the validation service
+    - name: Create OpenStackDataPlaneService/pre-adoption-validation
       no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
         {{ shell_header }}
@@ -415,29 +295,27 @@
           playbook: osp.edpm.pre_adoption_validation
         EOF
 
-    - name: create a OpenStackDataPlaneDeployment CR that runs only the validation
+    - name: Create OpenStackDataPlaneDeployment to run the validation only
       no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
         {{ shell_header }}
-        {{ nodesets_env_oc }}
-
-        {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
-        NODESETS="${NODESETS%]*},openstack-networker]"
-        {%+ endif +%}
-
+        {{ oc_header }}
         oc apply -f - <<EOF
         apiVersion: dataplane.openstack.org/v1beta1
         kind: OpenStackDataPlaneDeployment
         metadata:
           name: openstack-pre-adoption
         spec:
-          nodeSets: $NODESETS
+          nodeSets:
+          - openstack-cell1
+          {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
+          - openstack-networker
+          {%+ endif +%}
           servicesOverride:
           - pre-adoption-validation
           backoffLimit: 1
         EOF
 
-    # FIXME: this is different in docs, need to align with tests
     - name: Wait for the validation deployment to finish
       ansible.builtin.shell: |
         {{ shell_header }}
@@ -468,9 +346,9 @@
         echo "Run out of retries"
         exit 2
 
-- name: Remove the remaining TripleO services
+- name: Remove leftover OOO services
   block:
-    - name: Create an OpenStackDataPlaneService CR to clean up the data plane services you are adopting
+    - name: Create OpenStackDataPlaneService/tripleo-cleanup
       no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
         {{ shell_header }}
@@ -484,23 +362,22 @@
           playbook: osp.edpm.tripleo_cleanup
         EOF
 
-    - name: Create the OpenStackDataPlaneDeployment CR to run the clean-up
+    - name: Create OpenStackDataPlaneDeployment to run cleanup
       no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
         {{ shell_header }}
-        {{ nodesets_env_oc }}
-
-        {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
-        NODESETS="${NODESETS%]*},openstack-networker]"
-        {%+ endif +%}
-
+        {{ oc_header }}
         oc apply -f - <<EOF
         apiVersion: dataplane.openstack.org/v1beta1
         kind: OpenStackDataPlaneDeployment
         metadata:
           name: tripleo-cleanup
         spec:
-          nodeSets: $NODESETS
+          nodeSets:
+          - openstack-cell1
+          {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
+          - openstack-networker
+          {%+ endif +%}
           servicesOverride:
           - tripleo-cleanup
           backoffLimit: 1
@@ -536,23 +413,22 @@
         echo "Run out of retries"
         exit 2
 
-- name: When the clean-up is finished, deploy the OpenStackDataPlaneDeployment CR
+- name: deploy the dataplane deployment
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
-    {{ nodesets_env_oc }}
-
-    {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
-    NODESETS="${NODESETS%]*},openstack-networker]"
-    {%+ endif +%}
-
+    {{ oc_header }}
     oc apply -f - <<EOF
     apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
     metadata:
       name: openstack
     spec:
-      nodeSets: $NODESETS
+      nodeSets:
+      - openstack-cell1
+      {%+ if edpm_nodes_networker is defined or edpm_networker_deploy +%}
+      - openstack-networker
+      {%+ endif +%}
       backoffLimit: 3
     EOF
 

--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -1,4 +1,4 @@
-- name: wait for Compute data plane services version updated for all cells
+- name: wait for cell1 Nova compute EDPM services version updated
   ansible.builtin.shell: |
     {{ mariadb_copy_shell_vars_dst }}
     for CELL in $(echo $RENAMED_CELLS); do
@@ -10,16 +10,21 @@
   retries: 20
   delay: 6
 
-- name: patch the OpenStackControlPlane CR to remove the pre-fast-forward upgrade workarounds
+- name: remove pre-FFU workarounds for Nova control plane services
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
-
-    rm -f celltemplates
-    for CELL in $(echo $RENAMED_CELLS); do
-      cat >> celltemplates << EOF
-            ${CELL}:
+    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
+    spec:
+      nova:
+        template:
+          cellTemplates:
+            cell0:
+              conductorServiceTemplate:
+                customServiceConfig: |
+                  [workarounds]
+                  disable_compute_service_check_for_ffu=false
+            cell1:
               metadataServiceTemplate:
                 customServiceConfig: |
                   [workarounds]
@@ -28,13 +33,6 @@
                 customServiceConfig: |
                   [workarounds]
                   disable_compute_service_check_for_ffu=false
-    EOF
-    done
-
-    cat > oscp-patch.yaml << EOF
-    spec:
-      nova:
-        template:
           apiServiceTemplate:
             customServiceConfig: |
               [workarounds]
@@ -47,58 +45,47 @@
             customServiceConfig: |
               [workarounds]
               disable_compute_service_check_for_ffu=false
-          cellTemplates:
-            cell0:
-              conductorServiceTemplate:
-                customServiceConfig: |
-                  [workarounds]
-                  disable_compute_service_check_for_ffu=false
-    EOF
-    cat celltemplates >> oscp-patch.yaml
+    '
 
-- name: Apply the patch file
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
-
-- name: wait until the Compute control plane services CRs are ready
+- name: Wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_role:
     name: nova_adoption
     tasks_from: wait.yaml
 
-- name: remove the pre-fast-forward upgrade workarounds from the Compute data plane services
+- name: remove pre-FFU workarounds for Nova compute EDPM services
   ansible.builtin.shell: |
     {{ shell_header }}
-    {{ nodesets_env_oc }}
-    {{ nova_services_env }}
-
-    oc patch cm nova-cells-global-config --type=json -p='[{"op": "replace", "path": "/data/99-nova-compute-cells-workarounds.conf", "value": "[workarounds]\n"}]'
-    for CELL in $(echo $RENAMED_CELLS); do
-      oc get Openstackdataplanenodeset openstack-${CELL} || continue
-      oc apply -f - <<EOF
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: nova-extra-config
+      namespace: openstack
+    data:
+      20-nova-compute-cell1-workarounds.conf: |
+        [workarounds]
+        disable_compute_service_check_for_ffu=false
     ---
     apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
     metadata:
-      name: openstack-nova-compute-ffu-$CELL
+      name: openstack-nova-compute-ffu
       namespace: openstack
     spec:
       nodeSets:
-        - openstack-${CELL}
+        - openstack-cell1
       servicesOverride:
-        - nova-${CELL}
-    backoffLimit: 3
+        - nova
+      backoffLimit: 3
     EOF
-    done
 
-# TODO(bogdando): a concurrent wait loop for multiple node sets in multiple deployments?
-- name: wait for the Compute data plane services to be ready for all cells
+- name: wait for Nova compute EDPM services to become ready
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
 
-    DEPLOYMENT_NAME=openstack-nova-compute-ffu-cell1
+    DEPLOYMENT_NAME=openstack-nova-compute-ffu
     TRIES=180
     DELAY=10
     ALLOWED_JOB_RETRIES=3
@@ -107,8 +94,7 @@
     do
         ready=$(oc get osdpd/$DEPLOYMENT_NAME -o jsonpath='{.status.conditions[0].status}')
         if [ "$ready" == "True" ]; then
-            echo "Deployment $DEPLOYMENT_NAME is Ready, waiting for other deployments to finish..."
-            oc wait --for condition=Ready openstackdataplanedeployments --all --timeout=5m
+            echo "Deployment is Ready"
             exit 0
         else
             failed=$(oc get jobs -l openstackdataplanedeployment=$DEPLOYMENT_NAME -o jsonpath="{.items[?(@.status.failed > $ALLOWED_JOB_RETRIES)].metadata.name}")
@@ -124,22 +110,18 @@
     echo "Run out of retries"
     exit 2
 
-- name: run Compute database online migrations to complete the upgrade
+- name: run Nova DB online migrations to complete FFU
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
-
-    oc exec -it nova-cell0-conductor-0 -- nova-manage db online_data_migrations
-    for CELL in $(echo $RENAMED_CELLS); do
-      oc exec -it nova-${CELL}-conductor-0 -- nova-manage db online_data_migrations
-    done
+    oc rsh nova-cell0-conductor-0 nova-manage db online_data_migrations
+    oc rsh nova-cell1-conductor-0 nova-manage db online_data_migrations
   register: nova_exec_result
   until: nova_exec_result is success
   retries: 10
   delay: 6
 
-- name: discover Compute hosts in the cells
+- name: discover Nova compute hosts in the cell
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}

--- a/tests/roles/nova_adoption/defaults/main.yaml
+++ b/tests/roles/nova_adoption/defaults/main.yaml
@@ -4,15 +4,52 @@ ironic_adoption_remove_ffu_workaround_patch: true
 nova_libvirt_backend: local
 
 nova_libvirt_patch: |
-  {{ cells_env }}
-  rm -f celltemplates
-  for CELL in $(echo $RENAMED_CELLS); do
-    cat >> celltemplates << EOF
-          ${CELL}:
-            hasAPIAccess: true
-            cellDatabaseAccount: nova-$CELL
-            cellDatabaseInstance: openstack-$CELL
-            cellMessageBusInstance: rabbitmq-$CELL
+  spec:
+    nova:
+      enabled: true
+      apiOverride:
+        route: {}
+      template:
+        secret: osp-secret
+        apiServiceTemplate:
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
+                spec:
+                  type: LoadBalancer
+          customServiceConfig: |
+            [workarounds]
+            disable_compute_service_check_for_ffu=true
+        metadataServiceTemplate:
+          enabled: true # deploy single nova metadata on the top level
+          override:
+            service:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
+              spec:
+                type: LoadBalancer
+          customServiceConfig: |
+            [workarounds]
+            disable_compute_service_check_for_ffu=true
+        schedulerServiceTemplate:
+          customServiceConfig: |
+            [workarounds]
+            disable_compute_service_check_for_ffu=true
+        cellTemplates:
+          cell0:
+            conductorServiceTemplate:
+              customServiceConfig: |
+                [workarounds]
+                disable_compute_service_check_for_ffu=true
+          cell1:
             metadataServiceTemplate:
               enabled: false # enable here to run it in a cell instead
               override:
@@ -21,7 +58,7 @@ nova_libvirt_patch: |
                       annotations:
                         metallb.universe.tf/address-pool: internalapi
                         metallb.universe.tf/allow-shared-ip: internalapi
-                        metallb.universe.tf/loadBalancerIPs: 172.17.0.$(( 79 + ${CELL##*cell} ))
+                        metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
                     spec:
                       type: LoadBalancer
               customServiceConfig: |
@@ -31,65 +68,7 @@ nova_libvirt_patch: |
               customServiceConfig: |
                 [workarounds]
                 disable_compute_service_check_for_ffu=true
-  EOF
-  done
 
-  cat > oscp-patch.yaml << EOF
-  spec:
-    nova:
-      enabled: true
-      apiOverride:
-        route: {}
-      template:
-        secret: osp-secret
-        apiDatabaseAccount: nova-api
-        apiServiceTemplate:
-          override:
-            service:
-              internal:
-                metadata:
-                  annotations:
-                    metallb.universe.tf/address-pool: internalapi
-                    metallb.universe.tf/allow-shared-ip: internalapi
-                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
-                spec:
-                  type: LoadBalancer
-          customServiceConfig: |
-            [workarounds]
-            disable_compute_service_check_for_ffu=true
-        metadataServiceTemplate:
-          enabled: true # deploy single nova metadata on the top level
-          override:
-            service:
-              metadata:
-                annotations:
-                  metallb.universe.tf/address-pool: internalapi
-                  metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
-              spec:
-                type: LoadBalancer
-          customServiceConfig: |
-            [workarounds]
-            disable_compute_service_check_for_ffu=true
-        schedulerServiceTemplate:
-          customServiceConfig: |
-            [workarounds]
-            disable_compute_service_check_for_ffu=true
-        cellTemplates:
-          cell0:
-            hasAPIAccess: true
-            cellDatabaseAccount: nova-cell0
-            cellDatabaseInstance: openstack
-            cellMessageBusInstance: rabbitmq
-            conductorServiceTemplate:
-              customServiceConfig: |
-                [workarounds]
-                disable_compute_service_check_for_ffu=true
-  EOF
-  cat celltemplates >> oscp-patch.yaml
-
-# NOTE(bogdando): no exact commands provided in docs for nova-ironic,
-# so we can use ansible/jinja2 features to simplify testing these
 nova_ironic_patch: |
   spec:
     nova:
@@ -98,7 +77,6 @@ nova_ironic_patch: |
         route: {}
       template:
         secret: osp-secret
-        apiDatabaseAccount: nova-api
         apiServiceTemplate:
           override:
             service:
@@ -137,23 +115,16 @@ nova_ironic_patch: |
               customServiceConfig: |
                 [workarounds]
                 disable_compute_service_check_for_ffu=true
-          {%+ for cell in renamed_cells +%}
-          {{ cell }}:
-            hasAPIAccess: true
-            cellDatabaseAccount: nova-cell{{ loop.index }}
-            cellDatabaseInstance: openstack-cell{{ loop.index }}
-            cellMessageBusInstance: rabbitmq-cell{{ loop.index }}
+          cell1:
             conductorServiceTemplate:
               customServiceConfig: |
                 [workarounds]
                 disable_compute_service_check_for_ffu=true
-            {%+ if ironic_adoption|bool and cell in source_ironic_nodes +%}
             novaComputeTemplates:
-              {%+ for n in source_ironic_nodes[cell] +%}
-              {{ n.template }}:
+              standalone:
                 customServiceConfig: |
                   [DEFAULT]
-                  host = {{ n.name }}
+                  host = standalone.localdomain
                   [workarounds]
                   disable_compute_service_check_for_ffu=true
                 replicas: 1
@@ -161,9 +132,6 @@ nova_ironic_patch: |
                 computeDriver: ironic.IronicDriver
                 networkAttachments:
                   - internalapi
-              {%+ endfor +%}
-            {%+ endif +%}
-          {%+ endfor +%}
 
 remove_ffu_workaround_patch: |
   spec:
@@ -187,26 +155,15 @@ remove_ffu_workaround_patch: |
               customServiceConfig: |
                 [workarounds]
                 disable_compute_service_check_for_ffu=false
-          {%+ for cell in renamed_cells +%}
-          {{ cell }}:
+          cell1:
             conductorServiceTemplate:
               customServiceConfig: |
                 [workarounds]
                 disable_compute_service_check_for_ffu=false
-            {%+ if ironic_adoption|bool and cell in source_ironic_nodes +%}
             novaComputeTemplates:
-              {%+ for n in source_ironic_nodes[cell] +%}
-              {{ n.template }}:
+              standalone:
                 customServiceConfig: |
                   [DEFAULT]
-                  host = {{ n.name }}
+                  host = standalone.localdomain
                   [workarounds]
                   disable_compute_service_check_for_ffu=false
-                replicas: 1
-                resources: {}
-                computeDriver: ironic.IronicDriver
-                networkAttachments:
-                  - internalapi
-              {%+ endfor +%}
-            {%+ endif +%}
-          {%+ endfor +%}

--- a/tests/roles/nova_adoption/tasks/nova_ironic.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_ironic.yaml
@@ -2,20 +2,20 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ nova_ironic_patch }}'
+    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ nova_ironic_patch}}'
 
-- name: wait until the Compute control plane services CRs are ready
+- name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_tasks:
     file: wait.yaml
 
-- name: remove the pre-fast-forward upgrade workarounds from the Compute data plane services
+- name: Remove FFU workarounds
   when: ironic_adoption_remove_ffu_workaround_patch is true
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ remove_ffu_workaround_patch }}'
 
-- name: wait until the Compute control plane services CRs are ready
+- name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_tasks:
     file: wait.yaml
 

--- a/tests/roles/nova_adoption/tasks/nova_libvirt.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_libvirt.yaml
@@ -2,10 +2,9 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ nova_libvirt_patch }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ nova_libvirt_patch }}'
 
-- name: wait until the Compute control plane services CRs are ready
+- name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_tasks:
     file: wait.yaml
 
@@ -14,19 +13,17 @@
     file: check_endpoints.yaml
 
 # TODO(bogdando): provide automated checks for 'The expected changes to happen'
-- name: query the superconductor to check that the expected cells exist, and compare it to pre-adoption values
+- name: query the superconductor for cell1 existance and compare it to pre-adoption values
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ cells_env }}
-    for CELL in $(echo $CELLS); do
-      set +u
-      . ~/.source_cloud_exported_variables_$CELL
-      set -u
-      RCELL=$CELL
-      [ "$CELL" = "default" ] && RCELL=$DEFAULT_CELL_NAME
+    {% if pulled_openstack_configuration_shell_headers is defined %}
+    {{ pulled_openstack_configuration_shell_headers }}
+    {% else %}
+    set +u
+    . ~/.source_cloud_exported_variables_default
+    set -u
+    {% endif %}
 
-      echo "comparing $CELL to $RCELL"
-      echo $PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS | grep -F "| $CELL |"
-      oc rsh nova-cell0-conductor-0 nova-manage cell_v2 list_cells | grep -F "| $RCELL |"
-    done
+    echo $PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS
+    oc rsh nova-cell0-conductor-0 nova-manage cell_v2 list_cells | grep -F '| cell1 |'

--- a/tests/roles/nova_adoption/tasks/wait.yaml
+++ b/tests/roles/nova_adoption/tasks/wait.yaml
@@ -1,6 +1,6 @@
 # NOTE(bogdando): Status phase 'Running' doesn't necessarily mean it IS running in fact.
 # Instead, wait for CR Ready status
-- name: wait until the Compute control plane services CRs are ready
+- name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -148,9 +148,9 @@
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
 
-    $CONTROLLER1_SSH if sudo systemctl is-active tripleo_ovn_cluster_northd.service ';' then sudo systemctl stop tripleo_ovn_cluster_northd.service ';' fi
-    $CONTROLLER2_SSH if sudo systemctl is-active tripleo_ovn_cluster_northd.service ';' then sudo systemctl stop tripleo_ovn_cluster_northd.service ';' fi
-    $CONTROLLER3_SSH if sudo systemctl is-active tripleo_ovn_cluster_northd.service ';' then sudo systemctl stop tripleo_ovn_cluster_northd.service ';' fi
+    $CONTROLLER1_SSH sudo systemctl stop tripleo_ovn_cluster_northd.service
+    $CONTROLLER2_SSH sudo systemctl stop tripleo_ovn_cluster_northd.service
+    $CONTROLLER3_SSH sudo systemctl stop tripleo_ovn_cluster_northd.service
 
 # If ovn_adoption is done using scenario A (different networks between podified
 # and tripleo deployments) in order to be able to dump OVN database a nftable
@@ -275,10 +275,10 @@
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
 
-    $CONTROLLER1_SSH if sudo systemctl is-active tripleo_ovn_cluster_north_db_server.service ';' then sudo systemctl stop tripleo_ovn_cluster_north_db_server.service ';' fi
-    $CONTROLLER2_SSH if sudo systemctl is-active tripleo_ovn_cluster_north_db_server.service ';' then sudo systemctl stop tripleo_ovn_cluster_north_db_server.service ';' fi
-    $CONTROLLER3_SSH if sudo systemctl is-active tripleo_ovn_cluster_north_db_server.service ';' then sudo systemctl stop tripleo_ovn_cluster_north_db_server.service ';' fi
+    $CONTROLLER1_SSH sudo systemctl stop tripleo_ovn_cluster_north_db_server.service
+    $CONTROLLER2_SSH sudo systemctl stop tripleo_ovn_cluster_north_db_server.service
+    $CONTROLLER3_SSH sudo systemctl stop tripleo_ovn_cluster_north_db_server.service
 
-    $CONTROLLER1_SSH if sudo systemctl is-active tripleo_ovn_cluster_south_db_server.service ';' then sudo systemctl stop tripleo_ovn_cluster_south_db_server.service ';' fi
-    $CONTROLLER2_SSH if sudo systemctl is-active tripleo_ovn_cluster_south_db_server.service ';' then sudo systemctl stop tripleo_ovn_cluster_south_db_server.service ';' fi
-    $CONTROLLER3_SSH if sudo systemctl is-active tripleo_ovn_cluster_south_db_server.service ';' then sudo systemctl stop tripleo_ovn_cluster_south_db_server.service ';' fi
+    $CONTROLLER1_SSH sudo systemctl stop tripleo_ovn_cluster_south_db_server.service
+    $CONTROLLER2_SSH sudo systemctl stop tripleo_ovn_cluster_south_db_server.service
+    $CONTROLLER3_SSH sudo systemctl stop tripleo_ovn_cluster_south_db_server.service

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -16,62 +16,12 @@ source_galera_members:
 source_mariadb_ip:
   default: 172.17.0.2 #CUSTOMIZE_THIS
 
-# EDPM nodes info, for each cell compute (omitting dedicated cell controllers) on the destination cloud.
 # To enable TLS-E, the standalone hostname must be set to standalone.ooo.test
-# Defaults provided for a single-cell case.
-# Provide for each cell on the target cloud, considering default_cell_name value.
-# The defined 'networks' connections must match netconfig_networks which manages NetConfig CR
-# to retain fixed IPs, provide values matching the source TripleO deployment
-edpm_nodes:
-  cell1:
-    standalone:
-      hostName: standalone.localdomain
-      ansible:
-        ansibleHost: 192.168.122.100
-      networks:
-        - defaultRoute: true
-          fixedIP: 192.168.122.100
-          name: ctlplane
-          subnetName: subnet1
-        - name: internalapi
-          # uncomment to retain the source cloud fixed IP value
-          #fixedIP: 172.17.0.100
-          subnetName: subnet2
-        - name: storage
-          subnetName: subnet3
-        - name: tenant
-          subnetName: subnet4
-        - name: storagemgmt
-          subnetName: subnet5
+edpm_node_hostname: standalone.localdomain
 # TODO: There is no reason to change the domain depending on the type of
 # deployment, but we are doing this to keep the CI green when TLS-E is merged.
 # This setting should at some point be switched in the CI to standalone.ooo.test
 # for all types of jobs and removed entirely afterwards.
-
-# For a local libvirt setup outside of CI-framework, enable EDPM net config, and define netconfig_networks
-# That is required to update DNS config in resolv.conf at very least, so that edpm can reach out OCP pods.
-dataplane_os_net_config_set_route: false #CUSTOMIZE_THIS
-netconfig_networks: #CUSTOMIZE_THIS
-  - name: ctlplane
-    dnsDomain: ctlplane.example.com
-    subnets:
-      - name: subnet1
-  - name: internalapi
-    dnsDomain: internalapi.example.com
-    subnets:
-      - name: subnet2
-  - name: storage
-    dnsDomain: storage.example.com
-    subnets:
-      - name: subnet3
-  - name: tenant
-    dnsDomain: tenant.example.com
-    subnets:
-      - name: subnet4
-  - name: storagemgmt
-    dnsDomain: storagemgmt.example.com
-    subnets:
-      - name: subnet5
 
 # If 'true', this flag will create a Barbican secret before the adoption runs
 # and after the adoption it'll be verified with the secret tills exists with
@@ -107,6 +57,9 @@ source_os_diff_config_ip: 192.168.122.100
 # Source OVN DB IP for DB exports on internal_api network.
 source_ovndb_ip: 172.17.0.100 #CUSTOMIZE_THIS
 
+# EDPM node IP
+edpm_node_ip: 192.168.122.100 #CUSTOMIZE_THIS
+
 # NTP servers list
 timesync_ntp_servers:
   # - clock.redhat.com # Will not work outside of RH intranet
@@ -117,11 +70,6 @@ auth_url: http://keystone-public-openstack.apps-crc.testing
 
 # Set this to true if adopting the ironic services (ironic + ironic-inspector + nova w/compute-ironic)
 ironic_adoption: false
-# provide the source cloud Ironic topology, for any cells with Ironic services
-source_ironic_nodes:
-  default:
-    - name: standalone.localdomain
-      template: standalone
 
 # Name of network used in ironic spec networkAttachments and provisionNetwork
 ironic_network: baremetal
@@ -149,9 +97,6 @@ supported_backup_backends: #CUSTOMIZE_THIS
 # Whether the adopted node will host compute services
 compute_adoption: true
 use_hugepages: false
-
-# For a multi-node, should be 'overcloud'
-os_cloud_name: standalone
 
 # Where perform or not telemetry installation during adoption
 telemetry_adoption: true


### PR DESCRIPTION
Below three commits are reverted:-
Revert "Retain host IPs on internalapi network"

This reverts commit 4a8d8f80b4a181a5420510a2e93e08bab82ce0d3.

Revert "Add edpmRoleServiceName value for tlsCerts"

This reverts commit bf38f3cf34659fd9353a465b4b22bd9fd32d9433.

Revert "Multi-cell adoption for remaining services"

This reverts commit 1f273c9f59ad6073fa69d129f41782aa85ba351a.

Related-Issue: OSPCIX-759