### PR TITLE
uni01alpha - Remove NeutronDhcpAgent on networkers

### DIFF
--- a/scenarios/uni01alpha/roles.yaml
+++ b/scenarios/uni01alpha/roles.yaml
@@ -279,7 +279,6 @@
     - OS::TripleO::Services::LoginDefs
     - OS::TripleO::Services::MetricsQdr
     - OS::TripleO::Services::MySQLClient
-    - OS::TripleO::Services::NeutronDhcpAgent
     - OS::TripleO::Services::NeutronL2gwAgent
     - OS::TripleO::Services::NeutronL3Agent
     - OS::TripleO::Services::NeutronMetadataAgent


### PR DESCRIPTION
The RHOSO uni01alpha architecture does not enable NeutronDhcpAgent on the networker nodes. Align the OSP17.1 Networkers to match.

Jira: [OSPRH-15749](https://issues.redhat.com//browse/OSPRH-15749)