### PR TITLE
Use uniquePodNames for cinder and glance pods

### DIFF
--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -18,6 +18,7 @@ heat_stack_domain_admin_password: ''
 swift_password: ''
 dns_lb_ip: 192.168.122.80
 dns_server_ip: 192.168.122.1
+enable_unique_pod_names: false
 
 dpa_dir: "../.."
 dpa_tests_dir: "{{ dpa_dir }}/tests"

--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -14,6 +14,9 @@ spec:
       barbicanKeystoneListener: {}
 
   cinder:
+{% if enable_unique_pod_names %}
+    uniquePodNames: true
+{% endif %}
     enabled: false
     template:
       cinderAPI: {}
@@ -39,6 +42,9 @@ spec:
       replicas: 1
 
   glance:
+{% if enable_unique_pod_names %}
+    uniquePodNames: true
+{% endif %}
     enabled: false
     template:
       glanceAPIs: {}

--- a/tests/vars.sample.yaml
+++ b/tests/vars.sample.yaml
@@ -4,6 +4,9 @@ install_yamls_path: ~/install_yamls #CUSTOMIZE_THIS
 # This flag signifies if TLS Everywhere is enabled on the source cloud
 enable_tlse: false
 
+# This flag enables unique pod names for the adopted OpenStack services.
+enable_unique_pod_names: false
+
 # Source MariaDB Galera cluster members {name:IP} pairs of addresses on internal_api network (also in additional cells) for pre-adoption checks.
 # Defaults provided for a single-cell case. Complete the lists for an HA multi-cell adoption.
 source_galera_members:


### PR DESCRIPTION
There is a descrepency between adoption and clean deployemnt as clean deployment of OSP18 uses uniquePodNames. This patch changes the behavior to use uniquePodNames: true for glance and cinder. The documentation is changes accordingly

Jira: [OSPRH-15353](https://issues.redhat.com//browse/OSPRH-15353)