### PR TITLE
glance: fix the syntax of the glance-over-cinder template

### DIFF
--- a/tests/roles/glance_adoption/templates/glance_cinder.yaml.j2
+++ b/tests/roles/glance_adoption/templates/glance_cinder.yaml.j2
@@ -34,7 +34,7 @@ spec:
                     metallb.universe.tf/allow-shared-ip: internalapi
 {% endraw %}
                     metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
-              spec:
-                type: LoadBalancer
+                spec:
+                  type: LoadBalancer
           networkAttachments:
             - storage


### PR DESCRIPTION
The internal spec was incorrectly indented.
