### PR TITLE
Reintroduce TLS-e instructions for Standalone deployment

### DIFF
--- a/docs_dev/assemblies/development_environment.adoc
+++ b/docs_dev/assemblies/development_environment.adoc
@@ -153,6 +153,19 @@ EDPM_CONFIGURE_HUGEPAGES=false make standalone <1>
 ----
 <1> To configure the host for a simplistic hugepages setup, set `EDPM_CONFIGURE_HUGEPAGES=true`.
 
+=== Enabling TLS everywhere (TLS-e) on Standalone
+
+To deploy the Standalone environment with TLS everywhere enabled, set `TLS_ENABLED=true` and provide a DNS domain to be used for certificates. Optionally disable the Ceph backend for a faster setup.
+
+[,bash]
+----
+cd ~/install_yamls/devsetup
+TLS_ENABLED=true DNS_DOMAIN=ooo.test EDPM_COMPUTE_CEPH_ENABLED=false make standalone
+----
+
+[NOTE]
+Disabling Ceph here mirrors the CI setup and speeds up the deployment.
+
 === Snapshot/revert
 
 When the deployment of the Standalone OpenStack is finished, it's a


### PR DESCRIPTION
Restore instructions on enabling TLS Everywhere (TLS-e) when
deploying the TripleO Standalone dev environment, including
example with LS_ENABLED and DNS_DOMAIN.

Mirrors previous instructions removed in 2abb38eb.

Signed-off-by: Grzegorz Grasza <xek@redhat.com>
