### PR TITLE
Provision MQ/DB by the requested cells

### DIFF
--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -78,19 +78,12 @@ spec:
         secret: osp-secret
         replicas: 1
         storageRequest: 1Gi
-      openstack-cell1:
+{% for cell in renamed_cells %}
+      openstack-{{ cell }}:
         secret: osp-secret
         replicas: 1
         storageRequest: 1Gi
-      # TODO(bogdando): iterate based on renamed_cells value in kustomization.yaml
-      openstack-cell2:
-        secret: osp-secret
-        replicas: 1
-        storageRequest: 1Gi
-      openstack-cell3:
-        secret: osp-secret
-        replicas: 1
-        storageRequest: 1Gi
+{% endfor %}
 
   memcached:
     enabled: true
@@ -146,7 +139,9 @@ spec:
                 metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.85
             spec:
               type: LoadBalancer
-      rabbitmq-cell1:
+{% set ind = {'val': 86} %}
+{% for cell in renamed_cells %}
+      rabbitmq-{{ cell }}:
         persistence:
           storage: 3Gi
         override:
@@ -154,31 +149,12 @@ spec:
             metadata:
               annotations:
                 metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.86
+                metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.{{ ind.val }}
             spec:
               type: LoadBalancer
-      rabbitmq-cell2:
-        persistence:
-          storage: 3Gi
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.87
-            spec:
-              type: LoadBalancer
-      rabbitmq-cell3:
-        persistence:
-          storage: 3Gi
-        override:
-          service:
-            metadata:
-              annotations:
-                metallb.universe.tf/address-pool: internalapi
-                metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.88
-            spec:
-              type: LoadBalancer
+{% set _ = ind.update({'val': ind.val + 1}) %}
+{% endfor %}
+
   telemetry:
     enabled: false
 


### PR DESCRIPTION
Do not hardcode a fixed 3 cells topology for oscp CR, define it based on the renamed_cells input.

Jira: [OSPCIX-758](https://issues.redhat.com//browse/OSPCIX-758)