### PR TITLE
backport ospdo NS overhal

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -425,7 +425,6 @@ data:
 kind: Secret
 metadata:
   name: ceph-conf-files
-  namespace: openstack
 type: Opaque
 EOF
 

--- a/docs_user/modules/con_adoption-prerequisites.adoc
+++ b/docs_user/modules/con_adoption-prerequisites.adoc
@@ -18,6 +18,19 @@ endif::[]
 ** link:{defaultOCPURL}/nodes/overview-of-nodes[Overview of nodes]
 ** link:{defaultOCPURL}/nodes/index#nodes-scheduler-node-selectors-about_nodes-scheduler-node-selectors[About node selectors]
 ** link:{defaultOCPURL}/machine_configuration/index[Machine configuration overview]
+* Make sure to set the correct {rhos_acro} project namespace in which to run commands.
+ifeval::["{build_variant}" == "ospdo"]
+In director Operator adoption, the adopted namespace is `openstack`. The adopting namespace is different, for example, `rhoso`.
+endif::[]
+[source, shell]
+----
+ifeval::["{build_variant}" == "ospdo"]
+$ oc project rhoso
+endif::[]
+ifeval::["{build_variant}" != "ospdo"]
+$ oc project openstack
+endif::[]
+----
 
 Back-up information::
 

--- a/docs_user/modules/con_adoption-prerequisites.adoc
+++ b/docs_user/modules/con_adoption-prerequisites.adoc
@@ -20,7 +20,7 @@ endif::[]
 ** link:{defaultOCPURL}/machine_configuration/index[Machine configuration overview]
 * Make sure to set the correct {rhos_acro} project namespace in which to run commands.
 ifeval::["{build_variant}" == "ospdo"]
-In director Operator adoption, the adopted namespace is `openstack`. The adopting namespace is different, for example, `rhoso`.
+* In director Operator adoption, the source {rhos_prev_long} {rhos_prev_ver} namespace is `openstack`. In order to successfully adopt the {OpenStackShort} {rhos_prev_ver} environment, the destination {rhos_acro} {rhos_curr_ver} namespace must be different, for example, `rhoso`.
 endif::[]
 [source, shell]
 ----

--- a/docs_user/modules/con_preparing-the-shared-file-systems-service-configuration.adoc
+++ b/docs_user/modules/con_preparing-the-shared-file-systems-service-configuration.adoc
@@ -133,7 +133,7 @@ __EOF__
 ----
 +
 ----
-$ oc create secret generic osp-secret-manila-netapp --from-file=~/<secret> -n openstack
+$ oc create secret generic osp-secret-manila-netapp --from-file=~/<secret>
 ----
 +
 ** Replace `<secret>` with the name of the file that includes your secrets, for example, `netapp_secrets.conf`.

--- a/docs_user/modules/openstack-troubleshooting.adoc
+++ b/docs_user/modules/openstack-troubleshooting.adoc
@@ -45,7 +45,7 @@ the cluster's compute nodes, then trigger a new pod deployment to pull the
 container image with:
 
 ----
-kubectl delete pod rabbitmq-server-0 -n openstack
+kubectl delete pod rabbitmq-server-0
 ----
 
 And the pod should be able to pull the image successfully.  For more

--- a/docs_user/modules/proc_adopting-autoscaling.adoc
+++ b/docs_user/modules/proc_adopting-autoscaling.adoc
@@ -40,7 +40,7 @@ spec:
 . Inspect the aodh pods:
 +
 ----
-$ AODH_POD=`oc get pods -l service=aodh -n openstack | tail -n 1 | cut -f 1 -d' '`
+$ AODH_POD=`oc get pods -l service=aodh | tail -n 1 | cut -f 1 -d' '`
 $ oc exec -t $AODH_POD -c aodh-api -- cat /etc/aodh/aodh.conf
 ----
 

--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -116,7 +116,6 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: dataplane-adoption-secret
-    namespace: openstack
 data:
     ssh-privatekey: |
 ifeval::["{build}" != "downstream"]
@@ -138,7 +137,6 @@ endif::[]
 $ cd "$(mktemp -d)"
 ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
 oc get secret nova-migration-ssh-key || oc create secret generic nova-migration-ssh-key \
-  -n openstack \
   --from-file=ssh-privatekey=id \
   --from-file=ssh-publickey=id.pub \
   --type kubernetes.io/ssh-auth
@@ -164,7 +162,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: libvirt-secret
-  namespace: openstack
 type: Opaque
 data:
   LibvirtPassword: ${LIBVIRT_PASSWORD_BASE64}
@@ -178,10 +175,9 @@ $ oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-extra-config
-  namespace: openstack
-data:
-  19-nova-compute-cell1-workarounds.conf: |
+  name: nova-cells-global-config
+data: <1>
+  99-nova-compute-cells-workarounds.conf: | <2>
     [workarounds]
     disable_compute_service_check_for_ffu=true
 EOF
@@ -212,8 +208,7 @@ $ oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-extra-config
-  namespace: openstack
+  name: nova-cells-global-config
 data:
   19-nova-compute-cell1-workarounds.conf: |
     [workarounds]

--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -175,9 +175,9 @@ $ oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-cells-global-config
-data: <1>
-  99-nova-compute-cells-workarounds.conf: | <2>
+  name: nova-extra-config
+data:
+  19-nova-compute-cell1-workarounds.conf: |
     [workarounds]
     disable_compute_service_check_for_ffu=true
 EOF
@@ -208,7 +208,7 @@ $ oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-cells-global-config
+  name: nova-extra-config
 data:
   19-nova-compute-cell1-workarounds.conf: |
     [workarounds]

--- a/docs_user/modules/proc_adopting-telemetry-services.adoc
+++ b/docs_user/modules/proc_adopting-telemetry-services.adoc
@@ -82,12 +82,12 @@ spec:
 . Verify that the `alertmanager` and `prometheus` pods are available:
 +
 ----
-$ oc get pods -l alertmanager=metric-storage -n openstack
+$ oc get pods -l alertmanager=metric-storage
 NAME                            READY   STATUS    RESTARTS   AGE
 alertmanager-metric-storage-0   2/2     Running   0          46s
 alertmanager-metric-storage-1   2/2     Running   0          46s
 
-$ oc get pods -l prometheus=metric-storage -n openstack
+$ oc get pods -l prometheus=metric-storage
 NAME                          READY   STATUS    RESTARTS   AGE
 prometheus-metric-storage-0   3/3     Running   0          46s
 ----
@@ -95,7 +95,7 @@ prometheus-metric-storage-0   3/3     Running   0          46s
 . Inspect the resulting Ceilometer pods:
 +
 ----
-CEILOMETETR_POD=`oc get pods -l service=ceilometer -n openstack | tail -n 1 | cut -f 1 -d' '`
+CEILOMETETR_POD=`oc get pods -l service=ceilometer | tail -n 1 | cut -f 1 -d' '`
 oc exec -t $CEILOMETETR_POD -c ceilometer-central-agent -- cat /etc/ceilometer/ceilometer.conf
 ----
 

--- a/docs_user/modules/proc_adopting-the-identity-service.adoc
+++ b/docs_user/modules/proc_adopting-the-identity-service.adoc
@@ -19,7 +19,6 @@ data:
 kind: Secret
 metadata:
   name: keystone
-  namespace: openstack
 type: Opaque
 EOF
 ----

