### PR TITLE
dev_env allow multiple pre-launch instance scripts

### DIFF
--- a/tests/playbooks/test_with_ironic.yaml
+++ b/tests/playbooks/test_with_ironic.yaml
@@ -26,7 +26,8 @@
   vars:
     ironic_adoption: true
     nova_libvirt_backend: local
-    prelaunch_test_instance_script: pre_launch_ironic.bash
+    prelaunch_test_instance_scripts:
+      - pre_launch_ironic.bash
   roles:
     - role: development_environment
       tags:

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -1,5 +1,6 @@
 prelaunch_test_instance: true
-prelaunch_test_instance_script: pre_launch.bash
+prelaunch_test_instance_scripts:
+  - pre_launch.bash
 # Ping test activation flag, note that it needs
 # prelaunch_test_instance as well.
 ping_test: false

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -1,6 +1,8 @@
 - name: pre-launch test VM instance
   no_log: "{{ use_no_log }}"
-  when: prelaunch_test_instance|bool
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
   vars:
     cinder_volume_backend_configured: "{{  cinder_volume_backend in supported_volume_backends }}"
     cinder_backup_backend_configured: "{{  cinder_backup_backend in supported_backup_backends }}"
@@ -11,14 +13,26 @@
       export EDPM_CONFIGURE_HUGEPAGES={{ use_hugepages | string | lower }}
       export CINDER_VOLUME_BACKEND_CONFIGURED={{ cinder_volume_backend_configured | string | lower }}
       export CINDER_BACKUP_BACKEND_CONFIGURED={{ cinder_backup_backend_configured | string | lower }}
+      export PING_TEST_VM={{ ping_test | string | lower }}
+      {{ lookup('ansible.builtin.file', 'pre_launch.bash') }}
+
+- name: pre-launch test Ironic instance
+  no_log: "{{ use_no_log }}"
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch_ironic.bash' in prelaunch_test_instance_scripts"
+  ansible.builtin.shell:
+    cmd: |
+      {{ shell_header }}
+      export OPENSTACK_COMMAND="{{ openstack_command }}"
       export ENROLL_BMAAS_IRONIC_NODES={{ enroll_ironic_bmaas_nodes | string | lower }}
       export PRE_LAUNCH_IRONIC_RESTART_CHRONY={{ pre_launch_ironic_restart_chrony | string | lower }}
-      export PING_TEST_VM={{ ping_test | string | lower }}
-      {{ lookup('ansible.builtin.file', prelaunch_test_instance_script) }}
+      {{ lookup('ansible.builtin.file', 'pre_launch_ironic.bash') }}
 
 - name: Start and setup ping test
   when:
     - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
     - ping_test|bool
   block:
     - name: Start the ping test to the VM instance.


### PR DESCRIPTION
This re-factors how the logic around including `pre_launch.bash` and `pre_launch_ironic.bash` works so that one or both scripts can run.

Splits the test instance task into separate task for "VM instance" vs "Ironic instance" and condition the tasks on a list defined in `prelaunch_test_instance_scripts`.

Related: [OSPRH-15321](https://issues.redhat.com//browse/OSPRH-15321)