### PR TITLE
cinder, manila: various fixes (undef vars, file perms, extra net)

### DIFF
--- a/tests/roles/cinder_adoption/files/cinder_volume_netapp_nfs.yaml
+++ b/tests/roles/cinder_adoption/files/cinder_volume_netapp_nfs.yaml
@@ -5,7 +5,6 @@ spec:
         ontap-nfs:
           networkAttachments:
             - storage
-            - storageMgmt
           customServiceConfig: |
             [ontap-nfs]
             volume_backend_name=ontap-nfs

--- a/tests/roles/cinder_adoption/tasks/cinder_volume_netapp_nfs.yaml
+++ b/tests/roles/cinder_adoption/tasks/cinder_volume_netapp_nfs.yaml
@@ -4,7 +4,6 @@
       become: true
       ansible.builtin.shell: |
         {{ shell_header }}
-        {{ controller_ssh }}
         CONTROLLER1_SCP="{{ controller1_ssh  | regex_replace('^ssh', 'scp')}}"
         ${CONTROLLER1_SCP}:{{ cinder_tripleo_path }} {{ cinder_conf_path }}
         ${CONTROLLER1_SCP}:{{ cinder_tripleo_nfs_shares_config_path }} {{ cinder_nfs_shares_conf_path }}

--- a/tests/roles/cinder_adoption/tasks/cinder_volume_netapp_nfs.yaml
+++ b/tests/roles/cinder_adoption/tasks/cinder_volume_netapp_nfs.yaml
@@ -7,6 +7,7 @@
         CONTROLLER1_SCP="{{ controller1_ssh  | regex_replace('^ssh', 'scp')}}"
         ${CONTROLLER1_SCP}:{{ cinder_tripleo_path }} {{ cinder_conf_path }}
         ${CONTROLLER1_SCP}:{{ cinder_tripleo_nfs_shares_config_path }} {{ cinder_nfs_shares_conf_path }}
+        chmod a+r {{ cinder_conf_path }} {{ cinder_nfs_shares_conf_path }}
 
     - name: Extract Netapp data from cinder.conf
       ansible.builtin.set_fact:

--- a/tests/roles/manila_adoption/tasks/netapp.yaml
+++ b/tests/roles/manila_adoption/tasks/netapp.yaml
@@ -6,6 +6,7 @@
         {{ shell_header }}
         CONTROLLER1_SCP="{{ controller1_ssh  | regex_replace('^ssh', 'scp')}}"
         ${CONTROLLER1_SCP}:{{ manila_tripleo_path }} {{ manila_conf_path }}
+        chmod a+r {{ manila_conf_path }}
 
     - name: Extract Netapp data from manila.conf
       ansible.builtin.set_fact:

--- a/tests/roles/manila_adoption/tasks/netapp.yaml
+++ b/tests/roles/manila_adoption/tasks/netapp.yaml
@@ -4,7 +4,6 @@
       become: true
       ansible.builtin.shell: |
         {{ shell_header }}
-        {{ controller_ssh }}
         CONTROLLER1_SCP="{{ controller1_ssh  | regex_replace('^ssh', 'scp')}}"
         ${CONTROLLER1_SCP}:{{ manila_tripleo_path }} {{ manila_conf_path }}
 


### PR DESCRIPTION
cinder: fix the reference to access a controller
controller_ssh by itself is undefined. But it is not used either, so just remove it.

manila: fix the reference to access a controller
controller_ssh by itself is undefined for the netapp codepath (it is defined when using the cephfs backend).
But it is not used either in the netapp codepath, so just remove it.

manila, cinder: fix permissions when fetching conf files
When fetching the configuration files of cinder and manila through scp, make sure the files are given wider permissions so that the subsequent tasks don't need to be run with become: yes.

cinder: remove an unneeded storageMgmt network attachment
Only storage is needed.