--- a/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
+++ b/docs_user/modules/proc_adopting-the-loadbalancer-service.adoc
@@ -35,7 +35,6 @@ include::../../tests/roles/octavia_adoption/tasks/octavia_certs.yaml[lines="7..8
     kind: ConfigMap
     metadata:
       name: octavia-ssh-pubkey
-      namespace: openstack
     data:
       key: $(cat $HOME/octavia_sshkey.pub)
     EOF
@@ -53,12 +52,12 @@ parameter_defaults:
 . To isolate the management network, add the network interface for the VLAN base interface:
 +
 ----
-$ oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
+$ oc get --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
 interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
 (echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
-        oc patch -n openstack nncp $REPLY --type json --patch '
+        oc patch nncp $REPLY --type json --patch '
 [{
     "op": "add",
     "path": "/spec/desiredState/interfaces/-",
@@ -105,7 +104,6 @@ metadata:
   labels:
     osp/net: octavia
   name: octavia
-  namespace: openstack
 spec:
   config: |
     {
@@ -127,13 +125,13 @@ spec:
       }
     }
 EOF_CAT
-$ oc apply -n openstack -f octavia-nad.yaml
+$ oc apply -f octavia-nad.yaml
 ----
 
 . Enable the {loadbalancer_service} in {OpenShiftShort}:
 +
 ----
-$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
+$ oc patch openstackcontrolplane openstack --type=merge --patch '
 spec:
   ovn:
     template:

--- a/docs_user/modules/proc_adopting-the-object-storage-service.adoc
+++ b/docs_user/modules/proc_adopting-the-object-storage-service.adoc
@@ -19,7 +19,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: swift-conf
-  namespace: openstack
 type: Opaque
 data:
   swift.conf: $($CONTROLLER1_SSH sudo cat /var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf | base64 -w0)

--- a/docs_user/modules/proc_configuring-a-ceph-backend.adoc
+++ b/docs_user/modules/proc_configuring-a-ceph-backend.adoc
@@ -47,7 +47,6 @@ data:
 kind: Secret
 metadata:
   name: ceph-conf-files
-  namespace: openstack
 type: Opaque
 EOF
 ----
@@ -60,7 +59,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ceph-conf-files
-  namespace: openstack
 stringData:
   ceph.client.openstack.keyring: |
     [client.openstack]

--- a/docs_user/modules/proc_configuring-networking-for-control-plane-services.adoc
+++ b/docs_user/modules/proc_configuring-networking-for-control-plane-services.adoc
@@ -15,7 +15,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: internalapi
-  namespace: openstack
 spec:
   config: |
     {
@@ -42,7 +41,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: internalapi
-  namespace: openstack
 spec:
   config: |
     {

--- a/docs_user/modules/proc_deploying-the-bare-metal-provisioning-service.adoc
+++ b/docs_user/modules/proc_deploying-the-bare-metal-provisioning-service.adoc
@@ -42,7 +42,7 @@ $ alias openstack="oc exec -t openstackclient -- openstack"
 . Patch the `OpenStackControlPlane` custom resource (CR) to deploy the {bare_metal}:
 +
 ----
-$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
+$ oc patch openstackcontrolplane openstack --type=merge --patch '
 spec:
   ironic:
     enabled: true
@@ -136,7 +136,7 @@ If the `openstack baremetal node list` command output reports an incorrect power
 . If any {bare_metal} nodes are missing from the `openstack baremetal node list` command, temporarily disable the new RBAC policy to see the nodes again:
 +
 ----
-$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
+$ oc patch openstackcontrolplane openstack --type=merge --patch '
 spec:
   ironic:
     enabled: true
@@ -169,7 +169,7 @@ for node in $(openstack baremetal node list -f json -c UUID -c Owner | jq -r '.[
 . Re-apply the default RBAC by removing the `customServiceConfig` section or by setting the following values in the `customServiceConfig` section to `true`. For example:
 +
 ----
-$ oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '
+$ oc patch openstackcontrolplane openstack --type=merge --patch '
 spec:
   ironic:
     enabled: true

--- a/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
+++ b/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
@@ -35,8 +35,6 @@ $ CELLS="default" <1>
 $ DEFAULT_CELL_NAME="cell1"
 $ RENAMED_CELLS="$DEFAULT_CELL_NAME"
 
-$ NAMESPACE="openstack"
-
 $ CHARACTER_SET=utf8 # <2>
 $ COLLATION=utf8_general_ci
 
@@ -224,7 +222,7 @@ $ test -z "$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"  || [ "x$PULL_OPENSTACK
 +
 ----
 $ for CELL in $(echo "super $RENAMED_CELLS"); do
->   oc run mariadb-client -n $NAMESPACE --image $MARIADB_IMAGE -i --rm --restart=Never -- \
+>   oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
 >     mysql -rsh "${PODIFIED_MARIADB_IP[$CELL]}" -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" -e 'SHOW databases;'
 > done
 ----
@@ -258,7 +256,7 @@ Gnocchi is no longer used as a metric store as well
 $ for CELL in $(echo $CELLS); do
 >   RCELL=$CELL
 >   [ "$CELL" = "default" ] && RCELL=$DEFAULT_CELL_NAME
->   oc rsh -n $NAMESPACE mariadb-copy-data << EOF
+>   oc rsh mariadb-copy-data << EOF
 >     declare -A db_name_map  <1>
 >     db_name_map['nova']="nova_$RCELL"
 >     db_name_map['ovs_neutron']='neutron'
@@ -334,11 +332,11 @@ For more information, see xref:proc_retrieving-topology-specific-service-configu
 $ set +u
 $ . ~/.source_cloud_exported_variables_default
 $ set -u
-$ dbs=$(oc exec openstack-galera-0 -n $NAMESPACE -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD['super']}" -e 'SHOW databases;')
+$ dbs=$(oc exec openstack-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD['super']}" -e 'SHOW databases;')
 $ echo $dbs | grep -Eq '\bkeystone\b' && echo "OK" || echo "CHECK FAILED"
 $ echo $dbs | grep -Eq '\bneutron\b' && echo "OK" || echo "CHECK FAILED"
 $ echo "${PULL_OPENSTACK_CONFIGURATION_DATABASES[@]}" | grep -Eq '\bovs_neutron\b' && echo "OK" || echo "CHECK FAILED" <1>
-$ novadb_mapped_cells=$(oc exec openstack-galera-0 -n $NAMESPACE -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD['super']}" \
+$ novadb_mapped_cells=$(oc exec openstack-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD['super']}" \
 >   nova_api -e 'select uuid,name,transport_url,database_connection,disabled from cell_mappings;') <2>
 $ uuidf='\S{8,}-\S{4,}-\S{4,}-\S{4,}-\S{12,}'
 $ default=$(printf "%s\n" "$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS" | sed -rn "s/^($uuidf)\s+default\b.*$/\1/p")
@@ -358,9 +356,9 @@ $ for CELL in $(echo $RENAMED_CELLS); do <3>
 >   set +u
 >   . ~/.source_cloud_exported_variables_$RCELL
 >   set -u
->   c1dbs=$(oc exec openstack-$CELL-galera-0 -n $NAMESPACE -c galera -- mysql -rs -uroot -p${PODIFIED_DB_ROOT_PASSWORD[$CELL]} -e 'SHOW databases;') <4>
+>   c1dbs=$(oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p${PODIFIED_DB_ROOT_PASSWORD[$CELL]} -e 'SHOW databases;') <4>
 >   echo $c1dbs | grep -Eq "\bnova_${CELL}\b" && echo "OK" || echo "CHECK FAILED"
->   novadb_svc_records=$(oc exec openstack-$CELL-galera-0 -n $NAMESPACE -c galera -- mysql -rs -uroot -p${PODIFIED_DB_ROOT_PASSWORD[$CELL]} \
+>   novadb_svc_records=$(oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p${PODIFIED_DB_ROOT_PASSWORD[$CELL]} \
 >     nova_$CELL -e "select host from services where services.binary='nova-compute' and deleted=0 order by host asc;")
 >   diff -Z <(echo "x$novadb_svc_records") <(echo "x${PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES[@]}") && echo "OK" || echo "CHECK FAILED" <5>
 > done

--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -65,7 +65,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ovn-data-cert
-  namespace: openstack
 spec:
   commonName: ovn-data-cert
   secretName: ovn-data-cert

--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -246,10 +246,6 @@ ifeval::["{build_variant}" != "ospdo"]
 $ oc exec ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
 $ oc exec ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
 endif::[]
-ifeval::["{build_variant}" == "ospdo"]
-$ oc exec -n $RHOSO_NAMESPACE ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
-$ oc exec -n $RHOSO_NAMESPACE ovn-copy-data -- bash -c "ovsdb-client restore tcp:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
-endif::[]
 ----
 
 .. If you enabled TLS everywhere, use the following command:

--- a/docs_user/modules/proc_migrating-tls-everywhere.adoc
+++ b/docs_user/modules/proc_migrating-tls-everywhere.adoc
@@ -100,17 +100,17 @@ With that file, you can also get the certificate and the key by using the `opens
 . Create the secret that contains the root CA:
 +
 ----
-$ oc create secret generic rootca-internal -n openstack
+$ oc create secret generic rootca-internal
 ----
 
 . Import the certificate and the key from FreeIPA:
 +
 ----
-$ oc patch secret rootca-internal -n openstack -p="{\"data\":{\"ca.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
+$ oc patch secret rootca-internal -p="{\"data\":{\"ca.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
 
-$ oc patch secret rootca-internal -n openstack -p="{\"data\":{\"tls.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
+$ oc patch secret rootca-internal -p="{\"data\":{\"tls.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
 
-$ oc patch secret rootca-internal -n openstack -p="{\"data\":{\"tls.key\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nocerts -noenc | openssl rsa | base64 -w 0`\"}}"
+$ oc patch secret rootca-internal -p="{\"data\":{\"tls.key\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nocerts -noenc | openssl rsa | base64 -w 0`\"}}"
 ----
 
 . Create the cert-manager issuer and reference the secret:
@@ -122,7 +122,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: rootca-internal
-  namespace: openstack
   labels:
     osp-rootca-issuer-public: ""
     osp-rootca-issuer-internal: ""
@@ -145,11 +144,11 @@ $IPA_SSH rm /tmp/freeipa.p12
 * Verify that the necessary resources are created:
 +
 ----
-$ oc get issuers -n openstack
+$ oc get issuers
 ----
 +
 ----
-$ oc get secret rootca-internal -n openstack -o yaml
+$ oc get secret rootca-internal -o yaml
 ----
 
 [NOTE]

--- a/docs_user/modules/proc_ospdo-scale-down-pre-database-adoption.adoc
+++ b/docs_user/modules/proc_ospdo-scale-down-pre-database-adoption.adoc
@@ -96,12 +96,12 @@ $ oc delete openstackclients.client.openstack.org --all
 . Delete the OSPdO `OpenStackControlPlane` custom resource (CR):
 +
 ----
-$ oc delete openstackcontrolplanes.osp-director.openstack.org -n openstack --all
+$ oc delete openstackcontrolplanes.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" --all
 ----
 . Delete the OSPdO `OpenStackNetConfig` CR to remove the associated node network configuration policies:
 +
 ----
-$ oc delete osnetconfig -n openstack --all
+$ oc delete osnetconfig -n "${OSPDO_NAMESPACE}" --all
 ----
 . Label the {OpenShiftShort} node that contains the OSPdO virtual machine (VM):
 +
@@ -239,33 +239,33 @@ $ oc apply -f /tmp/node3_nncp.yaml
 . Delete the remaining OSPdO resources. Do not delete the `OpenStackBaremetalSets` and `OpenStackProvisionServer` resources:
 +
 ----
-$ for i in $(oc get crd | grep osp-director | grep -v baremetalset | grep -v provisionserver | awk {'print $1'}); do echo Deleting $i...; oc delete $i -n openstack --all; done
+$ for i in $(oc get crd | grep osp-director | grep -v baremetalset | grep -v provisionserver | awk {'print $1'}); do echo Deleting $i...; oc delete $i -n "${OSPDO_NAMESPACE}" --all; done
 ----
 
 . Scale down OSPdO to 0 replicas:
 +
 ----
-$ ospdo_csv_ver=$(oc get csv -n openstack -l operators.coreos.com/osp-director-operator.openstack -o json | jq -r '.items[0].metadata.name')
-$ oc patch csv -n openstack $ospdo_csv_ver --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "0"}]"
+$ ospdo_csv_ver=$(oc get csv -n "${OSPDO_NAMESPACE}" -l operators.coreos.com/osp-director-operator.openstack -o json | jq -r '.items[0].metadata.name')
+$ oc patch csv -n "${OSPDO_NAMESPACE}" $ospdo_csv_ver --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "0"}]"
 ----
 
 . Remove the webhooks from OSPdO:
 +
 ----
-$ oc patch csv $ospdo_csv_ver -n openstack --type json -p="[{"op": "remove", "path": "/spec/webhookdefinitions"}]"
+$ oc patch csv $ospdo_csv_ver -n "${OSPDO_NAMESPACE}" --type json -p="[{"op": "remove", "path": "/spec/webhookdefinitions"}]"
 ----
 
 . Remove the finalizer from the OSPdO `OpenStackBaremetalSet` resource:
 +
 ----
-$ oc patch openstackbaremetalsets.osp-director.openstack.org -n openstack compute --type json -p="[{"op": "remove", "path": "/metadata/finalizers"}]"
+$ oc patch openstackbaremetalsets.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" compute --type json -p="[{"op": "remove", "path": "/metadata/finalizers"}]"
 ----
 
 . Delete the `OpenStackBaremetalSet` and `OpenStackProvisionServer` resources:
 +
 ----
-$ oc delete openstackbaremetalsets.osp-director.openstack.org -n openstack --all
-$ oc delete openstackprovisionservers.osp-director.openstack.org -n openstack --all
+$ oc delete openstackbaremetalsets.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" --all
+$ oc delete openstackprovisionservers.osp-director.openstack.org -n "${OSPDO_NAMESPACE}" --all
 ----
 
 . Annotate each {OpenStackShort} Compute `BareMetalHost` resource so that Metal3 does not start the node:
@@ -290,14 +290,14 @@ done
 . Delete the OSPdO Operator Lifecycle Manager resources to remove OSPdO:
 +
 ----
-$ oc delete subscription osp-director-operator -n openstack
-$ oc delete operatorgroup osp-director-operator -n openstack
-$ oc delete catalogsource osp-director-operator-index -n openstack
-$ oc delete csv $ospdo_csv_ver -n openstack
+$ oc delete subscription osp-director-operator -n "${OSPDO_NAMESPACE}"
+$ oc delete operatorgroup osp-director-operator -n "${OSPDO_NAMESPACE}"
+$ oc delete catalogsource osp-director-operator-index -n "${OSPDO_NAMESPACE}"
+$ oc delete csv $ospdo_csv_ver -n "${OSPDO_NAMESPACE}"
 ----
 
 . Scale up the {rhos_acro} OpenStack Operator `controller-manager` to 1 replica so that the associated `OpenStackControlPlane` CR is reconciled and its `OpenStackClient` pod is recreated:
 +
 ----
-$ oc patch csv -n openstack-operators openstack-operator.v0.0.1 --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "1"}]"
+$ oc patch csv -n "${OSPDO_NAMESPACE}"-operators openstack-operator.v0.0.1 --type json   -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "1"}]"
 ----

