### PR TITLE
Optimize manila adoption code

### DIFF
--- a/tests/playbooks/test_minimal.yaml
+++ b/tests/playbooks/test_minimal.yaml
@@ -48,6 +48,9 @@
     - role: glance_adoption
       tags:
         - glance_adoption
+    - role: manila_adoption
+      tags:
+        - manila_adoption
     - role: placement_adoption
       tags:
         - placement_adoption

--- a/tests/roles/manila_adoption/defaults/main.yaml
+++ b/tests/roles/manila_adoption/defaults/main.yaml
@@ -1,5 +1,5 @@
 # manila_backend can be 'cephfs', 'cephnfs', 'netapp'
-manila_backend: cephfs
+manila_backend: ''
 os_net_conf_path: "/etc/os-net-config/config.yaml"
 manila_storagenfs_nic: "nic2"
 manila_storagenfs_vlan_id: "70"
@@ -20,3 +20,8 @@ manila_netapp_vars:
   - netapp_password
   - netapp_server_hostname
   - netapp_vserver
+# supported backends in the manila adoption test suite
+supported_backends:
+  - cephfs
+  - cephnfs
+  - netapp

--- a/tests/roles/manila_adoption/tasks/ceph.yaml
+++ b/tests/roles/manila_adoption/tasks/ceph.yaml
@@ -1,0 +1,30 @@
+- name: Check the required input when manila_backend is NFS
+  when: manila_backend == "cephnfs"
+  block:
+    - name: Get ceph-nfs IP Address
+      become: true
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        ${CONTROLLER1_SSH} awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' {{ ganesha_default_path }}
+      register: cephnfs_vip
+
+    - name: Fail if the OLD Ganesha VIP is not a good input value
+      when:
+        - not (cephnfs_vip.stdout | ansible.builtin.ipaddr)
+      ansible.builtin.fail:
+        msg: "The (TRIPLEO) gathered Ganesha server IP is malformed"
+
+- name: Deploy Podified Manila - Ceph
+  when: manila_backend == "cephfs" or manila_backend == "cephnfs"
+  block:
+    - name: Generate CR config based on the selected backend
+      ansible.builtin.template:
+        src: manila_cephfs.yaml.j2
+        dest: /tmp/manila_cephfs.yaml
+        mode: "0600"
+
+    - name: Deploy podified Manila with cephfs backend
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/manila_cephfs.yaml

--- a/tests/roles/manila_adoption/tasks/main.yaml
+++ b/tests/roles/manila_adoption/tasks/main.yaml
@@ -1,75 +1,46 @@
-- name: Check the required input when manila_backend is NFS
-  when: manila_backend == "cephnfs"
-  block:
-    - name: Set shell vars to connect to controller1
-      no_log: "{{ use_no_log }}"
-      ansible.builtin.set_fact:
-        controller_ssh: |
-          CONTROLLER1_SSH="{{ controller1_ssh }}"
-
-    - name: Get ceph-nfs IP Address
-      become: true
-      ansible.builtin.shell: |
-        {{ shell_header }}
-        {{ controller_ssh }}
-        ${CONTROLLER1_SSH} awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' {{ ganesha_default_path }}
-      register: cephnfs_vip
-
-    - name: Fail if the OLD Ganesha VIP is not a good input value
-      when:
-        - not (cephnfs_vip.stdout | ansible.builtin.ipaddr)
-      ansible.builtin.fail:
-        msg: "The (TRIPLEO) gathered Ganesha server IP is malformed"
-
 - name: Deploy Podified Manila - Ceph
   when: manila_backend == "cephfs" or manila_backend == "cephnfs"
-  block:
-    - name: Generate CR config based on the selected backend
-      ansible.builtin.template:
-        src: manila_cephfs.yaml.j2
-        dest: /tmp/manila_cephfs.yaml
-        mode: "0600"
-
-    - name: Deploy podified Manila with cephfs backend
-      ansible.builtin.shell: |
-        {{ shell_header }}
-        {{ oc_header }}
-        oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/manila_cephfs.yaml
+  ansible.builtin.include_tasks: ceph.yaml
 
 - name: Deploy Podified Manila - Netapp
   when: manila_backend == "netapp"
   ansible.builtin.include_tasks: netapp.yaml
 
