### PR TITLE
test_minimal: call manila_adoption if a backend is set

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -71,6 +71,10 @@
       tags:
         - autoscaling_adoption
       when: telemetry_adoption|default(true)
+    - role: manila_adoption
+      tags:
+        - manila_adoption
+      when: manila_backend|default('')
     - role: stop_remaining_services
       tags:
         - stop_remaining_services


### PR DESCRIPTION
It is already included by test_with_ceph and test_rollback_with_ceph (where the backend is explicitly set), so ensure it is called only when manila is requested, following the pattern established for other services.