--- a/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
+++ b/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
@@ -103,7 +103,7 @@ data:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-nova-compute-ffu-$CELL
+  name: openstack-nova-compute-ffu
 spec:
   nodeSets:
     - openstack

--- a/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
+++ b/docs_user/modules/proc_performing-a-fast-forward-upgrade-on-compute-services.adoc
@@ -17,8 +17,6 @@ You must upgrade the Compute services from {rhos_prev_long} {rhos_prev_ver} to {
 DEFAULT_CELL_NAME="cell1"
 RENAMED_CELLS="$DEFAULT_CELL_NAME"
 
-NAMESPACE="openstack"
-
 declare -A PODIFIED_DB_ROOT_PASSWORD
 for CELL in $(echo "super $RENAMED_CELLS"); do
   PODIFIED_DB_ROOT_PASSWORD[$CELL]=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
@@ -31,7 +29,7 @@ done
 +
 ----
 $ for CELL in $(echo $RENAMED_CELLS); do
-  oc exec openstack-$CELL-galera-0 -n $NAMESPACE -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \
+  oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \
     -e "select a.version from nova_${CELL}.services a join nova_${CELL}.services b where a.version!=b.version and a.binary='nova-compute' and a.deleted=0;"
 done
 ----
@@ -105,8 +103,7 @@ data:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-nova-compute-ffu
-  namespace: openstack
+  name: openstack-nova-compute-ffu-$CELL
 spec:
   nodeSets:
     - openstack

--- a/docs_user/modules/proc_preparing-RHOSO-for-director-operator-adoption.adoc
+++ b/docs_user/modules/proc_preparing-RHOSO-for-director-operator-adoption.adoc
@@ -33,6 +33,7 @@ $ oc get namespace ${RHOSO18_NAMESPACE} 2>/dev/null || {
         echo "Failed to create namespace ${RHOSO18_NAMESPACE}"
         exit 1
     }
+    oc project ${RHOSO18_NAMESPACE}
 }
 ----
 
