### PR TITLE
Update glance adoption scenarios

### DIFF
--- a/tests/roles/glance_adoption/tasks/glance_nfs.yaml
+++ b/tests/roles/glance_adoption/tasks/glance_nfs.yaml
@@ -1,0 +1,19 @@
+- name: Fail if no nfs_server_addr/nfs_server_path are definied
+  when:
+    - glance_nfs_server_addr is not defined
+    - glance_nfs_server_path is not defined
+  ansible.builtin.fail:
+    msg:
+      - 'glance_nfs_server_addr/glance_nfs_server_path must be defined'
+
+- name: Generate the glance CR config spec based on the selected backend
+  ansible.builtin.template:
+    src: glance_nfs.yaml.j2
+    dest: /tmp/glance_nfs.yaml
+    mode: "0600"
+
+- name: Deploy GlanceAPI with NFS backend
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/glance_nfs.yaml

--- a/tests/roles/glance_adoption/tasks/main.yaml
+++ b/tests/roles/glance_adoption/tasks/main.yaml
@@ -12,30 +12,14 @@
 
 - name: deploy podified Glance with local backend
   when: glance_backend == 'nfs'
-  block:
-    - name: Fail if no nfs_server_addr/nfs_server_path are definied
-      when:
-        - nfs_server_addr is not defined
-        - nfs_server_path is not defined
-      ansible.builtin.fail:
-        msg:
-          - 'nfs_server_addr/nfs_server_path must be defined'
-    - name: Generate the glance CR config spec based on the selected backend
-      ansible.builtin.template:
-        src: glance_nfs.yaml.j2
-        dest: /tmp/glance_nfs.yaml
-        mode: "0600"
-    - name: Deploy GlanceAPI with NFS backend
-      ansible.builtin.shell: |
-        {{ shell_header }}
-        {{ oc_header }}
-        oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/glance_nfs.yaml
+  ansible.builtin.include_tasks: glance_nfs.yaml
 
 - name: template out the glance backend
   ansible.builtin.template:
     src: "{{ role_path }}/templates/glance_ceph.yaml.j2"
     dest: "{{ role_path }}/files/glance_ceph.yaml"
     mode: '644'
+  when: glance_backend == 'ceph'
 
 - name: deploy podified Glance with Ceph backend
   ansible.builtin.shell: |
@@ -49,6 +33,7 @@
     src: "{{ role_path }}/templates/glance_swift.yaml.j2"
     dest: "{{ role_path }}/files/glance_swift.yaml"
     mode: '644'
+  when: glance_backend == 'swift'
 
 - name: deploy podified Glance with Swift backend
   ansible.builtin.shell: |
@@ -62,6 +47,7 @@
     src: "{{ role_path }}/templates/glance_cinder.yaml.j2"
     dest: "{{ role_path }}/files/glance_cinder.yaml"
     mode: '644'
+  when: glance_backend == 'cinder'
 
 - name: deploy podified Glance with Cinder backend
   ansible.builtin.shell: |

--- a/tests/roles/glance_adoption/templates/glance_nfs.yaml.j2
+++ b/tests/roles/glance_adoption/templates/glance_nfs.yaml.j2
@@ -11,7 +11,7 @@ spec:
       databaseInstance: openstack
       glanceAPIs:
         default:
-          replicas: 1
+          replicas: 3
           type: single
       extraMounts:
       - extraVol:
@@ -22,7 +22,7 @@ spec:
           volumes:
           - name: nfs
             nfs:
-              path: "{{ nfs_server_path }}"
-              server: "{{ nfs_server_address }}"
+              path: "{{ glance_nfs_server_path }}"
+              server: "{{ glance_nfs_server_addr }}"
         name: r1
         region: r1


### PR DESCRIPTION
This patch updates the test suite to clean up the glance code a bit and make sure it is easy to understand the scenarios where Glance is adopted.
This patch moves the `glance_nfs` tasks in a dedicated file, it updates the variable names and prefix them with `glance_`, which is important considering that we have other services using the same approach.