### PR TITLE
Fix multi-cell topology

### DIFF
--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -187,13 +187,13 @@ edpm_computes_shell_vars_src: |-
   {% for cell in renamed_cells %}
   declare -A COMPUTES_{{ cell.upper() }}
   COMPUTES_{{ cell.upper() }}=(
-    {%- for v in edpm_nodes_real[cell] %}
+    {%- for v in edpm_nodes_real[cell] | default([]) %}
     ["{{ edpm_nodes_real[cell][v].hostName }}"]={{ edpm_nodes_real[cell][v].ansible.ansibleHost }}
     {% endfor -%}
   )
   declare -A COMPUTES_API_{{ cell.upper() }}
   COMPUTES_API_{{ cell.upper() }}=(
-    {%- for v in edpm_nodes_real[cell] %}
+    {%- for v in edpm_nodes_real[cell] | default([]) %}
     ["{{ edpm_nodes_real[cell][v].hostName }}"]={{ edpm_nodes_real[cell][v].networks[1].fixedIP|default("") }}
     {% endfor -%}
   )

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -263,7 +263,7 @@
     {% if cell in edpm_nodes_real %}
     cat > computes-real-{{ cell }} << EOF
     {% filter indent(width=4) %}
-        {{ edpm_nodes_real[cell] | to_yaml(indent=2) }}
+        {{ edpm_nodes_real[cell] | default([]) | to_yaml(indent=2) }}
     {% endfilter %}
     EOF
     cat computes-real-{{ cell }} >> nodeset-{{ cell }}.yaml


### PR DESCRIPTION
Fix regression to multiple cells topology for edpm_hosts regressed after
https://github.com/openstack-k8s-operators/data-plane-adoption/pull/881

Do not fail when a cell is missing hosts for a reason.

Jira: [OSPRH-14913](https://issues.redhat.com//browse/OSPRH-14913)