### PR TITLE
Increase delay time to 5 seconds

### DIFF
--- a/tests/roles/autoscaling_adoption/defaults/main.yaml
+++ b/tests/roles/autoscaling_adoption/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+autoscaling_retry_delay: 5

--- a/tests/roles/autoscaling_adoption/tasks/main.yaml
+++ b/tests/roles/autoscaling_adoption/tasks/main.yaml
@@ -27,7 +27,7 @@
   register: aodh_running_result
   until: aodh_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ autoscaling_retry_delay }}"
 
 - name: check that Aodh is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -39,4 +39,4 @@
   register: aodh_responding_result
   until: aodh_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ autoscaling_retry_delay }}"

--- a/tests/roles/backend_services/defaults/main.yaml
+++ b/tests/roles/backend_services/defaults/main.yaml
@@ -26,3 +26,4 @@ dpa_tests_dir: "{{ dpa_dir }}/tests"
 # director operator namespace
 director_namespace: "ospdo_openstack"
 # adoption repo default location
+backend_retry_delay: 5

--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -120,7 +120,7 @@
   register: mariadb_running_result
   until: mariadb_running_result is success
   retries: 60
-  delay: 5
+  delay: "{{ backend_retry_delay }}"
 # TODO- debug value (was 2)
 
 - name: verify that MariaDB and RabbitMQ CR's deployed, for all defined cells
@@ -131,7 +131,7 @@
   register: service_cr_result
   until: service_cr_result.stdout == "true"
   retries: 60
-  delay: 5
+  delay: "{{ backend_retry_delay }}"
   failed_when: service_cr_result.rc != 0 and service_cr_result.stdout != "true"
   loop:
     - "Galera"
@@ -170,4 +170,4 @@
   register: openstack_control_plane_cr_result
   until: openstack_control_plane_cr_result is success
   retries: 60
-  delay: 2
+  delay: "{{ backend_retry_delay }}"

--- a/tests/roles/barbican_adoption/defaults/main.yaml
+++ b/tests/roles/barbican_adoption/defaults/main.yaml
@@ -38,3 +38,4 @@ barbican_patch: |
           replicas: 1
         barbicanKeystoneListener:
           replicas: 1
+barbican_retry_delay: 5

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -19,7 +19,7 @@
   register: barbican_running_result
   until: barbican_running_result is success
   retries: 180
-  delay: 2
+  delay: "{{ barbican_retry_delay }}"
 
 - name: check that Barbican is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -33,7 +33,7 @@
   register: barbican_responding_result
   until: barbican_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ barbican_retry_delay }}"
 
 - name: check that Barbican secret payload was migrated successfully
   when: prelaunch_barbican_secret|default(false)

--- a/tests/roles/ceph_migrate/defaults/main.yaml
+++ b/tests/roles/ceph_migrate/defaults/main.yaml
@@ -49,3 +49,4 @@ ceph_prometheus_container_image: "quay.io/prometheus/prometheus:v2.43.0"
 ceph_storagenfs_nic: "nic2"
 ceph_storagenfs_vlan_id: "70"
 rhoso_namespace: "openstack"
+ceph_retry_delay: 5

--- a/tests/roles/ceph_migrate/tasks/mon.yaml
+++ b/tests/roles/ceph_migrate/tasks/mon.yaml
@@ -29,7 +29,7 @@
   register: monmap
   until: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) >= ((decomm_nodes |default([]) | length | int) | default(3))
   retries: 100
-  delay: 5
+  delay: "{{ ceph_retry_delay }}"
   tags:
     - ceph_mon_quorum
 
@@ -140,7 +140,7 @@
       until: '"Removed" in rmmon.stdout'
       register: rmmon
       retries: 30
-      delay: 4
+      delay: "{{ ceph_retry_delay }}"
       loop_control:
         label: "MON - Get tmp mon"
       notify: restart mgr
@@ -169,7 +169,7 @@
   register: monmap
   until: (monmap.stdout | from_json | community.general.json_query('monmap.num_mons') | int) >= ((decomm_nodes |default([]) | length | int) | default(3))
   retries: 100
-  delay: 5
+  delay: "{{ ceph_retry_delay }}"
   tags:
     - ceph_mon_quorum
 