@@ -171,7 +172,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: ctlplane
-  namespace: <RHOSO18_NAMESPACE>
 spec:
   config: |
     {
@@ -191,7 +191,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: internalapi
-  namespace: <RHOSO18_NAMESPACE>
 spec:
   config: |
     {
@@ -211,7 +210,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: external
-  namespace: <RHOSO18_NAMESPACE>
 spec:
   config: |
     {
@@ -231,7 +229,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: storage
-  namespace: $<RHOSO18_NAMESPACE>
 spec:
   config: |
     {
@@ -251,7 +248,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: storagemgmt
-  namespace: <RHOSO18_NAMESPACE>
 spec:
   config: |
     {
@@ -271,7 +267,6 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   name: tenant
-  namespace: <RHOSO18_NAMESPACE>
 spec:
   config: |
     {

--- a/docs_user/modules/proc_preparing-controller-nodes-for-director-operator-adoption.adoc
+++ b/docs_user/modules/proc_preparing-controller-nodes-for-director-operator-adoption.adoc
@@ -22,7 +22,7 @@ $ oc project openstack
 ----
 export PASSWORD_FILE="tripleo-passwords.yaml"
 
-export RHOSO18_NAMESPACE="rhoso18"
+export RHOSO18_NAMESPACE="rhoso"
 
 export OSPDO_NAMESPACE="openstack"
 

--- a/docs_user/modules/proc_preparing-controller-nodes-for-director-operator-adoption.adoc
+++ b/docs_user/modules/proc_preparing-controller-nodes-for-director-operator-adoption.adoc
@@ -93,13 +93,13 @@ You might need to wait a few minutes for the control plane to get operational. T
 .. When Pacemaker is only managing one of the Controllers, delete 2 of the Controller VMs. The following example specifies Controller-1 and Controller-2 VMs for deletion:
 +
 ----
-$ oc -n openstack annotate vm controller-1 osp-director.openstack.org/delete-host=true
-$ oc -n openstack annotate vm controller-2 osp-director.openstack.org/delete-host=true
+$ oc -n "${OSPDO_NAMESPACE}"annotate vm controller-1 osp-director.openstack.org/delete-host=true
+$ oc -n "${OSPDO_NAMESPACE}"annotate vm controller-2 osp-director.openstack.org/delete-host=true
 ----
 .. Reduce the `roleCount` for the Controller role in the `OpenStackControlPlane` CR to `1`:
 +
 ----
-$ oc -n openstack patch OpenStackControlPlane overcloud --type json -p '[{"op": "replace", "path":"/spec/virtualMachineRoles/controller/roleCount", "value": 1}]'
+$ oc -n "${OSPDO_NAMESPACE}"patch OpenStackControlPlane overcloud --type json -p '[{"op": "replace", "path":"/spec/virtualMachineRoles/controller/roleCount", "value": 1}]'
 ----
 .. Ensure that the `OpenStackClient` pod is running on the same {OpenShiftShort} nodes as the remaining Controller VM. If the `OpenStackClient` pod is not on the same node, then move it by cordoning off the two nodes that have been freed up for {rhos_acro}. Then you delete the `OpenStackClient` pod so that it gets rescheduled on the {OpenShiftShort} node that has the remaining Controller VM. After the pod is moved to the correct node, uncordon all the nodes:
 +

--- a/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
+++ b/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
@@ -16,7 +16,6 @@ If you use IPv6, define the `SOURCE_MARIADB_IP` value without brackets. For exam
 +
 ----
 $ PASSWORD_FILE="$HOME/overcloud-passwords.yaml"
-$ NAMESPACE="openstack"
 ifeval::["{build}" != "downstream"]
 $ MARIADB_IMAGE=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 endif::[]
@@ -33,7 +32,7 @@ endif::[]
 ifeval::["{build_variant}" == "ospdo"]
 $ CELLS="default"
 $ for CELL in $(echo $CELLS); do
->     oc get secret tripleo-passwords -n $NAMESPACE -o json | jq -r '.data["tripleo-overcloud-passwords.yaml"]' | base64 -d >"$TRIPLEO_PASSWORDS[$CELL]"
+>     oc get secret tripleo-passwords -o json | jq -r '.data["tripleo-overcloud-passwords.yaml"]' | base64 -d >"$TRIPLEO_PASSWORDS[$CELL]"
 > done
 endif::[]
 $ declare -A SOURCE_DB_ROOT_PASSWORD
@@ -55,7 +54,7 @@ $ export SOURCE_OVN_OVSDB_IP=172.17.0.160 # get this from the source OVN DB
 . Find the mysql service IP in the `ctlplane-export.yaml` section of the `tripleo-exports-default` ConfigMap:
 +
 ----
-$ cpexport=$(oc -n "${NAMESPACE}" get cm tripleo-exports-default -o json | jq -r '.data["ctlplane-export.yaml"]')
+$ cpexport=$(oc get cm tripleo-exports-default -o json | jq -r '.data["ctlplane-export.yaml"]')
 $ declare -A SOURCE_MARIADB_IP
 $ for CELL in $(echo $CELLS); do
 >     SOURCE_MARIADB_IP[$CELL]=$(echo "$cpexport" | sed -e '0,/ MysqlInternal/d' | sed -n '0,/host_nobrackets/s/^.*host_nobrackets\:\s*\(.*\)$/\1/p')
@@ -101,11 +100,10 @@ $ CONTROLLER1_SSH="ssh -i *<path to SSH key>* root@*<node IP>*"
 endif::[]
 endif::[]
 ifeval::["{build_variant}" == "ospdo"]
-$ MARIADB_CLIENT_ANNOTATIONS="-n $NAMESPACE"
 $ MARIADB_RUN_OVERRIDES="--overrides=${RUN_OVERRIDES} $MARIADB_CLIENT_ANNOTATIONS"
 
-$ CONTROLLER1_SSH="oc -n $NAMESPACE rsh -c openstackclient openstackclient ssh controller-0.ctlplane"
-$ oc get secret tripleo-passwords -n $NAMESPACE -o json | jq -r '.data["tripleo-overcloud-passwords.yaml"]' |
+$ CONTROLLER1_SSH="oc rsh -c openstackclient openstackclient ssh controller-0.ctlplane"
+$ oc get secret tripleo-passwords -o json | jq -r '.data["tripleo-overcloud-passwords.yaml"]' |
 base64 -d >"${PASSWORD_FILE}"
 endif::[]
 
@@ -135,12 +133,6 @@ $ sudo grep -rI 'listen mysql' -A10 /var/lib/config-data/puppet-generated/ | gre
 The source cloud always uses the same password for cells databases. For that reason, the same passwords file is used for all cells stacks. However, split-stack topology allows using different passwords files for each stack.
 
 .Procedure
-
-. Ensure you are on the `openstack` namespace:
-+
-----
-$ oc project openstack
-----
 
 . Export the shell variables for the following outputs and test the connection to the {OpenStackShort} database:
 +

--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -2,9 +2,8 @@
   import_playbook: _before_adoption.yaml
 
 - name: Adoption
-  hosts: "{{ adoption_host | default('localhost') }}"
+  hosts: local
   gather_facts: false
-  force_handlers: true
   module_defaults:
     ansible.builtin.shell:
       executable: /bin/bash

--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -22,12 +22,6 @@ dns_server_ip: 192.168.122.1
 dpa_dir: "../.."
 dpa_tests_dir: "{{ dpa_dir }}/tests"
 
-# ospdo env:
-# Whether source env is OSPD Director Operator
-# i.e. https://github.com/openstack-k8s-operators/osp-director-operator
-ospdo_src: false
-# rhoso namespace
-rhoso_namespace: "openstack"
 # director operator namespace
-org_namespace: "ospdo_openstack"
+director_namespace: "ospdo_openstack"
 # adoption repo default location

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -2,7 +2,6 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc project {{ rhoso_namespace }}
 
 - name: create osp-secret
   ansible.builtin.shell: |
@@ -126,7 +125,8 @@
   register: mariadb_running_result
   until: mariadb_running_result is success
   retries: 60
-  delay: 2
+  delay: 5
+# TODO- debug value (was 2)
 
 - name: Patch openstack upstream dns server to set the correct value for the environment
   when: upstream_dns is defined

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -1,8 +1,3 @@
-- name: use openstack project
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-
 - name: create osp-secret
   ansible.builtin.shell: |
     {{ shell_header }}

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -120,8 +120,7 @@
   register: mariadb_running_result
   until: mariadb_running_result is success
   retries: 60
-  delay: 5
-# TODO- debug value (was 2)
+  delay: 2
 
 - name: Patch openstack upstream dns server to set the correct value for the environment
   when: upstream_dns is defined

--- a/tests/roles/backend_services/tasks/ospdo_backend_services.yaml
+++ b/tests/roles/backend_services/tasks/ospdo_backend_services.yaml
@@ -6,7 +6,7 @@
 
 - name: get OSPdO storage storageClass
   ansible.builtin.shell: |
-    oc get -n {{ org_namespace }} pvc openstackclient-hosts -o jsonpath='{.spec.storageClassName}'
+    oc get -n {{ director_namespace }} pvc openstackclient-hosts -o jsonpath='{.spec.storageClassName}'
   register: ospdo_storage_class
   when: deploy_ctlplane_ospdo| default(false) | bool
 

--- a/tests/roles/backend_services/templates/openstack_version.j2
+++ b/tests/roles/backend_services/templates/openstack_version.j2
@@ -2,7 +2,6 @@ apiVersion: core.openstack.org/v1beta1
 kind: OpenStackVersion
 metadata:
   name: openstack
-  namespace: openstack
 spec:
   customContainerImages:
     aodhAPIImage: {{ container_registry }}/{{ container_namespace }}/openstack-aodh-api:{{ container_tag }}

--- a/tests/roles/ceph_backend_configuration/defaults/main.yaml
+++ b/tests/roles/ceph_backend_configuration/defaults/main.yaml
@@ -1,5 +1,4 @@
 # rhoso namespace
-rhoso_namespace: "openstack"
 ceph_backend_configuration_patch: |
   spec:
     extraMounts:

--- a/tests/roles/ceph_backend_configuration/tasks/main.yaml
+++ b/tests/roles/ceph_backend_configuration/tasks/main.yaml
@@ -31,7 +31,6 @@
     kind: Secret
     metadata:
       name: ceph-conf-files
-      namespace: {{ rhoso_namespace }}
     type: Opaque
     EOF
 

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -5,8 +5,12 @@ use_no_log: false
 # Whether the adopted node will host compute services
 compute_adoption: true
 
-# Whether adopting OSPDo or Director based TripleO deployment
-deploy_ctlplane_ospdo: false
+# rhoso namespace
+rhoso_namespace: "openstack"
+
+# Whether source env is OSPD Director Operator
+# i.e. https://github.com/openstack-k8s-operators/osp-director-operator
+ospdo_src: false
 
 # The names of cells on the target cloud
 renamed_cells: "{{ [default_cell_name] + cells | difference(['default']) }}"
@@ -84,8 +88,8 @@ mariadb_copy_shell_vars_src: |-
   done
 
   RUN_OVERRIDES=' '
-  MARIADB_CLIENT_ANNOTATIONS={{ deploy_ctlplane_ospdo | bool | ternary("-n $NAMESPACE", "--annotations=k8s.v1.cni.cncf.io/networks=internalapi") }}
-  MARIADB_RUN_OVERRIDES={{ deploy_ctlplane_ospdo | bool | ternary("--overrides=${RUN_OVERRIDES} $MARIADB_CLIENT_ANNOTATIONS {{ mysql_client_override }}", "$MARIADB_CLIENT_ANNOTATIONS") }}
+  MARIADB_CLIENT_ANNOTATIONS={{ deploy_ctlplane_ospdo | default(false) | bool | ternary("-n $NAMESPACE", "--annotations=k8s.v1.cni.cncf.io/networks=internalapi") }}
+  MARIADB_RUN_OVERRIDES={{ deploy_ctlplane_ospdo | default(false) | bool | ternary("--overrides=${RUN_OVERRIDES} $MARIADB_CLIENT_ANNOTATIONS {{ mysql_client_override }}", "$MARIADB_CLIENT_ANNOTATIONS") }}
 
   OSPDO_MARIADB_CLIENT_ANNOTATIONS='[{"name": "internalapi-static","ips": ["172.17.0.99/24"]}]'
 

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -65,9 +65,6 @@ mariadb_passwords_env: |-
     PODIFIED_DB_ROOT_PASSWORD[$CELL]=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
   done
 
-namespace_env: |-
-  NAMESPACE={{ deploy_ctlplane_ospdo | bool | ternary(org_namespace, rhoso_namespace ) }}
-
 # Header for the source database access
 # TODO: Env vars for OSPDo case are also configured in env_vars_src_ospdo.yaml. Move them here, eventually?
 # OSPDo RUN_OVERRIDES definition exists only in docs (missing in code?).
@@ -77,7 +74,6 @@ mariadb_copy_shell_vars_src: |-
   {{ shell_header }}
 
   PASSWORD_FILE="$HOME/overcloud-passwords.yaml"
-  {{ namespace_env }}
 
   {{ mariadb_image_env }}
   {{ cells_env }}
@@ -114,7 +110,6 @@ mariadb_copy_shell_vars_dst: |
   {{ oc_header }}
   {{ mariadb_image_env }}
   {{ cells_env }}
-  {{ namespace_env }}
 
   CHARACTER_SET=utf8
   COLLATION=utf8_general_ci

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -284,14 +284,6 @@ dataplane_cr: |
 dpa_dir: "../.."
 dpa_tests_dir: "{{ dpa_dir }}/tests"
 
-# ospdo env:
-# Whether source env is OSPD Director Operator
-# i.e. https://github.com/openstack-k8s-operators/osp-director-operator
-ospdo_src: false
-# rhoso namespace
-rhoso_namespace: "openstack"
-# director operator namespace
-org_namespace: "ospdo_openstack"
 # adoption repo default location
 
 networker_cr: |

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -113,7 +113,7 @@
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: nova-cells-global-config
+      name: nova-extra-config
     data:
       19-nova-compute-cell1-workarounds.conf: |
         [workarounds]
@@ -133,7 +133,7 @@
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: nova-cells-global-config
+      name: nova-extra-config
     data:
       19-nova-compute-cell1-workarounds.conf: |
         [workarounds]

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -12,7 +12,6 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ oc_login_command }}
     oc patch openstackversion openstack \
       --type='json' -p='[{
       "op":"replace", "path":"/spec/customContainerImages/ansibleeeImage",

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -13,17 +13,10 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ oc_login_command }}
-    oc patch -n {{ rhoso_namespace }} openstackversion openstack \
+    oc patch openstackversion openstack \
       --type='json' -p='[{
       "op":"replace", "path":"/spec/customContainerImages/ansibleeeImage",
       "value": "{{ ansibleee_runner_img | default('quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest')}}"}]'
