### PR TITLE
Let more time for services to come up

### DIFF
--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -29,8 +29,8 @@
     oc wait pod --for condition=Ready --selector=service=keystone
   register: keystone_running_result
   until: keystone_running_result is success
-  retries: 60
-  delay: 2
+  retries: 10
+  delay: 30
 
 - name: wait for openstackclient pod to start up
   ansible.builtin.shell: |
@@ -39,8 +39,8 @@
     oc wait pod --for condition=Ready --selector=service=openstackclient
   register: osc_running_result
   until: osc_running_result is success
-  retries: 60
-  delay: 2
+  retries: 10
+  delay: 30
 
 - name: check that Keystone is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -52,8 +52,8 @@
     ${BASH_ALIASES[openstack]} endpoint list | grep keystone
   register: keystone_responding_result
   until: keystone_responding_result is success
-  retries: 60
-  delay: 2
+  retries: 10
+  delay: 30
 
 - name: verify that OpenStackControlPlane setup is complete
   ansible.builtin.shell: |


### PR DESCRIPTION
Also make the checking frequency lower to save resources.
Some job runs are failing because of services are not started in the given time. The delay between checks is also made longer to lower the cluster stress. 