### PR TITLE
Rename baremetal test instance

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -417,13 +417,13 @@ done
 watch openstack baremetal node list
 
 # Create an instance on baremetal
-openstack server show baremetal-test || {
-    openstack server create baremetal-test --flavor baremetal --image Fedora-Cloud-Base-38 --nic net-id=provisioning --wait
+openstack server show test-baremetal || {
+    openstack server create test-baremetal --flavor baremetal --image Fedora-Cloud-Base-38 --nic net-id=provisioning --wait
 }
 
 # Check instance status and network connectivity
-openstack server show baremetal-test
-ping -c 4 $(openstack server show baremetal-test -f json -c addresses | jq -r .addresses.provisioning[0])
+openstack server show test-baremetal
+ping -c 4 $(openstack server show test-baremetal -f json -c addresses | jq -r .addresses.provisioning[0])
 ----
 
 '''

--- a/tests/roles/development_environment/files/pre_launch_ironic.bash
+++ b/tests/roles/development_environment/files/pre_launch_ironic.bash
@@ -111,13 +111,13 @@ wait_node_state "available"
 sleep 60
 
 # Create an instance on baremetal
-${BASH_ALIASES[openstack]} server show baremetal-test || {
-    ${BASH_ALIASES[openstack]} server create baremetal-test --flavor baremetal --image CentOS-Stream-GenericCloud-x86_64-9 --nic net-id=provisioning --wait
+${BASH_ALIASES[openstack]} server show test-baremetal || {
+    ${BASH_ALIASES[openstack]} server create test-baremetal --flavor baremetal --image CentOS-Stream-GenericCloud-x86_64-9 --nic net-id=provisioning --wait
 }
 
 # Wait for node to boot
 sleep 60
 
 # Check instance status and network connectivity
-${BASH_ALIASES[openstack]} server show baremetal-test
-ping -c 4 $(${BASH_ALIASES[openstack]} server show baremetal-test -f json -c addresses | jq -r .addresses.provisioning[0])
+${BASH_ALIASES[openstack]} server show test-baremetal
+ping -c 4 $(${BASH_ALIASES[openstack]} server show test-baremetal -f json -c addresses | jq -r .addresses.provisioning[0])

--- a/tests/roles/nova_adoption/tasks/nova_ironic.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_ironic.yaml
@@ -47,9 +47,9 @@
       set -e
     }
 
-    ${BASH_ALIASES[openstack]} server create baremetal-test-post-adoption --flavor baremetal --image CentOS-Stream-GenericCloud-x86_64-9 --nic net-id=provisioning
-    wait_server_active baremetal-test-post-adoption
+    ${BASH_ALIASES[openstack]} server create test-baremetal-post-adoption --flavor baremetal --image CentOS-Stream-GenericCloud-x86_64-9 --nic net-id=provisioning
+    wait_server_active test-baremetal-post-adoption
 
     # Check instance status and network connectivity
-    ${BASH_ALIASES[openstack]} server show baremetal-test-post-adoption
-    ping -c 4 $(${BASH_ALIASES[openstack]} server show baremetal-test-post-adoption -f json -c addresses | jq -r .addresses.provisioning[0])
+    ${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption
+    ping -c 4 $(${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption -f json -c addresses | jq -r .addresses.provisioning[0])


### PR DESCRIPTION
Rename the baremetal test instances created to use `test-baremetal` instead of `baremetal-test` to avoid `grep` matchinig on the wrong instance in `tests/roles/dataplane_adoption/tasks/nova_verify.yaml`.

Related: [OSPRH-15321](https://issues.redhat.com//browse/OSPRH-15321)