### PR TITLE
NS residues removal

### DIFF
--- a/docs_user/modules/proc_adopting-the-compute-service.adoc
+++ b/docs_user/modules/proc_adopting-the-compute-service.adoc
@@ -121,7 +121,7 @@ spec:
               disable_compute_service_check_for_ffu=true
 EOF
 cat celltemplates >> oscp-patch.yaml
-oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+oc patch openstackcontrolplane openstack  --type=merge --patch-file=oscp-patch.yaml
 ----
 +
 <1> The `cellDatabaseInstance` is the database instance that is used by the cell. The database instance names must match the names defined for OpenStackControlPlane created earlier in xref:deploying-backend-services_{context}[Deploying back-end services].

--- a/docs_user/modules/proc_ospdo-scale-down-pre-database-adoption.adoc
+++ b/docs_user/modules/proc_ospdo-scale-down-pre-database-adoption.adoc
@@ -96,12 +96,12 @@ $ oc delete openstackclients.client.openstack.org --all
 . Delete the OSPdO `OpenStackControlPlane` custom resource (CR):
 +
 ----
-$ oc delete openstackcontrolplanes.osp-director.openstack.org -n openstack --all
+$ oc delete openstackcontrolplanes.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" --all
 ----
 . Delete the OSPdO `OpenStackNetConfig` CR to remove the associated node network configuration policies:
 +
 ----
-$ oc delete osnetconfig -n openstack --all
+$ oc delete osnetconfig -n "${OSPDO_NAMESPACE}" --all
 ----
 . Label the {OpenShiftShort} node that contains the OSPdO virtual machine (VM):
 +
@@ -239,33 +239,33 @@ $ oc apply -f /tmp/node3_nncp.yaml
 . Delete the remaining OSPdO resources. Do not delete the `OpenStackBaremetalSets` and `OpenStackProvisionServer` resources:
 +
 ----
-$ for i in $(oc get crd | grep osp-director | grep -v baremetalset | grep -v provisionserver | awk {'print $1'}); do echo Deleting $i...; oc delete $i -n openstack --all; done
+$ for i in $(oc get crd | grep osp-director | grep -v baremetalset | grep -v provisionserver | awk {'print $1'}); do echo Deleting $i...; oc delete $i -n "${OSPDO_NAMESPACE}" --all; done
 ----
 
 . Scale down OSPdO to 0 replicas:
 +
 ----
-$ ospdo_csv_ver=$(oc get csv -n openstack -l operators.coreos.com/osp-director-operator.openstack -o json | jq -r '.items[0].metadata.name')
-$ oc patch csv -n openstack $ospdo_csv_ver --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "0"}]"
+$ ospdo_csv_ver=$(oc get csv -n "${OSPDO_NAMESPACE}" -l operators.coreos.com/osp-director-operator.openstack -o json | jq -r '.items[0].metadata.name')
+$ oc patch csv -n "${OSPDO_NAMESPACE}" $ospdo_csv_ver --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "0"}]"
 ----
 
 . Remove the webhooks from OSPdO:
 +
 ----
-$ oc patch csv $ospdo_csv_ver -n openstack --type json -p="[{"op": "remove", "path": "/spec/webhookdefinitions"}]"
+$ oc patch csv $ospdo_csv_ver -n "${OSPDO_NAMESPACE}" --type json -p="[{"op": "remove", "path": "/spec/webhookdefinitions"}]"
 ----
 
 . Remove the finalizer from the OSPdO `OpenStackBaremetalSet` resource:
 +
 ----
-$ oc patch openstackbaremetalsets.osp-director.openstack.org -n openstack compute --type json -p="[{"op": "remove", "path": "/metadata/finalizers"}]"
+$ oc patch openstackbaremetalsets.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" compute --type json -p="[{"op": "remove", "path": "/metadata/finalizers"}]"
 ----
 
 . Delete the `OpenStackBaremetalSet` and `OpenStackProvisionServer` resources:
 +
 ----
-$ oc delete openstackbaremetalsets.osp-director.openstack.org -n openstack --all
-$ oc delete openstackprovisionservers.osp-director.openstack.org -n openstack --all
+$ oc delete openstackbaremetalsets.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" --all
+$ oc delete openstackprovisionservers.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" --all
 ----
 
 . Annotate each {OpenStackShort} Compute `BareMetalHost` resource so that Metal3 does not start the node:
@@ -290,14 +290,14 @@ done
 . Delete the OSPdO Operator Lifecycle Manager resources to remove OSPdO:
 +
 ----
