### PR TITLE
Fix hardcoded tripleo passwords file

### DIFF
--- a/tests/roles/backend_services/tasks/ospdo_backend_services.yaml
+++ b/tests/roles/backend_services/tasks/ospdo_backend_services.yaml
@@ -1,7 +1,7 @@
 - name: get service passwords
   ansible.builtin.shell: |
      oc get secret tripleo-passwords -o jsonpath='{.data.*}' | base64 -d>~/tripleo-standalone-passwords.yaml
-     cp ~/tripleo-standalone-passwords.yaml ~/overcloud-passwords.yaml
+     cp ~/tripleo-standalone-passwords.yaml {{ tripleo_passwords['default'] }}
   when: get_svc_pass| default(false) | bool
 
 - name: get OSPdO storage storageClass

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -119,7 +119,7 @@ mariadb_passwords_env: |-
 mariadb_copy_shell_vars_src: |-
   {{ shell_header }}
 
-  PASSWORD_FILE="$HOME/overcloud-passwords.yaml"
+  PASSWORD_FILE="{{ tripleo_passwords['default'] }}"
 
   {{ mariadb_image_env }}
   {{ cells_env }}


### PR DESCRIPTION
Note: rdo-jobs, and ci-framework-jobs still do hardcode it to overcloud-passwords.yaml in multiple places and jobs templates.

Jira: [OSPRH-16719](https://issues.redhat.com/browse/OSPRH-16719)