### PR TITLE
ovn_adoption: don't hardcode quay.io as ovn_base image source

### DIFF
--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -1,4 +1,7 @@
-ovn_image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
+container_registry: "quay.io"
+container_namespace: "podified-antelope-centos9"
+container_tag: "current-podified"
+ovn_image: "{{ container_registry }}/{{ container_namespace }}/openstack-ovn-base:{{ container_tag }}"
 storage_class_name: local-storage
 storage_reclaim_policy: delete
 ironic_adoption: false


### PR DESCRIPTION
Other test roles use/depend on variables like container_registry, container_namespace and container_tag to allow users to override the source of the containers.
So make use of them here too for consistency.
The default behavior is unchanged.