### PR TITLE
Add override-checkout 18.0-fr3 to github-check jobs

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -4,6 +4,9 @@
     github-check:
       jobs:
         - noop
-        - adoption-standalone-to-crc-ceph
-        - adoption-standalone-to-crc-no-ceph
+        - adoption-standalone-to-crc-ceph: &required_projects
+            required-projects:
+              - name: openstack-k8s-operators/data-plane-adoption
+                override-checkout: 18.0-fr3
+        - adoption-standalone-to-crc-no-ceph: *required_projects
         - adoption-docs-preview


### PR DESCRIPTION
This is required to test content of a change against FR3
branch. This was discovered for the FR2 branch and a similar
fix was implemented in [1].

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/894