--- a/tests/roles/ceph_migrate/tasks/wait_daemons.yaml
+++ b/tests/roles/ceph_migrate/tasks/wait_daemons.yaml
@@ -15,7 +15,7 @@
   ansible.builtin.command: "{{ ceph_cli }} orch ps --daemon_type {{ daemon }} {{ d_id }} -f json"
   register: daemonstat
   retries: 200
-  delay: 5
+  delay: "{{ ceph_retry_delay }}"
   until: "'running' in daemonstat.stdout | from_json | community.general.json_query('[*].status_desc') | default([]) | list"
   loop_control:
     label: "wait for {{ daemon }}"

--- a/tests/roles/cinder_adoption/defaults/main.yaml
+++ b/tests/roles/cinder_adoption/defaults/main.yaml
@@ -129,3 +129,4 @@ cinder_volume_netapp_vars:
 
 # Vars for cinder-backup
 cinder_backup_nfs_backup_mount_point_base: "/var/lib/cinder/backup"
+cinder_retry_delay: 5

--- a/tests/roles/cinder_adoption/tasks/main.yaml
+++ b/tests/roles/cinder_adoption/tasks/main.yaml
@@ -12,7 +12,7 @@
   register: cinder_api_running
   until: cinder_api_running is success
   retries: 60
-  delay: 2
+  delay: "{{ cinder_retry_delay }}"
 
 - name: Get cinder-api pod name
   ansible.builtin.shell: |
@@ -31,7 +31,7 @@
   register: cinder_responding_result
   until: cinder_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ cinder_retry_delay }}"
 
 - name: Get cinder-backup down services
   ansible.builtin.shell: |
@@ -99,7 +99,7 @@
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ cinder_retry_delay }}"
 
 # Give time for volume and backup services to initialize drivers, otherwise they
 # always looks ok (up) because that's the default at the start.
@@ -116,7 +116,7 @@
   register: cinder_scheduler_running_result
   until: cinder_scheduler_running_result is success
   retries: 5
-  delay: 2
+  delay: "{{ cinder_retry_delay }}"
 
 - name: wait for Cinder volume to be up and ready
   when: cinder_volume_backend != ''
@@ -127,7 +127,7 @@
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 5
-  delay: 2
+  delay: "{{ cinder_retry_delay }}"
 
 - name: wait for Cinder backup to be up and ready
   when: cinder_backup_backend != ''
@@ -138,7 +138,7 @@
   register: cinder_running_result
   until: cinder_running_result is success
   retries: 5
-  delay: 2
+  delay: "{{ cinder_retry_delay }}"
 
 - name: Cinder online data migrations
   ansible.builtin.shell: |

--- a/tests/roles/control_plane_rollback/defaults/main.yaml
+++ b/tests/roles/control_plane_rollback/defaults/main.yaml
@@ -3,3 +3,4 @@ source_osp_ssh_user: root
 # override var for openstack verify command to use on the source cloud. For multi-node source cloud standalone_ip is the ip address of the undercloud.
 control_plane_rollback_verify_command: |
   ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no {{ source_osp_ssh_user }}@{{ standalone_ip }} OS_CLOUD={{ os_cloud_name }} openstack user list
+control_plane_retry_delay: 5

--- a/tests/roles/control_plane_rollback/tasks/main.yaml
+++ b/tests/roles/control_plane_rollback/tasks/main.yaml
@@ -155,4 +155,4 @@
   register: source_control_plane_responding_result
   until: source_control_plane_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ control_plane_retry_delay }}"

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -396,3 +396,4 @@ networker_cr: |
           {% if edpm_container_registry_insecure_registries is defined -%}
           edpm_container_registry_insecure_registries: {{ edpm_container_registry_insecure_registries }}
           {% endif -%}
+dataplane_retry_delay: 10

--- a/tests/roles/dataplane_adoption/tasks/cinder_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/cinder_verify.yaml
@@ -16,7 +16,7 @@
   register: cinder_verify_volumes
   until: cinder_verify_volumes is success
   retries: 10
-  delay: 2
+  delay: "{{ dataplane_retry_delay }}"
 
 - name: verify the backup of disk volume
   when:
@@ -28,7 +28,7 @@
   register: cinder_verify_resources
   until: cinder_verify_resources is success
   retries: 10
-  delay: 2
+  delay: "{{ dataplane_retry_delay }}"
 
 - name: Detach disk volume
   when:
@@ -47,7 +47,7 @@
       register: detach_volume
       until: detach_volume is success
       retries: 10
-      delay: 10
+      delay: "{{ dataplane_retry_delay }}"
 
 - name: Restore snapshot
   when:
@@ -66,7 +66,7 @@
       register: revert_snapshot
       until: revert_snapshot is success
       retries: 10
-      delay: 10
+      delay: "{{ dataplane_retry_delay }}"
 
 - name: Attach disk volume
   when:
@@ -85,4 +85,4 @@
       register: attach_volume
       until: attach_volume is success
       retries: 10
-      delay: 10
+      delay: "{{ dataplane_retry_delay }}"

--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -16,7 +16,7 @@
   # NOTE(slaweq): retries should not be needed but it seems there is some minor
   # bug in Neutron which causes reporting ovn-metadata-agent as DOWN in every first API request after deploying it on host.
   retries: 2
-  delay: 1
+  delay: "{{ dataplane_retry_delay }}"
 
 - name: get neutron-sriov-nic-agent alive state
   when: compute_adoption|bool

--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -8,7 +8,7 @@
   register: records_check_results
   until: records_check_results.rc == 0 and records_check_results.stdout_lines | length == 0
   retries: 20
-  delay: 6
+  delay: "{{ dataplane_retry_delay }}"
 
 - name: patch the OpenStackControlPlane CR to remove the pre-fast-forward upgrade workarounds
   ansible.builtin.shell: |
@@ -136,7 +136,7 @@
   register: nova_exec_result
   until: nova_exec_result is success
   retries: 10
-  delay: 6
+  delay: "{{ dataplane_retry_delay }}"
 
 - name: discover Compute hosts in the cells
   ansible.builtin.shell: |

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -26,7 +26,7 @@
     - ("FAIL" not in nova_verify_stop_result.stdout_lines)
     - ("it is in power state shutdown" in nova_verify_stop_result.stdout)
   retries: 10
-  delay: 6
+  delay: "{{ dataplane_retry_delay }}"
 
 - name: verify if the Compute services can start the existing test VM instance
   when: prelaunch_test_instance|bool
@@ -38,4 +38,4 @@
   register: nova_verify_start_result
   until: ("FAIL" not in nova_verify_start_result.stdout_lines)
   retries: 60
-  delay: 6
+  delay: "{{ dataplane_retry_delay }}"

--- a/tests/roles/glance_adoption/defaults/main.yaml
+++ b/tests/roles/glance_adoption/defaults/main.yaml
@@ -1,2 +1,3 @@
 # glance_backend can be 'nfs', 'ceph', 'swift', 'cinder'
 glance_backend: swift
+glance_retry_delay: 5

--- a/tests/roles/glance_adoption/tasks/check_glance.yaml
+++ b/tests/roles/glance_adoption/tasks/check_glance.yaml
@@ -8,7 +8,7 @@
       register: glance_running_result
       until: glance_running_result is success
       retries: 60
-      delay: 2
+      delay: "{{ glance_retry_delay }}"
 
     - name: check that Glance is reachable and its endpoints are defined
       ansible.builtin.shell: |
@@ -21,4 +21,4 @@
       register: glance_responding_result
       until: glance_responding_result is success
       retries: 15
-      delay: 2
+      delay: "{{ glance_retry_delay }}"

--- a/tests/roles/heat_adoption/defaults/main.yaml
+++ b/tests/roles/heat_adoption/defaults/main.yaml
@@ -16,3 +16,5 @@ heat_patch: |
           stackDomainAdminPassword: HeatStackDomainAdminPassword
         rabbitMqClusterName: rabbitmq
         serviceUser: heat
+
+heat_retry_delay: 5

--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -24,7 +24,7 @@
   register: heat_running_result
   until: heat_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ heat_retry_delay }}"
 
 - name: check that heat is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -37,4 +37,4 @@
   register: heat_responding_result
   until: heat_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ heat_retry_delay }}"

--- a/tests/roles/horizon_adoption/defaults/main.yaml
+++ b/tests/roles/horizon_adoption/defaults/main.yaml
@@ -8,3 +8,5 @@ horizon_patch: |
       template:
         memcachedInstance: memcached
         secret: osp-secret
+
+horizon_retry_delay: 5