-
-- name: ensure namespace
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc project {{ rhoso_namespace }}
 
 - name: Include RHEV vars
   ansible.builtin.include_vars:
@@ -85,7 +78,6 @@
     cd "$(mktemp -d)"
     ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
     oc get secret nova-migration-ssh-key || oc create secret generic nova-migration-ssh-key \
-    -n  {{ rhoso_namespace }} \
     --from-file=ssh-privatekey=id \
     --from-file=ssh-publickey=id.pub \
     --type kubernetes.io/ssh-auth
@@ -102,7 +94,6 @@
     kind: Secret
     metadata:
         name: libvirt-secret
-        namespace: {{ rhoso_namespace }}
     type: Opaque
     data:
       LibvirtPassword: {{ libvirt_password | b64encode }}
@@ -123,8 +114,7 @@
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: nova-extra-config
-      namespace:  {{ rhoso_namespace }}
+      name: nova-cells-global-config
     data:
       19-nova-compute-cell1-workarounds.conf: |
         [workarounds]
@@ -144,8 +134,7 @@
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: nova-extra-config
-      namespace: {{ rhoso_namespace }}
+      name: nova-cells-global-config
     data:
       19-nova-compute-cell1-workarounds.conf: |
         [workarounds]

--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -2,7 +2,7 @@
   ansible.builtin.shell: |
     {{ mariadb_copy_shell_vars_dst }}
     for CELL in $(echo $RENAMED_CELLS); do
-      oc exec openstack-$CELL-galera-0 -n $NAMESPACE -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \
+      oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \
         -e "select a.version from nova_${CELL}.services a join nova_${CELL}.services b where a.version!=b.version and a.binary='nova-compute' and a.deleted=0;"
     done
   register: records_check_results

--- a/tests/roles/dataplane_adoption/tasks/ospdo_dataplane.yaml
+++ b/tests/roles/dataplane_adoption/tasks/ospdo_dataplane.yaml
@@ -8,10 +8,9 @@
       kind: Secret
       metadata:
           name: dataplane-adoption-secret
-          namespace: {{ rhoso_namespace }}
       data:
           ssh-privatekey: |
-      $(oc exec -n {{ org_namespace }} -t openstackclient openstackclient -- cat /home/cloud-admin/.ssh/id_rsa | base64 | sed 's/^/        /')
+      $(oc exec -t openstackclient openstackclient -- cat /home/cloud-admin/.ssh/id_rsa | base64 | sed 's/^/        /')
       EOF
 
 
@@ -27,6 +26,5 @@
     kind: Secret
     metadata:
     name: libvirt-secret
-    namespace: {{ rhoso_namespace }}
     type: Opaque
     EOF

