### PR TITLE
Workaround lack of external_vlan_id

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -40,6 +40,7 @@ netconfig_networks:
             start: 10.0.0.100
         cidr: 10.0.0.0/24
         gateway: 10.0.0.1
+        vlan: 44
   - name: storage
     dnsDomain: storage.example.com
     subnets:


### PR DESCRIPTION
Add `vlan: 44` to tests/roles/dataplane_adoption/defaults/main.yaml

Without this change, `playbooks/test_with_ceph.yaml` fails for me at:
```
TASK [dataplane_adoption : wait for dataplane node set to be ready]
```
On investigation I see EDPM jobs failed for:

  configure-network-openstack-openstack-cell1-*
  configure-network-openstack-openstack-networker-*

and `oc logs` of either of the above job pods returns

```
fatal: [osp-compute-ek9z8slv-0]: FAILED! =>
{"changed": false,
 "msg": "Task failed: No variable named 'external_vlan_id' was found."}
```