### PR TITLE
development_environment - ensure packages

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -27,3 +27,5 @@ openstack_command: >-
   ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no {{ source_osp_ssh_user }}@{{ standalone_ip | default(edpm_node_ip) }} OS_CLOUD={{ os_cloud_name }} openstack
 enroll_ironic_bmaas_nodes: true
 pre_launch_ironic_restart_chrony: true
+development_environment_required_packages:
+  - qemu-img

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -1,3 +1,9 @@
+- name: Make sure required packages are installed
+  become: true
+  ansible.builtin.dnf:
+    state: present
+    name: "{{ development_environment_required_packages }}"
+
 - name: pre-launch test VM instance
   no_log: "{{ use_no_log }}"
   when: prelaunch_test_instance|bool


### PR DESCRIPTION
The `pre_launch_ironic.bash` script in development_environment needs `qemu-img` package. Add a task to ensure it is installed.

Jira: [OSPRH-15323](https://issues.redhat.com//browse/OSPRH-15323)