--- a/tests/roles/ironic_adoption/tasks/main.yaml
+++ b/tests/roles/ironic_adoption/tasks/main.yaml
@@ -42,7 +42,7 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ ironic_disable_rbac_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_disable_rbac_patch }}'
 
 - name: Wait for Ironic control plane services' CRs to become ready
   ansible.builtin.include_tasks:
@@ -77,7 +77,7 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ ironic_enable_rbac_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_enable_rbac_patch }}'
 
 - name: Wait for Ironic control plane services' CRs to become ready
   ansible.builtin.include_tasks:

--- a/tests/roles/keystone_adoption/defaults/main.yaml
+++ b/tests/roles/keystone_adoption/defaults/main.yaml
@@ -1,6 +1,5 @@
 ---
-# rhoso namespace
-rhoso_namespace: "openstack"
+
 keystone_patch: |
   spec:
     keystone:

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -13,7 +13,6 @@
     kind: Secret
     metadata:
       name: keystone
-      namespace: {{ rhoso_namespace }}
     type: Opaque
     EOF
 

--- a/tests/roles/mariadb_copy/defaults/main.yaml
+++ b/tests/roles/mariadb_copy/defaults/main.yaml
@@ -7,11 +7,5 @@ dpa_tests_dir: "{{ dpa_dir }}/tests"
 
 mysql_client_override: ""
 
-# ospdo env:
-# Whether source env is OSPD Director Operator
-# i.e. https://github.com/openstack-k8s-operators/osp-director-operator
-ospdo_src: false
-# rhoso namespace
-rhoso_namespace: "openstack"
 # director operator namespace
-org_namespace: "ospdo_openstack"
+director_namespace: "ospdo_openstack"

--- a/tests/roles/mariadb_copy/tasks/env_vars_src_ospdo.yaml
+++ b/tests/roles/mariadb_copy/tasks/env_vars_src_ospdo.yaml
@@ -2,19 +2,19 @@
   block:
     - name: register source_mariadb_ip
       ansible.builtin.shell: |
-        oc -n {{ org_namespace }} get cm tripleo-exports-default -o json | jq -r '.data["ctlplane-export.yaml"]'| sed -e '0,/ MysqlInternal/d' | sed -n '0,/host_nobrackets/s/^.*host_nobrackets\:\s*\(.*\)$/\1/p'
+        oc -n {{ director_namespace }} get cm tripleo-exports-default -o json | jq -r '.data["ctlplane-export.yaml"]'| sed -e '0,/ MysqlInternal/d' | sed -n '0,/host_nobrackets/s/^.*host_nobrackets\:\s*\(.*\)$/\1/p'
       register: source_mariadb_ip
 
     - name: register controller node
       no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
-        oc get vmi -n{{ org_namespace }} -o jsonpath='{.items[0].metadata.labels.kubevirt\.io/nodeName}'
+        oc get vmi -n{{ director_namespace }} -o jsonpath='{.items[0].metadata.labels.kubevirt\.io/nodeName}'
       register: controller_node
 
     - name: register source_db_root_pass
       no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
-        oc get secret -n {{ org_namespace }} tripleo-passwords -o jsonpath='{.data.*}'| base64 -d |grep MysqlRootPassword|sed 's/.*: //g'
+        oc get secret -n {{ director_namespace }} tripleo-passwords -o jsonpath='{.data.*}'| base64 -d |grep MysqlRootPassword|sed 's/.*: //g'
       register: source_db_root_pass
 
     # FIXME: OSPDo RUN_OVERRIDES definition exists only in docs (missing in code?).
@@ -32,5 +32,5 @@
           )
           declare -A SOURCE_DB_ROOT_PASSWORD
           SOURCE_DB_ROOT_PASSWORD['default']={{ source_db_root_pass.stdout }}
-          MARIADB_CLIENT_ANNOTATIONS="-n {{ org_namespace }}"
+          MARIADB_CLIENT_ANNOTATIONS="-n {{ director_namespace }}"
           CONTROLLER_NODE={{ controller_node.stdout }}

--- a/tests/roles/mariadb_copy/tasks/env_vars_src_ospdo.yaml
+++ b/tests/roles/mariadb_copy/tasks/env_vars_src_ospdo.yaml
@@ -34,7 +34,3 @@
           SOURCE_DB_ROOT_PASSWORD['default']={{ source_db_root_pass.stdout }}
           MARIADB_CLIENT_ANNOTATIONS="-n {{ org_namespace }}"
           CONTROLLER_NODE={{ controller_node.stdout }}
-
-- name: set default NS to {{ rhoso_namespace }}
-  ansible.builtin.shell: |
-    oc project {{ rhoso_namespace }}

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -15,7 +15,6 @@
     kind: PersistentVolumeClaim
     metadata:
       name: mariadb-data
-      namespace: $NAMESPACE
     spec:
       storageClassName: $STORAGE_CLASS
       accessModes:
@@ -31,7 +30,6 @@
       annotations:
         openshift.io/scc: anyuid
         k8s.v1.cni.cncf.io/networks: {{ copy_pods_custom_networks | default('internalapi') }}
-      namespace: $NAMESPACE
       labels:
         app: adoption
     spec:
@@ -62,8 +60,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ namespace_env }}
-    oc wait --for condition=Ready -n $NAMESPACE pod/mariadb-copy-data --timeout=10s
+    oc wait --for condition=Ready pod/mariadb-copy-data --timeout=10s
   register: mariadb_data_pod_result
   until: mariadb_data_pod_result is success
   retries: 25
@@ -79,7 +76,7 @@
       MEMBERS=SOURCE_GALERA_MEMBERS_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')[@]
       for i in "${!MEMBERS}"; do
         echo "Checking for the database node $i WSREP status Synced"
-        oc rsh  -n $NAMESPACE mariadb-copy-data mysql \
+        oc rsh mariadb-copy-data mysql \
           -h "$i" -uroot -p"${SOURCE_DB_ROOT_PASSWORD[$CELL]}" \
           -e "show global status like 'wsrep_local_state_comment'" | \
           grep -qE "\bSynced\b"

--- a/tests/roles/mariadb_copy/templates/dump_dbs.bash
+++ b/tests/roles/mariadb_copy/templates/dump_dbs.bash
@@ -7,7 +7,7 @@
 # Gnocchi is no longer used as a metric store, skip dumping gnocchi database as well
 # Migrating Aodh alarms from previous release is not supported, hence skip aodh database
 for CELL in $(echo $CELLS); do
-  oc rsh -n $NAMESPACE mariadb-copy-data << EOF
+  oc rsh mariadb-copy-data << EOF
     mysql -h"${SOURCE_MARIADB_IP[$CELL]}" -uroot -p"${SOURCE_DB_ROOT_PASSWORD[$CELL]}" \
     -N -e "show databases" | grep -E -v "schema|mysql|gnocchi|aodh" | \
     while read dbname; do

--- a/tests/roles/mariadb_copy/templates/pre_checks.bash
+++ b/tests/roles/mariadb_copy/templates/pre_checks.bash
@@ -3,6 +3,6 @@
 
 # Test the connection to the control plane "upcall" and cells' databases
 for CELL in $(echo "super $RENAMED_CELLS"); do
-  oc run mariadb-client -n $NAMESPACE --image $MARIADB_IMAGE -i --rm --restart=Never -- \
+  oc run mariadb-client --image $MARIADB_IMAGE -i --rm --restart=Never -- \
     mysql -rsh "${PODIFIED_MARIADB_IP[$CELL]}" -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" -e 'SHOW databases;'
 done

--- a/tests/roles/mariadb_copy/templates/restore_dbs.bash
+++ b/tests/roles/mariadb_copy/templates/restore_dbs.bash
@@ -7,7 +7,7 @@
 for CELL in $(echo $CELLS); do
   RCELL=$CELL
   [ "$CELL" = "default" ] && RCELL=$DEFAULT_CELL_NAME
-  oc rsh -n $NAMESPACE mariadb-copy-data << EOF
+  oc rsh mariadb-copy-data << EOF
     declare -A db_name_map # <1>
     db_name_map['nova']="nova_$RCELL"
     db_name_map['ovs_neutron']='neutron'

--- a/tests/roles/nova_adoption/tasks/nova_ironic.yaml
+++ b/tests/roles/nova_adoption/tasks/nova_ironic.yaml
@@ -13,7 +13,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack -n openstack --type=merge --patch '{{ remove_ffu_workaround_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ remove_ffu_workaround_patch }}'
 
 - name: wait for Nova control plane services' CRs to become ready
   ansible.builtin.include_tasks:

