### PR TITLE
Fix ping test failures in pre_launch.bash

### DIFF
--- a/tests/roles/development_environment/files/pre_launch.bash
+++ b/tests/roles/development_environment/files/pre_launch.bash
@@ -118,7 +118,14 @@ ${BASH_ALIASES[openstack]} security group rule list --protocol tcp --ingress -f 
 
 export FIP=192.168.122.20
 # check connectivity via FIP
-ping -c4 ${FIP}
+TRIES=0
+until ping -D -c1 -W2 "$FIP"; do
+    ((TRIES++)) || true
+    if [ "$TRIES" -gt 20 ]; then
+        echo "Ping timeout"
+        exit 1
+    fi
+done
 
 if [ "$CINDER_VOLUME_BACKEND_CONFIGURED" = "true" ]; then
     create_volume_resources


### PR DESCRIPTION
The `ping -c4` is sometimes not enough time for the instance to start responding, and the ping test fails. We shouldn't just increase the number for `-c` because that would prolong the test even if the ping is already responding. We now use a small bash loop to quit at the first ping success or error out due to (now considerably longer) timeout.