### PR TITLE
Fix ansible 2.19 jinja incompatibilities

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -455,7 +455,7 @@ endif::[]
            ---
            {% set mtu_list = [ctlplane_mtu] %}
            {% for network in nodeset_networks %}
-           {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+           {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
            {%- endfor %}
            {% set min_viable_mtu = mtu_list | max %}
            network_config:

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -163,7 +163,7 @@ endif::[]
            ---
            {% set mtu_list = [ctlplane_mtu] %}
            {% for network in nodeset_networks %}
-           {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+           {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
            {%- endfor %}
            {% set min_viable_mtu = mtu_list | max %}
            network_config:

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -121,7 +121,7 @@ edpm_network_config_template: |
   ---
   {% set mtu_list = [ctlplane_mtu] %}
   {% for network in nodeset_networks %}
-  {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+  {%set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
   {%- endfor %}
   {% set min_viable_mtu = mtu_list | max %}
   network_config:

--- a/tests/roles/dataplane_adoption/vars/ospdo.yaml
+++ b/tests/roles/dataplane_adoption/vars/ospdo.yaml
@@ -45,7 +45,7 @@ edpm_network_config_template: |
  ---
            {% set mtu_list = [ctlplane_mtu] %}
            {% for network in nodeset_networks %}
-           {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+           {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
            {%- endfor %}
            {% set min_viable_mtu = mtu_list | max %}
            network_config:

--- a/tests/roles/dataplane_adoption/vars/rhev.yaml
+++ b/tests/roles/dataplane_adoption/vars/rhev.yaml
@@ -85,7 +85,7 @@ edpm_network_config_template: |
   ---
   {% set mtu_list = [ctlplane_mtu] %}
   {% for network in nodeset_networks %}
-  {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+  {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
   {%- endfor %}
   {% set min_viable_mtu = mtu_list | max %}
   network_config:


### PR DESCRIPTION
{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }} will print return value None and it will break the nic config.

jira: [OSPRH-18609](https://issues.redhat.com//browse/OSPRH-18609)