### PR TITLE
Disable NetworkManager DNS config update

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -490,6 +490,10 @@ endif::[]
            {% endfor %}
 
         edpm_network_config_nmstate: false
+        # Control resolv.conf management by NetworkManager
+        # false = disable NetworkManager resolv.conf update (default)
+        # true = enable NetworkManager resolv.conf update
+        edpm_bootstrap_network_resolvconf_update: false
         edpm_network_config_hide_sensitive_logs: false
         #
         # These vars are for the network config templates themselves and are

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -222,6 +222,7 @@ dataplane_cr: |
             {{ edpm_network_config_template| indent(10) }}
 
           edpm_network_config_nmstate: false
+          edpm_bootstrap_network_resolvconf_update: false
           edpm_network_config_hide_sensitive_logs: false
           #
           # These vars are for the network config templates themselves and are


### PR DESCRIPTION
This chenge is to prevent the DNS config update via NetworkManager for ifcfg provider and only set this edpm ansible variable 'edpm_bootstrap_network_resolvconf_update' true for supporting nmsate provider.