### PR TITLE
Stop additonal ironic services

### DIFF
--- a/docs_user/modules/proc_stopping-openstack-services.adoc
+++ b/docs_user/modules/proc_stopping-openstack-services.adoc
@@ -131,7 +131,10 @@ ServicesToStop=("tripleo_aodh_api.service"
                 "tripleo_ironic_neutron_agent.service"
                 "tripleo_ironic_api.service"
                 "tripleo_ironic_inspector.service"
-                "tripleo_ironic_conductor.service")
+                "tripleo_ironic_conductor.service"
+                "tripleo_ironic_inspector_dnsmasq.service"
+                "tripleo_ironic_pxe_http.service"
+                "tripleo_ironic_pxe_tftp.service")
 
 PacemakerResourcesToStop=("openstack-cinder-volume"
                           "openstack-cinder-backup"

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -65,7 +65,10 @@
                     "tripleo_ironic_neutron_agent.service"
                     "tripleo_ironic_api.service"
                     "tripleo_ironic_inspector.service"
-                    "tripleo_ironic_conductor.service")
+                    "tripleo_ironic_conductor.service"
+                    "tripleo_ironic_inspector_dnsmasq.service"
+                    "tripleo_ironic_pxe_http.service"
+                    "tripleo_ironic_pxe_tftp.service")
 
     PacemakerResourcesToStop=("openstack-cinder-volume"
                               "openstack-cinder-backup"


### PR DESCRIPTION
Adding a few more ironic services to the ServicesToStop list:
  * "tripleo_ironic_inspector_dnsmasq.service"
  * "tripleo_ironic_pxe_http.service"
  * "tripleo_ironic_pxe_tftp.service"

Jira: [OSPRH-15751](https://issues.redhat.com//browse/OSPRH-15751)