### PR TITLE
Call the external ceph deploy hooks for unideltaipv6

### DIFF
--- a/scenarios/uni04delta-ipv6.yaml
+++ b/scenarios/uni04delta-ipv6.yaml
@@ -68,3 +68,16 @@ stacks:
     stack_nodes:
       - osp-computes
       - osp-controllers
+    pre_oc_run:
+      - name: Prepare Ceph nodes
+        type: playbook
+        source: "setup_cephnodes_ipv6.yaml"
+        inventory: "uni04delta-ipv6/ceph_inventory.yaml"
+        extra_vars:
+          file: "uni04delta-ipv6/repo_setup_and_CA_vars.yaml"
+      - name: Deploy external ceph
+        type: playbook
+        source: "ceph.yml"
+        inventory: "uni04delta-ipv6/ceph_inventory.yaml"
+        extra_vars:
+          file: "uni04delta-ipv6/ceph_overrides.yaml"

--- a/scenarios/uni04delta-ipv6/ceph_inventory.yaml
+++ b/scenarios/uni04delta-ipv6/ceph_inventory.yaml
@@ -1,0 +1,29 @@
+ceph:
+  hosts:
+    ceph-uni04delta-ipv6-0:
+      ansible_user: zuul
+      ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
+      bridge_ip: 2620:cf:cf:aaaa::6a/64
+      external_ip: 2620:cf:cf:cf02::6a/64
+      internalapi_ip: 2620:cf:cf:bbbb::6a/64
+      storage_ip: 2620:cf:cf:cccc::6a/64
+      storagemgmt_ip: 2620:cf:cf:dddd::6a/64
+      tenant_ip: 2620:cf:cf:eeee::6a/64
+    ceph-uni04delta-ipv6-1:
+      ansible_user: zuul
+      ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
+      bridge_ip: 2620:cf:cf:aaaa::6b/64
+      external_ip: 2620:cf:cf:cf02::6b/64
+      internalapi_ip: 2620:cf:cf:bbbb::6b/64
+      storage_ip: 2620:cf:cf:cccc::6b/64
+      storagemgmt_ip: 2620:cf:cf:dddd::6b/64
+      tenant_ip: 2620:cf:cf:eeee::6b/64
+    ceph-uni04delta-ipv6-2:
+      ansible_user: zuul
+      ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
+      bridge_ip: 2620:cf:cf:aaaa::6c/64
+      external_ip: 2620:cf:cf:cf02::6c/64
+      internalapi_ip: 2620:cf:cf:bbbb::6c/64
+      storage_ip: 2620:cf:cf:cccc::6c/64
+      storagemgmt_ip: 2620:cf:cf:dddd::6c/64
+      tenant_ip: 2620:cf:cf:eeee::6c/64

--- a/scenarios/uni04delta-ipv6/ceph_overrides.yaml
+++ b/scenarios/uni04delta-ipv6/ceph_overrides.yaml
@@ -1,0 +1,19 @@
+---
+storage_network_range: "2620:cf:cf:cccc::/64"
+storage_mgmt_network_range: "2620:cf:cf:dddd::/64"
+cifmw_cephadm_default_container: false
+cifmw_cephadm_container_ns: registry-proxy.engineering.redhat.com/rh-osbs
+cifmw_cephadm_container_image: rhceph
+cifmw_cephadm_container_tag: 7
+cifmw_cephadm_ceph_spec_fqdn: false
+cifmw_cephadm_haproxy_container_image: "{{ cifmw_cephadm_container_ns }}/haproxy:latest"
+cifmw_cephadm_keepalived_container_image: "{{ cifmw_cephadm_container_ns }}/keepalived:latest"
+cifmw_cephadm_prometheus_container_ns: registry-proxy.engineering.redhat.com/prometheus
+cifmw_cephadm_alertmanager_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/alertmanager:latest"
+cifmw_cephadm_grafana_container_image: "{{ cifmw_cephadm_container_ns }}/grafana:latest"
+cifmw_cephadm_node_exporter_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/node-exporter:latest"
+cifmw_cephadm_prometheus_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/prometheus:latest"
+cifmw_ceph_target: "ceph"
+ansible_user_dir: "/home/zuul"
+cifmw_ceph_ipv6: true
+adoption_deploy_ceph_for_tripleo: true

--- a/scenarios/uni04delta-ipv6/repo_setup_and_CA_vars.yaml
+++ b/scenarios/uni04delta-ipv6/repo_setup_and_CA_vars.yaml
@@ -1,0 +1,14 @@
+# repo setup vars
+_oso_release: "{{ cifmw_oso_release | default('osp18') }}"
+_ceph_version: "{{ cifmw_ceph_release | default('ceph-7.1-rhel-9') }}"
+_rhel_version: "{{ cifmw_rhel_version | default('9.4') }}"
+_rhoso_version: "{{ cifmw_rhoso_release | default('') }}"
+_default_rhos_release_args: "{{ _ceph_version }} {{ _rhoso_version }} -r {{ _rhel_version }}"
+
+cifmw_repo_setup_rhos_release_path: "/home/zuul/rhos-release"
+cifmw_repo_setup_rhos_release_rpm: "http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm"
+cifmw_repo_setup_rhos_release_args: "{{ _default_rhos_release_args }}"
+cifmw_repo_setup_output: "/etc/yum.repos.d"
+
+# install_ca vars   
+cifmw_install_ca_url: "https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem"


### PR DESCRIPTION
Before overcloud deployment, call the cifmw hooks to configure ceph nodes and deploy ceph.