### PR TITLE
[tls_adoption] Set namespace explicitly for secret create

### DIFF
--- a/tests/roles/tls_adoption/tasks/main.yaml
+++ b/tests/roles/tls_adoption/tasks/main.yaml
@@ -5,7 +5,7 @@
     IPA_SSH="{{ ipa_ssh }}"
     $IPA_SSH pk12util -o /tmp/freeipa.p12 -n 'caSigningCert\ cert-pki-ca' -d /etc/pki/pki-tomcat/alias -k /etc/pki/pki-tomcat/alias/pwdfile.txt -w /etc/pki/pki-tomcat/alias/pwdfile.txt
 
-    oc create secret generic rootca-internal
+    oc create secret generic rootca-internal -n openstack
 
     oc patch secret rootca-internal -n openstack -p="{\"data\":{\"ca.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
 


### PR DESCRIPTION
Docs were fixed long back with [1], also fixing the role.

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/460