### PR TITLE
Stick to Mirrored queues during adoption

### DIFF
--- a/tests/roles/backend_services/templates/openstack_control_plane.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane.j2
@@ -131,6 +131,7 @@ spec:
   rabbitmq:
     templates:
       rabbitmq:
+        queueType: Mirrored
         persistence:
           storage: 3Gi
         override:
@@ -144,6 +145,7 @@ spec:
 {% set ind = {'val': 86} %}
 {% for cell in renamed_cells %}
       rabbitmq-{{ cell }}:
+        queueType: Mirrored
         persistence:
           storage: 3Gi
         override:

--- a/tests/roles/backend_services/templates/openstack_control_plane_ospdo.j2
+++ b/tests/roles/backend_services/templates/openstack_control_plane_ospdo.j2
@@ -123,6 +123,7 @@ spec:
   rabbitmq:
     templates:
       rabbitmq:
+        queueType: Mirrored
         replicas: 1
         override:
           service:
@@ -133,6 +134,7 @@ spec:
             spec:
               type: LoadBalancer
       rabbitmq-cell1:
+        queueType: Mirrored
         persistence:
           storageClassName: {{ ospdo_storage_class.stdout }}
         replicas: 1


### PR DESCRIPTION
Quorum queues right now are only supported for greenfield deployments. 
Since adoption needs controlplane services to be interoperable between osp17 and 18 we need to stick to the minimum common denominator and postpone the migration to quorum queues to a later step, after adoption is completed.

Jira: https://issues.redhat.com/browse/OSPCIX-1063