### PR TITLE
support ext ceph in ceph_backend_configuration

### DIFF
--- a/tests/roles/ceph_backend_configuration/tasks/main.yaml
+++ b/tests/roles/ceph_backend_configuration/tasks/main.yaml
@@ -2,7 +2,9 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.set_fact:
     ceph_backend_configuration_shell_vars: |
-      CEPH_SSH="{{ controller1_ssh }}"
+      # if tripleo uses external ceph, ssh to ceph nodes otherwise controller nodes
+      # for external ceph, external_ceph and ceph1_ssh vars should be defined
+      CEPH_SSH="{{ external_ceph | default(false) | ternary(ceph1_ssh, controller1_ssh) }}"
       CEPH_KEY=$($CEPH_SSH "cat /etc/ceph/ceph.client.openstack.keyring | base64 -w 0")
       CEPH_CONF=$($CEPH_SSH "cat /etc/ceph/ceph.conf | base64 -w 0")
 
@@ -11,7 +13,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    CEPH_SSH="{{ controller1_ssh }}"
+    CEPH_SSH="{{ external_ceph | default(false) | ternary(ceph1_ssh, controller1_ssh) }}"
     CEPH_CAPS="mgr 'allow *' mon 'allow r, profile rbd' osd 'profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=images, profile rbd pool=backups, allow rw pool manila_data'"
     OSP_KEYRING="client.openstack"
     CEPH_ADM=$($CEPH_SSH "cephadm shell -- ceph auth caps $OSP_KEYRING $CEPH_CAPS")


### PR DESCRIPTION
with external ceph, ceph_backend_configuration should fetch ceph details from ceph nodes instead of controller nodes, this patch implements it.

Jira: https://issues.redhat.com/browse/OSPRH-5712