### PR TITLE
Update tobiko advance image

### DIFF
--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -144,8 +144,8 @@
           test_runner_timeout = 14400.0
           timeout = 1800.0
           [advanced_vm]
-          image_url = "https://softwarefactory-project.io/ubuntu-minimal-customized-enp3s0"
-          username: ubuntu
+          image_url = "kaplonski.pl/files/Customized-Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
+          username: fedora
           [tripleo]
           undercloud_ssh_hostname = undercloud
           undercloud_ssh_username = zuul


### PR DESCRIPTION
With recent tobiko changes, customized fedora images are supported to test QoS, VLANs, etc
Related to: [TOBIKO-142](https://issues.redhat.com//browse/TOBIKO-142)