### PR TITLE
Add default manila_backend value when evaluating pcs constraints

### DIFF
--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -7,7 +7,7 @@
       CONTROLLER3_SSH="{{ controller3_ssh }}"
 
 - name: Remove colocation constraints between manila-share and ceph-nfs
-  when: manila_backend == "cephnfs"
+  when: manila_backend | default("")  == "cephnfs"
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}


### PR DESCRIPTION
Jobs **without ceph** might not have knowledge about `manila_backend` variable if not explicitly passed. Because the same task is executed in several scenarios, we need to make sure that `manila_backend` does not point to an undefined variable.

Jira: https://issues.redhat.com/browse/OSPCIX-1034