--- a/tests/roles/octavia_adoption/defaults/main.yaml
+++ b/tests/roles/octavia_adoption/defaults/main.yaml
@@ -1,4 +1,3 @@
 octavia_ssh_pubkey_path: /root/.ssh/id_ecdsa.pub
 octavia_ssh_path: /tmp/octavia-ssl
-# rhoso namespace
-rhoso_namespace: "openstack"
+run_octavia_ssh_adoption: true

--- a/tests/roles/octavia_adoption/tasks/octavia_certs.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_certs.yaml
@@ -57,7 +57,6 @@
     kind: Secret
     metadata:
       name: octavia-certs-secret
-      namespace: {{ rhoso_namespace }}
     type: Opaque
     data:
       server_ca.key.pem:  $(cat ${CERT_MIGRATE_PATH}/server_ca/private/server_ca.key.pem | base64 -w0)
@@ -71,7 +70,6 @@
     kind: Secret
     metadata:
       name: octavia-ca-passphrase
-      namespace: {{ rhoso_namespace }}
     type: Opaque
     data:
       server-ca-passphrase: $(echo $SERVER_CA_PASSPHRASE | base64 -w0)

--- a/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
@@ -53,7 +53,6 @@
       labels:
         osp/net: octavia
       name: octavia
-      namespace: openstack
     spec:
       config: |
         {

--- a/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
@@ -3,12 +3,12 @@
     {{ shell_header }}
     {{ oc_header }}
 
-    oc get -n openstack --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
+    oc get --no-headers nncp | cut -f 1 -d ' ' | grep -v nncp-dns | while read; do
 
     interfaces=$(oc get nncp $REPLY -o jsonpath="{.spec.desiredState.interfaces[*].name}")
 
     (echo $interfaces | grep -w -q "octbr\|enp6s0.24") || \
-            oc patch -n openstack nncp $REPLY --type json --patch '
+            oc patch nncp $REPLY --type json --patch '
     [{
         "op": "add",
         "path": "/spec/desiredState/interfaces/-",
@@ -74,7 +74,7 @@
           }
         }
     EOF_CAT
-    oc apply -n openstack -f octavia-nad.yaml
+    oc apply -f octavia-nad.yaml
 
 - name: Enable the octavia service in OpenShift
   ansible.builtin.shell: |
@@ -84,7 +84,7 @@
     # FIXME: debug only. remove.
     oc project
 
-    oc patch -n openstack openstackcontrolplane openstack --type=merge --patch '
+    oc patch openstackcontrolplane openstack --type=merge --patch '
     spec:
       ovn:
         template:

--- a/tests/roles/octavia_adoption/tasks/octavia_ssh.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_ssh.yaml
@@ -12,7 +12,6 @@
     kind: ConfigMap
     metadata:
       name: octavia-ssh-pubkey
-      namespace: openstack
     data:
       key: $(cat $HOME/octavia_sshkey.pub)
     EOF

--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -39,12 +39,6 @@ ovn_nic_mapping_patch: |
 dpa_dir: "../.."
 dpa_tests_dir: "{{ dpa_dir }}/tests"
 
-# ospdo env:
-# Whether source env is OSPD Director Operator
-# i.e. https://github.com/openstack-k8s-operators/osp-director-operator
-ospdo_src: false
-# rhoso namespace
-rhoso_namespace: "openstack"
 # director operator namespace
-org_namespace: "ospdo_openstack"
+director_namespace: "ospdo_openstack"
 # adoption repo default location

--- a/tests/roles/ovn_adoption/handlers/main.yaml
+++ b/tests/roles/ovn_adoption/handlers/main.yaml
@@ -2,8 +2,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ namespace_env }}
-    oc delete --ignore-not-found=true pod -n $NAMESPACE ovn-copy-data
-    oc delete --ignore-not-found=true certificate -n $NAMESPACE ovn-data-cert
-    oc delete --ignore-not-found=true secret -n $NAMESPACE ovn-data-cert
-    {% if storage_reclaim_policy.lower() == "delete" %}oc delete pvc --ignore-not-found=true -n $NAMESPACE ovn-data{% endif %}
+    oc delete --ignore-not-found=true pod ovn-copy-data
+    oc delete --ignore-not-found=true certificate ovn-data-cert
+    oc delete --ignore-not-found=true secret ovn-data-cert
+    {% if storage_reclaim_policy.lower() == "delete" %}oc delete pvc --ignore-not-found=true ovn-data{% endif %}

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -61,7 +61,6 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
-    {{ namespace_env}}
 
     oc apply -f - <<EOF
     ---
@@ -69,7 +68,6 @@
     kind: Certificate
     metadata:
       name: ovn-data-cert
-      namespace: $NAMESPACE
     spec:
       commonName: ovn-data-cert
       secretName: ovn-data-cert
@@ -79,7 +77,6 @@
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
-      namespace: $NAMESPACE
       name: ovn-data
       labels:
         app: adoption
@@ -134,8 +131,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    {{ namespace_env}}
-    oc wait --for condition=Ready -n $NAMESPACE pod/ovn-copy-data --timeout=30s
+    oc wait --for condition=Ready pod/ovn-copy-data --timeout=30s
   register: ovn_data_pod_result
   until: ovn_data_pod_result is success
   retries: 2
@@ -176,10 +172,9 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
-    {{ namespace_env}}
 
-    oc exec -n $NAMESPACE ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6641 > /backup/ovs-nb.db"
-    oc exec -n $NAMESPACE ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6642 > /backup/ovs-sb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6641 > /backup/ovs-nb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client backup tcp:$SOURCE_OVSDB_IP:6642 > /backup/ovs-sb.db"
   when: enable_tlse|bool is false
 
 - name: dump OVN databases using ssl connection
@@ -199,10 +194,9 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
-    {{ namespace_env }}
 
-    oc exec -n $NAMESPACE ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_NB_IP:6641 > /backup/ovs-nb.ovsschema && ovsdb-tool convert /backup/ovs-nb.db /backup/ovs-nb.ovsschema"
-    oc exec -n $NAMESPACE ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_SB_IP:6642 > /backup/ovs-sb.ovsschema && ovsdb-tool convert /backup/ovs-sb.db /backup/ovs-sb.ovsschema"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_NB_IP:6641 > /backup/ovs-nb.ovsschema && ovsdb-tool convert /backup/ovs-nb.db /backup/ovs-nb.ovsschema"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client get-schema tcp:$PODIFIED_OVSDB_SB_IP:6642 > /backup/ovs-sb.ovsschema && ovsdb-tool convert /backup/ovs-sb.db /backup/ovs-sb.ovsschema"
   when: enable_tlse|bool is false
 
 - name: upgrade OVN databases to the latest schema from podified ovsdb-servers (tls)
@@ -233,10 +227,9 @@
     {{ shell_header }}
     {{ oc_header }}
     {{ ovn_copy_shell_vars }}
-    {{ namespace_env}}
 
-    oc exec -n $NAMESPACE ovn-copy-data -- bash -c "ovsdb-client restore --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
-    oc exec -n $NAMESPACE ovn-copy-data -- bash -c "ovsdb-client restore --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client restore --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_NB_IP:6641 < /backup/ovs-nb.db"
+    oc exec ovn-copy-data -- bash -c "ovsdb-client restore --ca-cert=/etc/pki/tls/misc/ca.crt --private-key=/etc/pki/tls/misc/tls.key --certificate=/etc/pki/tls/misc/tls.crt ssl:$PODIFIED_OVSDB_SB_IP:6642 < /backup/ovs-sb.db"
   when: enable_tlse|bool
 
 - name: deploy podified OVN northd service to keep databases in sync

--- a/tests/roles/ovn_adoption/tasks/ovn_ospdo_src_vars.yaml
+++ b/tests/roles/ovn_adoption/tasks/ovn_ospdo_src_vars.yaml
@@ -1,17 +1,17 @@
 - name: get ospdo source_ovndb_ip
   ansible.builtin.shell: |
-    oc -n {{ org_namespace }} get cm tripleo-exports-default  -o yaml | awk '/ovn_dbs_node_ips:/{getline; print $3}'|tr -d '\\n'
+    oc -n {{ director_namespace }} get cm tripleo-exports-default  -o yaml | awk '/ovn_dbs_node_ips:/{getline; print $3}'|tr -d '\\n'
   register: source_ovndb_ip_str
 
 - name: register controller node
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
-    oc get vmi -n{{ org_namespace }} -o jsonpath='{.items[0].metadata.labels.kubevirt\.io/nodeName}'
+    oc get vmi -n{{ director_namespace }} -o jsonpath='{.items[0].metadata.labels.kubevirt\.io/nodeName}'
   register: controller_node
 
 - name: get OSPdO storage storageClass
   ansible.builtin.shell: |
