### PR TITLE
Set a default for use_hugepages

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -283,7 +283,7 @@ dataplane_cr: |
           edpm_ovs_packages:
           - openvswitch3.3
 
-          {% if use_hugepages|bool +%}
+          {% if use_hugepages|default(false)|bool +%}
           edpm_default_mounts:
             - path: /dev/hugepages2M
               opts: pagesize=2M

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -10,7 +10,7 @@
     cmd: |
       {{ shell_header }}
       export OPENSTACK_COMMAND="{{ openstack_command }}"
-      export EDPM_CONFIGURE_HUGEPAGES={{ use_hugepages | string | lower }}
+      export EDPM_CONFIGURE_HUGEPAGES={{ use_hugepages | default(false) | string | lower }}
       export CINDER_VOLUME_BACKEND_CONFIGURED={{ cinder_volume_backend_configured | string | lower }}
       export CINDER_BACKUP_BACKEND_CONFIGURED={{ cinder_backup_backend_configured | string | lower }}
       export PING_TEST_VM={{ ping_test | string | lower }}


### PR DESCRIPTION
While running `playbooks/test_with_ceph.yaml` Ansible failed with: `'use_hugepages' is undefined`. This patch sets a default value of `false` to handle when that variable is undefined.