### PR TITLE
Remove pcs colocation constraints from manila-share when cephnfs

### DIFF
--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -6,6 +6,24 @@
       CONTROLLER2_SSH="{{ controller2_ssh }}"
       CONTROLLER3_SSH="{{ controller3_ssh }}"
 
+- name: Remove colocation constraints between manila-share and ceph-nfs
+  when: manila_backend == "cephnfs"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ stop_openstack_services_shell_vars }}
+
+    echo "Removing Pacemaker constraints between manila-share and ceph-nfs"
+    for i in {1..3}; do
+        SSH_CMD=CONTROLLER${i}_SSH
+        if [ ! -z "${!SSH_CMD}" ]; then
+            echo "Using controller $i to run pacemaker commands"
+            ${!SSH_CMD} sudo pcs constraint remove colocation-openstack-manila-share-ceph-nfs-INFINITY
+            ${!SSH_CMD} sudo pcs constraint remove order-ceph-nfs-openstack-manila-share-Optional
+            break
+        fi
+    done
+
 - name: stop control plane services
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
This patch adds the missing tasks related to manila adoption in case cephnfs is the backend. In this context a pcs constraints exists between the VIP, the ceph-nfs systemd unit and manila-share. During the adoption process we shut down manila-share (which is adopted as part of the procedure), but we do not take any action to the existing A/P Ganesha instance, which still needs to stay up.
This patch adds the missing steps documented in [1].

[1] https://github.com/openstack-k8s-operators/data-plane-adoption/blob/main/docs_user/modules/proc_stopping-openstack-services.adoc