--- a/tests/roles/horizon_adoption/tasks/main.yaml
+++ b/tests/roles/horizon_adoption/tasks/main.yaml
@@ -11,7 +11,7 @@
   register: horizon_running_result
   until: horizon_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ horizon_retry_delay }}"
 
 - name: check that horizon instance is deployed successfully
   ansible.builtin.shell: |
@@ -22,7 +22,7 @@
   register: horizon_setup_result
   until: horizon_setup_result is success
   retries: 60
-  delay: 3
+  delay: "{{ horizon_retry_delay }}"
 
 - name: check horizon dashboard is reachable
   ansible.builtin.shell: |
@@ -34,4 +34,4 @@
   register: horizon_http_status_code
   until: horizon_http_status_code is success
   retries: 15
-  delay: 2
+  delay: "{{ horizon_retry_delay }}"

--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -76,3 +76,4 @@ ironic_enable_rbac_patch: |
             [oslo_policy]
             enforce_scope=true
             enforce_new_defaults=true
+ironic_retry_delay: 5

--- a/tests/roles/ironic_adoption/tasks/main.yaml
+++ b/tests/roles/ironic_adoption/tasks/main.yaml
@@ -19,7 +19,7 @@
   register: ironic_running_result
   until: ironic_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ ironic_retry_delay }}"
 
 - name: check that ironic-inspector is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -35,7 +35,7 @@
   register: ironic_inspector_running_result
   until: ironic_inspector_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ ironic_retry_delay }}"
 
 - name: Disable Role Based Access Control
   ansible.builtin.shell: |
@@ -57,7 +57,7 @@
   register: ironic_node_list_result
   until: ironic_node_list_result is success
   retries: 60
-  delay: 2
+  delay: "{{ ironic_retry_delay }}"
 
 - name: Set owner field on baremeteal nodes
   ansible.builtin.shell: |
@@ -92,7 +92,7 @@
   register: ironic_node_list_result
   until: ironic_node_list_result is success
   retries: 60
-  delay: 2
+  delay: "{{ ironic_retry_delay }}"
 
 - name: Change the DNS server in the provisioning subnet
   ansible.builtin.shell: |

--- a/tests/roles/ironic_adoption/tasks/wait.yaml
+++ b/tests/roles/ironic_adoption/tasks/wait.yaml
@@ -10,4 +10,4 @@
   register: ironic_crs_ready_result
   until: ironic_crs_ready_result is success
   retries: 60
-  delay: 2
+  delay: "{{ ironic_retry_delay }}"

--- a/tests/roles/keystone_adoption/defaults/main.yaml
+++ b/tests/roles/keystone_adoption/defaults/main.yaml
@@ -27,3 +27,4 @@ keystone_patch: |
                 type: LoadBalancer
         databaseInstance: openstack
         secret: osp-secret
+keystone_retry_delay: 30

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -30,7 +30,7 @@
   register: keystone_running_result
   until: keystone_running_result is success
   retries: 10
-  delay: 30
+  delay: "{{ keystone_retry_delay }}"
 
 - name: wait for openstackclient pod to start up
   ansible.builtin.shell: |
@@ -40,7 +40,7 @@
   register: osc_running_result
   until: osc_running_result is success
   retries: 10
-  delay: 30
+  delay: "{{ keystone_retry_delay }}"
 
 - name: check that Keystone is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -53,7 +53,7 @@
   register: keystone_responding_result
   until: keystone_responding_result is success
   retries: 10
-  delay: 30
+  delay: "{{ keystone_retry_delay }}"
 
 - name: verify that OpenStackControlPlane setup is complete
   ansible.builtin.shell: |

--- a/tests/roles/manila_adoption/defaults/main.yaml
+++ b/tests/roles/manila_adoption/defaults/main.yaml
@@ -25,3 +25,4 @@ supported_backends:
   - cephfs
   - cephnfs
   - netapp
+manila_retry_delay: 5

--- a/tests/roles/manila_adoption/tasks/main.yaml
+++ b/tests/roles/manila_adoption/tasks/main.yaml
@@ -21,7 +21,7 @@
       register: manila_running_result
       until: manila_running_result is success
       retries: 60
-      delay: 2
+      delay: "{{ manila_retry_delay }}"
 
     - name: Check that Manila is reachable and its endpoints are defined
       ansible.builtin.shell: |

