### PR TITLE
Fix order of OpenStackDataplaneServices in adopting compute docs

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -285,10 +285,10 @@ endif::[]
     - run-os
     - reboot-os
     - install-certs
-    - libvirt
-    - nova
     - ovn
     - neutron-metadata
+    - libvirt
+    - nova
     - telemetry
   env:
     - name: ANSIBLE_CALLBACKS_ENABLED


### PR DESCRIPTION
Fix order of OpenStackDataplaneServices in documentation to be correct and the same as in test suite.[1]

[1]https://github.com/openstack-k8s-operators/data-plane-adoption/blob/18.0-fr2/tests/roles/dataplane_adoption/defaults/main.yaml#L184

Resolves: [OSPRH-15291](https://issues.redhat.com//browse/OSPRH-15291)