-- name: Wait for Manila to start up
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    oc wait pod --for condition=Ready --selector=component=manila-api
-    oc wait pod --for condition=Ready --selector=component=manila-scheduler
-    oc wait pod --for condition=Ready --selector=component=manila-share
-  register: manila_running_result
-  until: manila_running_result is success
-  retries: 60
-  delay: 2
+- name: Check Manila deployment
+  when:
+    - manila_backend is defined
+    - manila_backend | length > 0
+  block:
+    - name: Wait for Manila to start up
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc wait pod --for condition=Ready --selector=component=manila-api
+        oc wait pod --for condition=Ready --selector=component=manila-scheduler
+        oc wait pod --for condition=Ready --selector=component=manila-share
+      register: manila_running_result
+      until: manila_running_result is success
+      retries: 60
+      delay: 2
 
-- name: Check that Manila is reachable and its endpoints are defined
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
+    - name: Check that Manila is reachable and its endpoints are defined
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        alias openstack="oc exec -t openstackclient -- openstack"
 
-    ${BASH_ALIASES[openstack]} endpoint list | grep -i share
-    ${BASH_ALIASES[openstack]} share pool list
-  register: manila_responding_result
-  until: manila_responding_result is success
-  retries: 15
+        ${BASH_ALIASES[openstack]} endpoint list | grep -i share
+        ${BASH_ALIASES[openstack]} share pool list
+      register: manila_responding_result
+      until: manila_responding_result is success
+      retries: 15
 
-- name: Create default share type
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
-    ${BASH_ALIASES[openstack]} share type create {{ share_type_name }} {{ driver_handles_share_servers }}
-  vars:
-    share_type_name: default
-    driver_handles_share_servers: false
+    - name: Create default share type
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        alias openstack="oc exec -t openstackclient -- openstack"
+        ${BASH_ALIASES[openstack]} share type create {{ share_type_name }} {{ driver_handles_share_servers }}
+      vars:
+        share_type_name: default
+        driver_handles_share_servers: false

--- a/tests/roles/manila_adoption/tasks/netapp.yaml
+++ b/tests/roles/manila_adoption/tasks/netapp.yaml
@@ -1,4 +1,4 @@
-- name: Deploy Podified Manila - Netapp
+- name: Get manila.conf from controller nodes
   block:
     - name: Slurp manila.conf from controller
       become: true
@@ -8,11 +8,26 @@
         CONTROLLER1_SCP="{{ controller1_ssh  | regex_replace('^ssh', 'scp')}}"
         ${CONTROLLER1_SCP}:{{ manila_tripleo_path }} {{ manila_conf_path }}
 
-    - name: Extract Netapp data from manila.conf
-      ansible.builtin.set_fact:
-        manila_netapp_config: "{{ manila_netapp_config | default({}) | combine({item: lookup('ansible.builtin.ini', item, file=manila_conf_path, section=manila_netapp_backend, allow_no_value=True)}) }}"
-      loop: "{{ manila_netapp_vars }}"
+    - name: Stat the retrieved manila.conf file
+      ansible.builtin.stat:
+        path: "{{ manila_conf_path }}"
+      register: manila_conf
 
+    - name: Fail if manila.conf is not present
+      when: not manila_conf.stat.exists
+      ansible.builtin.fail:
+        msg: "manila.conf does not exist"
+
+- name: Deploy Podified Manila - Netapp
+  vars:
+    manila_netapp_config: |
+      {% set manila_netapp_conf = {} %}
+      {% for item in manila_netapp_vars %}
+      {% set value = lookup('ansible.builtin.ini', item, file=manila_conf_path, section=manila_netapp_backend, allow_no_value=True) %}
+      {% set _ = manila_netapp_conf.__setitem__(item, value) %}
+      {% endfor %}
+      {{ manila_netapp_conf }}
+  block:
     - name: Fail if manila_netapp_config params are not defined
       when: |
         manila_netapp_config.netapp_login is not defined or


### PR DESCRIPTION
This patch introduces several improvements to the manila adoption flow:

1. always execute manila_adoption: test_minimal now runs manila_adoption, and if a valid 'manila_backend' is not specified, it results in a noop. This is useful to cover netapp and any other third party backend as part of this flow

2. remove "cephfs" as default backend: having cephfs as a default backend, let test_minimal fail when manila_adoption is executed. This happens because it tries to run manila-share with a ceph backend config, but in this case is invalid

3. Do not set_fact when netapp variables are extracted: extract netapp variables and pass them to the underlying block; check, in addition, that scp worked properly by running stat on the resulting manila.conf


(cherry picked from commit 5a8e78c9aa136ce803014152d3bc782b8b9fea12)