--- a/tests/roles/mariadb_copy/defaults/main.yaml
+++ b/tests/roles/mariadb_copy/defaults/main.yaml
@@ -9,3 +9,4 @@ mysql_client_override: ""
 
 # director operator namespace
 director_namespace: "ospdo_openstack"
+mariadb_retry_delay: 5

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -64,7 +64,7 @@
   register: mariadb_data_pod_result
   until: mariadb_data_pod_result is success
   retries: 25
-  delay: 2
+  delay: "{{ mariadb_retry_delay }}"
 
 - name: check that the Galera database cluster(s) members are online and synced, for all cells
   no_log: "{{ use_no_log }}"

--- a/tests/roles/neutron_adoption/defaults/main.yaml
+++ b/tests/roles/neutron_adoption/defaults/main.yaml
@@ -29,3 +29,4 @@ neutron_config_patch: |
         secret: osp-secret
         networkAttachments:
         - internalapi
+neutron_retry_delay: 5

--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -12,7 +12,7 @@
   register: neutron_running_result
   until: neutron_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ neutron_retry_delay }}"
 
 - name: check that Neutron is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -25,4 +25,4 @@
   register: neutron_responding_result
   until: neutron_responding_result is success
   retries: 15
-  delay: 2
+  delay: "{{ neutron_retry_delay }}"

--- a/tests/roles/nova_adoption/defaults/main.yaml
+++ b/tests/roles/nova_adoption/defaults/main.yaml
@@ -243,3 +243,4 @@ remove_ffu_workaround_patch: |
               {%+ endfor +%}
             {%+ endif +%}
           {%+ endfor +%}
+nova_retry_delay: 5

--- a/tests/roles/nova_adoption/tasks/check_endpoints.yaml
+++ b/tests/roles/nova_adoption/tasks/check_endpoints.yaml
@@ -10,4 +10,4 @@
   register: nova_responding_result
   until: nova_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ nova_retry_delay }}"

--- a/tests/roles/nova_adoption/tasks/wait.yaml
+++ b/tests/roles/nova_adoption/tasks/wait.yaml
@@ -8,4 +8,4 @@
   register: nova_crs_ready_result
   until: nova_crs_ready_result is success
   retries: 60
-  delay: 2
+  delay: "{{ nova_retry_delay }}"

--- a/tests/roles/octavia_adoption/defaults/main.yaml
+++ b/tests/roles/octavia_adoption/defaults/main.yaml
@@ -1,3 +1,4 @@
 octavia_ssh_pubkey_path: /root/.ssh/id_ecdsa.pub
 octavia_ssh_path: /tmp/octavia-ssl
 run_octavia_ssh_adoption: true
+octavia_retry_delay: 5

--- a/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
+++ b/tests/roles/octavia_adoption/tasks/octavia_cr_config.yaml
@@ -117,7 +117,7 @@
   register: octavia_crs_ready_result
   until: octavia_crs_ready_result is success
   retries: 60
-  delay: 2
+  delay: "{{ octavia_retry_delay }}"
 
 - name: check that Octavia is reachable and its endpoints are defined
   ansible.builtin.shell: |
@@ -128,4 +128,4 @@
   register: octavia_responding_result
   until: octavia_responding_result is success
   retries: 60
-  delay: 2
+  delay: "{{ octavia_retry_delay }}"

--- a/tests/roles/ovn_adoption/defaults/main.yaml
+++ b/tests/roles/ovn_adoption/defaults/main.yaml
@@ -52,3 +52,4 @@ dpa_tests_dir: "{{ dpa_dir }}/tests"
 # director operator namespace
 director_namespace: "ospdo_openstack"
 # adoption repo default location
+ovn_retry_delay: 5

--- a/tests/roles/ovn_adoption/tasks/main.yaml
+++ b/tests/roles/ovn_adoption/tasks/main.yaml
@@ -13,7 +13,7 @@
   register: ovn_ovsdb_servers_running_result
   until: ovn_ovsdb_servers_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ ovn_retry_delay }}"
 
 # NOTE: w/o pods readiness gates, a service IP is not immediately comes in, so we wait
 - name: get podified OVN NB ovsdb-server service cluster IP
@@ -24,7 +24,7 @@
   register: podified_ovn_nb_ip_result
   until: podified_ovn_nb_ip_result is success
   retries: 10