-    oc get -n {{ org_namespace }} pvc openstackclient-hosts -o jsonpath='{.spec.storageClassName}'
+    oc get -n {{ director_namespace }} pvc openstackclient-hosts -o jsonpath='{.spec.storageClassName}'
   register: ospdo_storage_class
 
 - name: set OVN copy shell vars
@@ -37,6 +37,6 @@
     kind: Secret
     metadata:
       name: ovn-data-cert
-      namespace: {{ org_namespace }}
+      namespace: {{ director_namespace }}
     type: Opaque
     EOF

--- a/tests/roles/ovn_adoption/tasks/ovn_ospdo_src_vars.yaml
+++ b/tests/roles/ovn_adoption/tasks/ovn_ospdo_src_vars.yaml
@@ -40,7 +40,3 @@
       namespace: {{ org_namespace }}
     type: Opaque
     EOF
-
-- name: set default NS to {{ rhoso_namespace }}
-  ansible.builtin.shell: |
-    oc project {{ rhoso_namespace }}

--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -3,17 +3,17 @@
     {{ shell_header }}
     {{ oc_header }}
     # Cleanup OpenStackControlPlane object
-    oc delete --ignore-not-found=true osctlplane -l core.openstack.org/openstackcontrolplane -n openstack
+    oc delete --ignore-not-found=true osctlplane -l core.openstack.org/openstackcontrolplane
 
     # Ensure that all pods in openstack namespace are deleted
-    while oc get pod -n openstack | grep -E 'rabbitmq-server-0|openstack-galera-0'; do
+    while oc get pod | grep -E 'rabbitmq-server-0|openstack-galera-0'; do
       sleep 2;
     done
 
     # Cleanup OpenStackDataplane objects
-    oc delete --ignore-not-found=true OpenStackDataPlaneDeployment --all -n openstack
-    oc delete --ignore-not-found=true OpenStackDataPlaneNodeSet --all -n openstack
-    oc delete --ignore-not-found=true OpenStackDataPlaneService --all -n openstack
+    oc delete --ignore-not-found=true OpenStackDataPlaneDeployment --all
+    oc delete --ignore-not-found=true OpenStackDataPlaneNodeSet --all
+    oc delete --ignore-not-found=true OpenStackDataPlaneService --all
 
     # Delete Adoption helper pods
     oc delete --ignore-not-found=true --wait=false pod mariadb-copy-data
@@ -21,11 +21,11 @@
     oc delete --ignore-not-found=true --wait=false pod ovn-copy-data
 
     # Delete secrets
-    for secret in $(oc -o name get secrets -n openstack); do
+    for secret in $(oc -o name get secrets ); do
       echo "Deleting secret ${secret}";
       #(TODO: holser) oc patch can be removed when OSPRH-10262 is merged
       oc patch ${secret} -p '{"metadata":{"finalizers":[]}}' --type=merge
-      oc delete ${secret} -n openstack;
+      oc delete ${secret} ;
     done
 
     # Make pvs available if they are released

--- a/tests/roles/pcp_cleanup/tasks/main.yaml
+++ b/tests/roles/pcp_cleanup/tasks/main.yaml
@@ -54,6 +54,7 @@
     cd {{ install_yamls_path }}
     for i in {1..3}; do make crc_storage_cleanup crc_storage && break || sleep 5; done
     {{ cells_env }}
+    NAMESPACE={{ rhoso_namespace }} make namespace
     for CELL in $(echo $RENAMED_CELLS); do
       oc delete pvc mysql-db-openstack-$CELL-galera-0 --ignore-not-found=true
       oc delete pvc persistence-rabbitmq-$CELL-server-0 --ignore-not-found=true

--- a/tests/roles/prelude_local/defaults/main.yaml
+++ b/tests/roles/prelude_local/defaults/main.yaml
@@ -3,3 +3,5 @@
 clone_install_yamls: false
 # Path where install_yamls repo should be found.
 install_yamls_path: "{{ inventory_dir }}/install_yamls"
+# rhoso namespace
+rhoso_namespace: "openstack"

--- a/tests/roles/prelude_local/tasks/main.yaml
+++ b/tests/roles/prelude_local/tasks/main.yaml
@@ -22,3 +22,8 @@
     {{ oc_header }}
     cd {{ install_yamls_path }}
     make namespace
+
+  # This sets the namespace for all of the tasks that follow
+- name: set default NS to {{ rhoso_namespace }}
+  ansible.builtin.shell: |
+    oc project {{ rhoso_namespace }}

--- a/tests/roles/prelude_local/tasks/main.yaml
+++ b/tests/roles/prelude_local/tasks/main.yaml
@@ -16,14 +16,21 @@
     {{ oc_header }}
     {{ oc_login_command }}
 
-- name: set up and use openstack namespace
+- name: use diffrent namespace for OSPdO adoption
+  ansible.builtin.set_fact:
+    rhoso_namespace: "rhoso"
+  when: ospdo_src | bool | default(false)
+
+- name: create namespace
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     cd {{ install_yamls_path }}
-    make namespace
+    NAMESPACE={{ rhoso_namespace }} make namespace
 
-  # This sets the namespace for all of the tasks that follow
-- name: set default NS to {{ rhoso_namespace }}
+# This sets the namespace in kubeconfig context for all of the tasks that follow
+- name: set default namespace to {{ rhoso_namespace }}
   ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
     oc project {{ rhoso_namespace }}

--- a/tests/roles/swift_adoption/defaults/main.yaml
+++ b/tests/roles/swift_adoption/defaults/main.yaml
@@ -1,6 +1,5 @@
 ---
 # rhoso namespace
-rhoso_namespace: "openstack"
 swift_patch: |
   spec:
     swift:

--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -8,7 +8,6 @@
     kind: Secret
     metadata:
       name: swift-conf
-      namespace: {{ rhoso_namespace }}
     type: Opaque
     data:
       swift.conf: $($CONTROLLER1_SSH sudo cat /var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf | base64 -w0)

--- a/tests/roles/tls_adoption/tasks/main.yaml
+++ b/tests/roles/tls_adoption/tasks/main.yaml
@@ -18,7 +18,6 @@
     kind: Issuer
     metadata:
       name: rootca-internal
-      namespace: openstack
       labels:
         osp-rootca-issuer-public: ""
         osp-rootca-issuer-internal: ""

--- a/tests/roles/tls_adoption/tasks/main.yaml
+++ b/tests/roles/tls_adoption/tasks/main.yaml
@@ -5,13 +5,13 @@
     IPA_SSH="{{ ipa_ssh }}"
     $IPA_SSH pk12util -o /tmp/freeipa.p12 -n 'caSigningCert\ cert-pki-ca' -d /etc/pki/pki-tomcat/alias -k /etc/pki/pki-tomcat/alias/pwdfile.txt -w /etc/pki/pki-tomcat/alias/pwdfile.txt
 
-    oc create secret generic rootca-internal -n openstack
+    oc create secret generic rootca-internal
 
-    oc patch secret rootca-internal -n openstack -p="{\"data\":{\"ca.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
+    oc patch secret rootca-internal -p="{\"data\":{\"ca.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
 
-    oc patch secret rootca-internal -n openstack -p="{\"data\":{\"tls.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
+    oc patch secret rootca-internal -p="{\"data\":{\"tls.crt\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nokeys | openssl x509 | base64 -w 0`\"}}"
 
-    oc patch secret rootca-internal -n openstack -p="{\"data\":{\"tls.key\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nocerts -noenc | openssl rsa | base64 -w 0`\"}}"
+    oc patch secret rootca-internal -p="{\"data\":{\"tls.key\": \"`$IPA_SSH openssl pkcs12 -in /tmp/freeipa.p12 -passin file:/etc/pki/pki-tomcat/alias/pwdfile.txt -nocerts -noenc | openssl rsa | base64 -w 0`\"}}"
 
     oc apply -f - <<EOF
     apiVersion: cert-manager.io/v1

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -111,4 +111,4 @@ ospdo_src: false
 # rhoso namespace
 rhoso_namespace: "openstack"
 # director operator namespace
-org_namespace: "ospdo_openstack"
+director_namespace: "ospdo_openstack"


### PR DESCRIPTION
Remove redundant namespace flags

As -n $namespace is called at the prelude role , there is no need
to call explicit -n namespace anymore , for ospdo adoption explicit
parametrized $namespace is called.

a Continuation of : https://issues.redhat.com/browse/OSPRH-14801
