### PR TITLE
Remove configuration drift for heat

### DIFF
--- a/tests/roles/heat_adoption/defaults/main.yaml
+++ b/tests/roles/heat_adoption/defaults/main.yaml
@@ -5,6 +5,8 @@ heat_patch: |
       enabled: true
       apiOverride:
         route: {}
+      cnfAPIOverride:
+        route: {}
       template:
         databaseInstance: openstack
         databaseAccount: heat


### PR DESCRIPTION
OpenStackControlPlane CRD was updated recently. The changes were reflected in [1] but not in Adoption templates. This patch removes configration drift for HEAT service

[1] https://github.com/openstack-k8s-operators/architecture/blob/main/lib/control-plane/base/openstackcontrolplane.yaml#L114-L126

Related-Issue: #[OSPCIX-1063](https://issues.redhat.com//browse/OSPCIX-1063)