### PR TITLE
Fix Glance NFS adoption doc

### DIFF
--- a/docs_user/modules/proc_adopting-image-service-with-nfs-backend.adoc
+++ b/docs_user/modules/proc_adopting-image-service-with-nfs-backend.adoc
@@ -92,8 +92,9 @@ spec:
         filesystem_store_datadir = /var/lib/glance/images/
       storage:
         storageRequest: 10G
+      keystoneEndpoint: nfs
       glanceAPIs:
-        default:
+        nfs:
           replicas: 3
           type: single
           override:
@@ -121,6 +122,12 @@ EOF
 $ oc patch openstackcontrolplane openstack --type=merge --patch-file glance_nfs_patch.yaml
 ----
 
+. Patch the `OpenStackControlPlane` CR to remove the default {image_service}:
++
+----
+$ oc patch openstackcontrolplane openstack --type=json -p="[{'op': 'remove', 'path': '/spec/glance/template/glanceAPIs/default'}]"
+----
+
 .Verification
 
 * When `GlanceAPI` is active, confirm that you can see a single API instance:
@@ -128,7 +135,9 @@ $ oc patch openstackcontrolplane openstack --type=merge --patch-file glance_nfs_
 ----
 $ oc get pods -l service=glance
 NAME                      READY   STATUS    RESTARTS
-glance-default-single-0   3/3     Running   0
+glance-nfs-single-0   2/2     Running   0
+glance-nfs-single-1   2/2     Running   0
+glance-nfs-single-2   2/2     Running   0
 ----
 
 * Ensure that the description of the pod reports the following output:


### PR DESCRIPTION
This patch introduces a small fix in the `Image Service` adoption documentation that is reflected in [1]. Even when `Glance` is disabled, because the `ctlplane` creates a `Glance` object that by default is `type: split`, we can't patch a default `API` anymore. For this reason, the documentation (and the automation) is updated to create a new `nfs` `glanceAPI` and register it and keystone as the default endpoint. An additional step is required to decommission the old one, which would be useless in this case.

Jira: https://issues.redhat.com/browse/OSPRH-15612

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/pull/996