### PR TITLE
[OSPRH-20017] Enable Ironic in uni04delta-ipv6

### DIFF
--- a/scenarios/uni04delta-ipv6.yaml
+++ b/scenarios/uni04delta-ipv6.yaml
@@ -59,6 +59,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/debug.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/services/ironic-overcloud.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/services/ironic-inspector.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/services/barbican.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/barbican-backend-simple-crypto.yaml"
     network_data_file: "uni04delta-ipv6/network_data.yaml.j2"
@@ -68,3 +70,15 @@ stacks:
     stack_nodes:
       - osp-computes
       - osp-controllers
+    post_oc_run:
+      - name: Ironic post overcloud deploy
+        type: playbook
+        source: adoption_ironic_post_oc.yml
+        extra_vars:
+          _subnet_ip_version: 6
+          _subnet_ipv6_address_mode: dhcpv6-stateful
+          _subnet_ipv6_ra_mode: dhcpv6-stateful
+          _subnet_range: 2620:cf:cf:ffff::0/64
+          _subnet_gateway: 2620:cf:cf:ffff::1
+          _subnet_alloc_pool_start: 2620:cf:cf:ffff::300
+          _subnet_alloc_pool_end: 2620:cf:cf:ffff::399

--- a/scenarios/uni04delta-ipv6/config_download.yaml
+++ b/scenarios/uni04delta-ipv6/config_download.yaml
@@ -10,6 +10,7 @@ resource_registry:
   OS::TripleO::Controller::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
   OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
   OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::Controller::Ports::IronicPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_ironic.yaml
   OS::TripleO::Services::CeilometerAgentCentral: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-central-container-puppet.yaml
   OS::TripleO::Services::CeilometerAgentNotification: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-notification-container-puppet.yaml
   OS::TripleO::Services::CeilometerAgentIpmi: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-ipmi-container-puppet.yaml
@@ -88,5 +89,25 @@ parameter_defaults:
         host_routes: []
         name: ctlplane-subnet
         ip_version: 6
+  NeutronFlatNetworks:
+    - datacentre
+    - ironic
+  ControllerParameters:
+    NeutronBridgeMappings:
+      - datacentre:br-ex
+      - ironic:br-baremetal
   NeutronBridgeMappings:
     - datacentre:br-ex
+  IronicInspectorInterface: br-baremetal
+  IronicInspectorSubnets:
+    osp-controller-uni04delta-ipv6-0:
+      - ip_range: 2620:cf:cf:ffff::210,2620:cf:cf:ffff::219
+    osp-controller-uni04delta-ipv6-1:
+      - ip_range: 2620:cf:cf:ffff::220,2620:cf:cf:ffff::229
+    osp-controller-uni04delta-ipv6-2:
+      - ip_range: 2620:cf:cf:ffff::230,2620:cf:cf:ffff::239
+  ServiceNetMap:
+    IronicApiNetwork: ironic
+    IronicNetwork: ironic
+    IronicInspectorNetwork: ironic
+  IronicCleaningDiskErase: metadata

--- a/scenarios/uni04delta-ipv6/network_data.yaml.j2
+++ b/scenarios/uni04delta-ipv6/network_data.yaml.j2
@@ -59,7 +59,7 @@
   subnets:
     ironic_subnet:
       ipv6_subnet: 2620:cf:cf:ffff::/64
-      ipv6_allocation_pools: [{'start': '2620:cf:cf:ffff::30', 'end': '2620:cf:cf:ffff::70'}]
+      ipv6_allocation_pools: [{'start': '2620:cf:cf:ffff::100', 'end': '2620:cf:cf:ffff::250'}]
 
 - name: StorageMgmt
   mtu: 1500


### PR DESCRIPTION
Goal is to have CI automation in uni04delta-ipv6 data plane adoption scenario to configure Ironic IPv6 in OSP17.1 cloud that is deployed.

It partially solves the [OSPRH-20019](https://issues.redhat.com//browse/OSPRH-20019)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3372

fixes: OSRPH-20017, [OSPRH-20019](https://issues.redhat.com//browse/OSPRH-20019)