### PR TITLE
cinder_adoption: update the comment which lists the backend

### DIFF
--- a/tests/roles/cinder_adoption/defaults/main.yaml
+++ b/tests/roles/cinder_adoption/defaults/main.yaml
@@ -1,5 +1,5 @@
-# Volume backends: ceph or ontap_nfs
-# Backup backends: ceph or swift or ontap_nfs
+# Volume backends: ceph, ontap-nfs, ontap-iscsi
+# Backup backends: ceph, swift, ontap-nfs
 cinder_volume_backend: ""
 cinder_backup_backend: ""
 


### PR DESCRIPTION
This is just a change in a comment, but that lists the backend values that are currently accepted for cinder-volume and cinder-backup. As long as that comment is around, it should be kept up-to-date as it happens with this change.