### PR TITLE
fix PASSWORD FILE

### DIFF
--- a/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
+++ b/docs_user/modules/proc_retrieving-topology-specific-service-configuration.adoc
@@ -27,10 +27,10 @@ endif::[]
 $ declare -A TRIPLEO_PASSWORDS
 ifeval::["{build_variant}" != "ospdo"]
 $ CELLS="default cell1 cell2"
+endif::[]
 $ for CELL in $(echo $CELLS); do
 >    TRIPLEO_PASSWORDS[$CELL]="$PASSWORD_FILE"
 > done
-endif::[]
 ifeval::["{build_variant}" == "ospdo"]
 $ CELLS="default"
 $ for CELL in $(echo $CELLS); do


### PR DESCRIPTION
- **copy keys from undercloud for tobiko and add image for new iperf test**
- **Add support for cleanup neutron agents post adopt**
- **Remove redundant namespace flags**
- **Remove label as a selector**
- **Document neutron agent cleanup**
- **Disable NetworkManager DNS config update**
- **Adds workflow to trigger branch sync**
- **[dataplane_adoption] Exclude incompatible ceph-common**
- **Update tobiko advance image**
- **Increase OpenStackControlPlane timeout**
- **Update docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc**
- **Update docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc**
- **Configure swift to use ceph rgw during miration**
- **uni02beta: base 17.1 tripleo deployment files**
- **Fix hardcoded tripleo passwords file**
- **refining multi-cell docs**
- **linting error**
- **Add an additional verification checks for CR deployment**
- **Update docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc**
- **Fix review comments**
- **Change the name of the output variable**
- **Make tobiko options configurable**
- **Removes frenzyfriday from approvers/reviewers**
- **fixed indentation issues**
- **moved step to prerequisites**
- **UniquePodNames enabler**
- **Update glance adoption scenarios**
- **Get cinder pod name**
- **Manila Netapp adoption**
- **Add adoption support for cinder netapp nfs**
- **Reduce ansible verbosity on dataplane**
- **cinder adoption: fix the reference to access a controller**
- **manila adoption: fix the reference to access a controller**
- **manila, cinder: fix permissions when fetching conf files**
- **cinder: remove an unneeded storageMgmt network attachment**
- **removed rootwrap_config**
- **overview and limitations updates**
- **Update docs_user/assemblies/assembly_rhoso-180-adoption-overview.adoc**
- **Update docs_user/assemblies/assembly_rhoso-180-adoption-overview.adoc**
- **remove unsupported feature**
- **Refactor pcp_cleanup role for better readility**
- **Enable glance in NFS scenario**
- **Fix Glance NFS adoption doc**
- **Optimize manila adoption code**
- **Fix grammar issues**
- **LDAP adoption documentation**
- **fixed linting error**
- **moved note below step 6**
- **Per backend glance adoption refactor**
- **Improve pcp_cleanup role**
- **doc: fix a typo in the block storage section**
- **ovn_adoption: don't hardcode quay.io as ovn_base image source**
- **improve ceph migration doc for rgw**
- **doc, cinder adoption: notes on the configuration group name**
- **cinder adoption, netapp: use the source configuration group name**
- **Fix ansible 2.19 jinja incompatibilities**
- **added link to mapping RHOSO versions KCS**
- **glance: fix the syntax of the glance-over-cinder template**
- **uni07eta: base 17.1 tripleo deployment files**
- **Bump ansible-lint to v25.8.1 (last release)**
- **ceph_migrate: rewrite a variable to avoid linting issues**
- **cinder adoption: generalize the netapp code (also iSCSI)**
- **cinder_adoption, netapp/iSCSI: track also netapp_pool_name_search_pattern**
- **doc: add section numbers**
- **support ext ceph in ceph_backend_configuration**
- **added vale file for fixing warnings**
- **added abstract role to all modules**
- **linting error and indentation issues**
- **Add unideltaipv6 scenario 17.1 for adoption**
- **copied cqa edits from downstream**
- **Fix shell quoting and unbound variable in Manila ceph-nfs IP task**
- **Remove pcs colocation constraints from manila-share when cephnfs**
- **Support IPv6 addresses in Ceph RGW object storage configuration**
- **TLS-e migration fixes**
- **Fixes a missing file name to store variables in**
