### PR TITLE
Enable glance in NFS scenario

### DIFF
--- a/tests/roles/glance_adoption/tasks/glance_nfs.yaml
+++ b/tests/roles/glance_adoption/tasks/glance_nfs.yaml
@@ -17,3 +17,16 @@
     {{ shell_header }}
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch-file=/tmp/glance_nfs.yaml
+
+# NOTE (fpantano):
+# Glance provides by default a type: split API that we do not use for this scenario.
+# type: split applies to all the existing use cases except NFS where there's no
+# need to split the API between internal and external. Because it is not possible
+# to modify an existing Glance object with type:split (webhooks prevent this operation)
+# we delete this unused API.
+# https://github.com/openstack-k8s-operators/glance-operator/blob/main/docs/design-decisions.md#decommissioning-a-glanceapi
+- name: Decommission the default API
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=json -p="[{'op': 'remove', 'path': '/spec/glance/template/glanceAPIs/default'}]"

--- a/tests/roles/glance_adoption/templates/glance_nfs.yaml.j2
+++ b/tests/roles/glance_adoption/templates/glance_nfs.yaml.j2
@@ -1,18 +1,32 @@
 spec:
   glance:
+    enabled: true
     template:
-      customServiceConfig: |
-        [DEFAULT]
-        enabled_backends = default_backend:file
-        [glance_store]
-        default_backend = default_backend
-        [default_backend]
-        filesystem_store_datadir = /var/lib/glance/images/
       databaseInstance: openstack
+      keystoneEndpoint: nfs
       glanceAPIs:
-        default:
+        nfs:
           replicas: 3
           type: single
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_backends = default_backend:file
+            [glance_store]
+            default_backend = default_backend
+            [default_backend]
+            filesystem_store_datadir = /var/lib/glance/images/
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
+                spec:
+                  type: LoadBalancer
+          networkAttachments:
+            - storage
       extraMounts:
       - extraVol:
         - extraVolType: NFS


### PR DESCRIPTION
This patch updates the glance template due to the missing "enabled: true". In addition, it adds the same overrides we have in all the other scenarios.
Because the ctlplane creates an API with type: split, we register a new NFS GlanceAPI based on [1] and we decommission the default one (not used in this scenario).

[1] https://github.com/openstack-k8s-operators/glance-operator/blob/main/docs/design-decisions.md#decommissioning-a-glanceapi


(cherry picked from commit dbce957d8807496c88531687796ed8fe7b02a076)