### PR TITLE
Enable ifcfg provider for dataplane adoption

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -502,6 +502,7 @@ endif::[]
                routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
            {% endfor %}
 
+        edpm_network_config_nmstate: false
         edpm_network_config_hide_sensitive_logs: false
         #
         # These vars are for the network config templates themselves and are

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -221,6 +221,7 @@ dataplane_cr: |
           edpm_network_config_template: |
             {{ edpm_network_config_template| indent(10) }}
 
+          edpm_network_config_nmstate: false
           edpm_network_config_hide_sensitive_logs: false
           #
           # These vars are for the network config templates themselves and are
@@ -355,6 +356,7 @@ networker_cr: |
           # nic config template for a EDPM compute node
           edpm_network_config_template: |
             {{ edpm_network_config_template| indent(10) }}
+          edpm_network_config_nmstate: false
           edpm_network_config_hide_sensitive_logs: false
           #
           # These vars are for the network config templates themselves and are


### PR DESCRIPTION
This changes to configure ifcfg provider for the
dataplane adoption and default will be nmstate provider going forward.