### PR TITLE
Add support for cleanup neutron agents post adopt

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -594,6 +594,10 @@
   ansible.builtin.include_tasks:
     file: nova_verify.yaml
 
+- name: Cleanup non-adopted Neutron and OVN agents
+  ansible.builtin.include_tasks:
+    file: neutron_agents_cleanup.yaml
+
 - name: Adopted Neutron and OVN agents post-checks
   ansible.builtin.include_tasks:
     file: neutron_verify.yaml

--- a/tests/roles/dataplane_adoption/tasks/neutron_agents_cleanup.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_agents_cleanup.yaml
@@ -1,0 +1,27 @@
+# These tasks will delete agents that where not adopted, but replaced by
+# either a new service or a new agent running on a different host post
+# adoption.
+
+- name: delete agent type dhcp
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    alias openstack="oc exec -t openstackclient -- openstack"
+
+    AGENT_ID=$(${BASH_ALIASES[openstack]} network agent list --agent-type dhcp --host {{ item }} -f value -c ID)
+    if [ -n "${AGENT_ID}" ]; then
+      ${BASH_ALIASES[openstack]} network agent delete ${AGENT_ID}
+    fi
+  loop: "{{ neutron_dhcp_agent_cleanup_hosts | default([]) }}"
+
+- name: delete OVN Gateway agents
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    alias openstack="oc exec -t openstackclient -- openstack"
+
+    AGENT_ID=$(${BASH_ALIASES[openstack]} network agent list --agent-type ovn-controller-gateway --host {{ item }} -f value -c ID)
+    if [ -n "${AGENT_ID}" ]; then
+      ${BASH_ALIASES[openstack]} network agent delete ${AGENT_ID}
+    fi
+  loop: "{{ neutron_ovn_controller_gateway_agent_cleanup_hosts | default([]) }}"


### PR DESCRIPTION
In some cases not all agents, such as neutron DHCP agents need to be adopted, or they are replaced by new agents running elsewhere.

These old agents are still visible when listing agents in neutron, and will show as Alive status "XXX". The validations in [tests/roles/dataplane_adoption/tasks/neutron_verify.yaml](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml#L37-L49) fails in this case.

This change adds tasks to allow deleting these agents by specifying the hostnames for agents that should be deleted in variables:
 * neutron_dhcp_agent_cleanup_hosts
 * neutron_ovn_controller_gateway_agent_cleanup_hosts

Jira: [OSPRH-15749](https://issues.redhat.com//browse/OSPRH-15749)