-$ oc delete subscription osp-director-operator -n openstack
-$ oc delete operatorgroup osp-director-operator -n openstack
-$ oc delete catalogsource osp-director-operator-index -n openstack
-$ oc delete csv $ospdo_csv_ver -n openstack
+$ oc delete subscription osp-director-operator -n "${OSPDO_NAMESPACE}"
+$ oc delete operatorgroup osp-director-operator -n "${OSPDO_NAMESPACE}"
+$ oc delete catalogsource osp-director-operator-index -n "${OSPDO_NAMESPACE}"
+$ oc delete csv $ospdo_csv_ver -n "${OSPDO_NAMESPACE}"
 ----
 
 . Scale up the {rhos_acro} OpenStack Operator `controller-manager` to 1 replica so that the associated `OpenStackControlPlane` CR is reconciled and its `OpenStackClient` pod is recreated:
 +
 ----
-$ oc patch csv -n openstack-operators openstack-operator.v0.0.1 --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "1"}]"
+$ oc patch csv -n "${OSPDO_NAMESPACE}"-operators openstack-operator.v0.0.1 --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "1"}]"
 ----

--- a/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
+++ b/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
@@ -106,7 +106,7 @@ $ cat celltemplates >> oscp-patch.yaml
 . Apply the patch file
 +
 ----
-$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+$ oc patch openstackcontrolplane openstack --type=merge --patch-file=oscp-patch.yaml
 ----
 
 . Wait until the Compute control plane services CRs are ready:

--- a/docs_user/modules/proc_preparing-controller-nodes-for-director-operator-adoption.adoc
+++ b/docs_user/modules/proc_preparing-controller-nodes-for-director-operator-adoption.adoc
@@ -93,13 +93,13 @@ You might need to wait a few minutes for the control plane to get operational. T
 .. When Pacemaker is only managing one of the Controllers, delete 2 of the Controller VMs. The following example specifies Controller-1 and Controller-2 VMs for deletion:
 +
 ----
-$ oc -n openstack annotate vm controller-1 osp-director.openstack.org/delete-host=true
-$ oc -n openstack annotate vm controller-2 osp-director.openstack.org/delete-host=true
+$ oc -n "${OSPDO_NAMESPACE}"annotate vm controller-1 osp-director.openstack.org/delete-host=true
+$ oc -n "${OSPDO_NAMESPACE}"annotate vm controller-2 osp-director.openstack.org/delete-host=true
 ----
 .. Reduce the `roleCount` for the Controller role in the `OpenStackControlPlane` CR to `1`:
 +
 ----
-$ oc -n openstack patch OpenStackControlPlane overcloud --type json -p '[{"op": "replace", "path":"/spec/virtualMachineRoles/controller/roleCount", "value": 1}]'
+$ oc -n "${OSPDO_NAMESPACE}"patch OpenStackControlPlane overcloud --type json -p '[{"op": "replace", "path":"/spec/virtualMachineRoles/controller/roleCount", "value": 1}]'
 ----
 .. Ensure that the `OpenStackClient` pod is running on the same {OpenShiftShort} nodes as the remaining Controller VM. If the `OpenStackClient` pod is not on the same node, then move it by cordoning off the two nodes that have been freed up for {rhos_acro}. Then you delete the `OpenStackClient` pod so that it gets rescheduled on the {OpenShiftShort} node that has the remaining Controller VM. After the pod is moved to the correct node, uncordon all the nodes:
 +

--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -60,7 +60,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+    oc patch openstackcontrolplane openstack --type=merge --patch-file=oscp-patch.yaml
 
 - name: wait until the Compute control plane services CRs are ready
   ansible.builtin.include_role:

--- a/tests/roles/ironic_adoption/tasks/main.yaml
+++ b/tests/roles/ironic_adoption/tasks/main.yaml
@@ -42,7 +42,7 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ ironic_disable_rbac_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_disable_rbac_patch }}'
 
 - name: Wait for Ironic control plane services' CRs to become ready
   ansible.builtin.include_tasks:
@@ -77,7 +77,7 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ ironic_enable_rbac_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_enable_rbac_patch }}'
 
 - name: Wait for Ironic control plane services' CRs to become ready
   ansible.builtin.include_tasks:

--- a/tests/roles/nova_adoption/tasks/nova_ironic.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_ironic.yaml
@@ -2,7 +2,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ nova_ironic_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ nova_ironic_patch }}'
 
 - name: wait until the Compute control plane services CRs are ready
   ansible.builtin.include_tasks:
@@ -13,7 +13,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ remove_ffu_workaround_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ remove_ffu_workaround_patch }}'
 
 - name: wait until the Compute control plane services CRs are ready
   ansible.builtin.include_tasks:

--- a/tests/roles/nova_adoption/tasks/nova_libvirt.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_libvirt.yaml
@@ -3,7 +3,7 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ nova_libvirt_patch }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch-file=oscp-patch.yaml
+    oc patch openstackcontrolplane openstack --type=merge --patch-file=oscp-patch.yaml
 
 - name: wait until the Compute control plane services CRs are ready
   ansible.builtin.include_tasks:

--- a/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
@@ -3,12 +3,12 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
+    oc get --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
     interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
     (echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
-            oc patch -n openstack nncp $REPLY --type json --patch '
+            oc patch nncp $REPLY --type json --patch '
     [{
         "op": "add",
         "path": "/spec/desiredState/interfaces/-",
@@ -74,7 +74,7 @@
           }
         }
     EOF_CAT
-    oc apply -n openstack -f octavia-nad.yaml
+    oc apply -f octavia-nad.yaml
 
 - name: Enable the octavia service in OpenShift
   ansible.builtin.shell: |
@@ -84,7 +84,7 @@
     # FIXME: debug only. remove.
     oc project
 
-    oc patch -n openstack openstackcontrolplane openstack --type=merge --patch '
+    oc patch openstackcontrolplane openstack --type=merge --patch '
     spec:
       ovn:
         template:


### PR DESCRIPTION
- **Make ironic network name configurable**
- **Allow customizing the test log file path**
- **nova_adoption: ironic, FFU patch remove optional**
- **Add Barbican to OSP17.1 uni06zeta**
- **Optional Octavia SSH adoption test**
- **Ironic API override internal service to ctlplane**
- **Add tobiko to adoption job**
- **Add more services and tags to test_with_ironic.yaml**
- **Apply required ospdo changes to adoption docs**
- **Tobiko adoption move to developement environmnet role**
- **Update ceph dashboard port**
- **updates from ironic testing**
- **added source tag on code blocks with hashtags**
- **    Update ceph dashboard port to 8443**
- **Enable Ceph dashboard in unigamma**
- **Multi-cell adoption for remaining services**
- **Add edpmRoleServiceName value for tlsCerts**
- **Retain host IPs on internalapi network**
- **Fixed incorrect grep in octavia adoption**
- **fixed ovn/networking adoption bugs**
- **incorporating QE comments**
- **additional QE comments**
- **fixed linting error**
- **added source yaml tag to resolve copy issue**
- **Modify control_plane_rollback_verify_command**
- **Provision MQ/DB by the requested cells**
- **adding tags to fix copy issue in published docs**
- **Apply suggestions from code review**
- **added source shell tag**
- **Enable ifcfg provider for dataplane adoption**
- **[tls_adoption] Set namespace explicitly for secret create**
- **Convert legacy edpm_nodes data for multi-cell**
- **fix copy issues downstream**
- **removed brackets from networking code**
- **added shell tags**
- **Modify the verify command**
- **Fix ping test failures in pre_launch.bash**
- **source_ironic_nodes - handle "default" cell rename**
- **Re-enabled dataplane_adoption in test_with_ironic**
- **Update docs_user/modules/proc_deploying-the-bare-metal-provisioning-service.adoc**
- **Add edpm_container_registry_insecure_registries for networker**
- **Remove a reference to mariadb CR**
- **Update docs_user/modules/proc_deploying-the-bare-metal-provisioning-service.adoc**
- **minor edits**
- **removed source yaml tag**
- **dev_env allow multiple pre-launch instances**
- **Rename baremetal test instance**
- **Refactor documentation for enabling TLS-e during controlplane creation**
- **updated limitations module**
- **sme feedback**
- **added new procedure and updated prerequisites**
- **linting error**
- **Add verification steps that look at OpenStackControlPlane CR status**
- **Use MariaDB/Rabbit verification commands that will make issues visible**
- **Use oc wait for checking that OpenStackControlPlane is Ready**
- **Use Galera service name in 'deploying backend services' doc**
- **sme comments**
- **Fix multi-cell topology**
- **Fix rgw keystone endpoint command**
- **removed fixed known issue and hid known issues section**
- **Fix rgw keystone ep command quotes**
- **Set namespace only at the beginning of adoption guide and procedure**
- **Refactoring as a follow-up work for NS change**
- **removed Compute unsupported feature**
- **Stop additonal ironic services**
- **Remove redundant namespace flags**
