### PR TITLE
Reduce ansible verbosity on dataplane

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -204,7 +204,7 @@ dataplane_cr: |
       - name: ANSIBLE_SSH_ARGS
         value: "-C -o ControlMaster=auto -o ControlPersist=80s"
       - name: ANSIBLE_VERBOSITY
-        value: "{{ dataplane_verbosity | default ('3') }}"
+        value: "{{ dataplane_verbosity | default ('1') }}"
     nodeTemplate:
       ansibleSSHPrivateKeySecret: {{ ansible_ssh_private_key_secret }}
       ansible:


### PR DESCRIPTION
verbosity 3 is very high value, whic creates a pressure on disk system. As a result we have sporadic failures or timeouts. This patch reduces verbosity to normal which can be overriden on job level when it's needed.