-  delay: 2
+  delay: "{{ ovn_retry_delay }}"
 
 - name: get podified OVN SB ovsdb-server IP
   ansible.builtin.shell: |
@@ -34,7 +34,7 @@
   register: podified_ovn_sb_ip_result
   until: podified_ovn_sb_ip_result is success
   retries: 10
-  delay: 2
+  delay: "{{ ovn_retry_delay }}"
 
 - name: execute alternative tasks when source env is ODPdO
   ansible.builtin.include_tasks: ovn_ospdo_src_vars.yaml
@@ -140,7 +140,7 @@
   register: ovn_data_pod_result
   until: ovn_data_pod_result is success
   retries: 2
-  delay: 6
+  delay: "{{ ovn_retry_delay }}"
 
 - name: stop northd service
   no_log: "{{ use_no_log }}"

--- a/tests/roles/placement_adoption/defaults/main.yaml
+++ b/tests/roles/placement_adoption/defaults/main.yaml
@@ -24,3 +24,4 @@ placement_patch: |
 
               spec:
                 type: LoadBalancer
+placement_retry_delay: 5

--- a/tests/roles/placement_adoption/tasks/main.yaml
+++ b/tests/roles/placement_adoption/tasks/main.yaml
@@ -12,7 +12,7 @@
   register: placement_running_result
   until: placement_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ placement_retry_delay }}"
 
 - name: check that Placement is reachable and its endpoints are defined
   # There is no placement CLI packaged in Fedora, we could do a CLI
@@ -31,4 +31,4 @@
   register: placement_responding_result
   until: placement_responding_result is success
   retries: 15
-  delay: 2
+  delay: "{{ placement_retry_delay }}"

--- a/tests/roles/swift_adoption/defaults/main.yaml
+++ b/tests/roles/swift_adoption/defaults/main.yaml
@@ -37,3 +37,4 @@ swift_patch: |
                   type: LoadBalancer
           networkAttachments:
           - storage
+swift_retry_delay: 5

--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -44,7 +44,7 @@
   register: swift_running_result
   until: swift_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ swift_retry_delay }}"
 
 - name: check that Swift is reachable and its endpoints are defined
   ansible.builtin.shell: |

--- a/tests/roles/swift_migration/defaults/main.yaml
+++ b/tests/roles/swift_migration/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+swift_migration_delay: 5

--- a/tests/roles/swift_migration/tasks/main.yaml
+++ b/tests/roles/swift_migration/tasks/main.yaml
@@ -28,7 +28,7 @@
   register: swift_storage_ready_result
   until: swift_storage_ready_result is success
   retries: 60
-  delay: 2
+  delay: "{{ swift_migration_delay }}"
 
 - name: wait until ring configmap includes new pv devices
   ansible.builtin.shell: |

--- a/tests/roles/telemetry_adoption/defaults/main.yaml
+++ b/tests/roles/telemetry_adoption/defaults/main.yaml
@@ -41,3 +41,4 @@ telemetry_logging_patch: |
 
           port: 10514
           cloNamespace: openshift-logging
+telemetry_retry_delay: 5

--- a/tests/roles/telemetry_adoption/tasks/main.yaml
+++ b/tests/roles/telemetry_adoption/tasks/main.yaml
@@ -24,7 +24,7 @@
   register: coo_install_result
   until: coo_install_result is success
   retries: 60
-  delay: 2
+  delay: "{{ telemetry_retry_delay }}"
 
 - name: deploy metric storage
   ansible.builtin.shell: |
@@ -40,7 +40,7 @@
   register: alertmanager_running_result
   until: alertmanager_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ telemetry_retry_delay }}"
 
 - name: wait for prometheus metric storage to start up
   ansible.builtin.shell: |
@@ -50,7 +50,7 @@
   register: prometheus_running_result
   until: prometheus_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ telemetry_retry_delay }}"
 
 - name: deploy podified Ceilometer
   ansible.builtin.shell: |
@@ -66,7 +66,7 @@
   register: ceilometer_running_result
   until: ceilometer_running_result is success
   retries: 60
-  delay: 2
+  delay: "{{ telemetry_retry_delay }}"
 
 - name: include logging
   ansible.builtin.shell: |


### PR DESCRIPTION
There is no need to make so often queries if the service is ready. It might raise complication on some CI host, that does not have enough power.