### PR TITLE
Increase OpenStackControlPlane timeout

### DIFF
--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -59,7 +59,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc wait --for=condition=Ready --timeout=1m OpenStackControlPlane openstack
+    oc wait --for=condition=Ready --timeout=3m OpenStackControlPlane openstack
 
 - name: clean up services and endpoints
   ansible.builtin.shell: |


### PR DESCRIPTION
1m is not enough on slow systems. This patch proposes to increase timeout to 3 min to minimize sporadic failures caused by slow environments.

```
TASK [keystone_adoption : verify that OpenStackControlPlane setup is complete] ***
Sunday 25 May 2025  20:01:27 +0000 (0:00:03.935)       0:09:32.219 ************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "set -euxo pipefail\n\nexport KUBECONFIG=~/adoption/kubeconfig\n\noc wait --for=condition=Ready --timeout=1m OpenStackControlPlane openstack\n", "delta": "0:01:00.097453", "end": "2025-05-25 20:02:27.600243", "msg": "non-zero return code", "rc": 1, "start": "2025-05-25 20:01:27.502790", "stderr": "+ export KUBECONFIG=/home/stack/adoption/kubeconfig\n+ KUBECONFIG=/home/stack/adoption/kubeconfig\n+ oc wait --for=condition=Ready --timeout=1m OpenStackControlPlane openstack\nerror: timed out waiting for the condition on openstackcontrolplanes/openstack", "stderr_lines": ["+ export KUBECONFIG=/home/stack/adoption/kubeconfig", "+ KUBECONFIG=/home/stack/adoption/kubeconfig", "+ oc wait --for=condition=Ready --timeout=1m OpenStackControlPlane openstack", "error: timed out waiting for the condition on openstackcontrolplanes/openstack"], "stdout": "", "stdout_lines": []}
```