### PR TITLE
[18.0-fr2][tls_adoption] Set namespace explicitly for secret create

### DIFF
--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -53,11 +53,11 @@ parameter_defaults:
 . To isolate the management network, add the network interface for the VLAN base interface:
 +
 ----
-$ oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | while read; do
+$ oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
 interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
-(echo $interfaces | grep -w -q "octbr|enp6s0.24") || \
+(echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
         oc patch -n openstack nncp $REPLY --type json --patch '
 [{
     "op": "add",

--- a/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
@@ -3,11 +3,11 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | while read; do
+    oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
     interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
-    (echo $interfaces | grep -w -q "octbr|enp6s0.24") || \
+    (echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
             oc patch -n openstack nncp $REPLY --type json --patch '
     [{
         "op": "add",

--- a/tests/roles/tls_adoption/tasks/main.yaml
+++ b/tests/roles/tls_adoption/tasks/main.yaml
@@ -5,7 +5,7 @@
     IPA_SSH="{{ ipa_ssh }}"
     $IPA_SSH pk12util -o /tmp/freeipa.p12 -n 'caSigningCert\ cert-pki-ca' -d /etc/pki/pki-tomcat/alias -k /etc/pki/pki-tomcat/alias/pwdfile.txt -w /etc/pki/pki-tomcat/alias/pwdfile.txt
 
-    oc create secret generic rootca-internal
+    oc create secret generic rootca-internal -n openstack
 
     oc patch secret rootca-internal -n openstack -p="{\"data\":{\"ca.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
 

--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -4,6 +4,9 @@
     github-check:
       jobs:
         - noop
-        - adoption-standalone-to-crc-ceph
-        - adoption-standalone-to-crc-no-ceph
+        - adoption-standalone-to-crc-ceph: &required_projects
+            required-projects:
+              - name: openstack-k8s-operators/data-plane-adoption
+                override-checkout: 18.0-fr2
+        - adoption-standalone-to-crc-no-ceph: *required_projects
         - adoption-docs-preview


### PR DESCRIPTION
Docs were fixed long back with [1], also fixing the role.

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/460

(cherry picked from commit 0308f74b09938999d33dad994af707787291faae)