### PR TITLE
keystone ldap adoption testing

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -1,3 +1,7 @@
+# IPA-related variables
+ipa_hostname: "osp-free-ipa-0.ooo.test"
+ipa_admin_password: "nomoresecrets"
+ipa_user_password: "nomoresecrets"
 prelaunch_test_instance: true
 prelaunch_test_instance_scripts:
   - pre_launch.bash

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -233,3 +233,33 @@
     cmd: |
       {{ shell_header }}
       curl {{ octavia_vip_address.stdout }}
+
+- name: Add IPA domain to Keystone and create IPA users
+  when: enable_ldap is defined and enable_ldap
+  block:
+    - name: SSH into standalone VM and execute IPA commands
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        ssh {{ ipa_hostname }} "echo {{ ipa_admin_password }} | kinit admin;\
+          ipa user-add svc-ldap --first=Openstack --last=LDAP;\
+          echo {{ ipa_admin_password }} | ipa passwd svc-ldap;\
+          ipa user-add ipauser1 --first=ipa1 --last=user1;\
+          echo {{ ipa_user_password }} | ipa passwd ipauser1;\
+          ipa user-add ipauser2 --first=ipa2 --last=user2;\
+          echo {{ ipa_user_password }} | ipa passwd ipauser2;\
+          ipa user-add ipauser3 --first=ipa3 --last=user3;\
+          echo {{ ipa_user_password }} | ipa passwd ipauser3;\
+          ipa group-add --desc=\"OpenStack Users\" grp-openstack;\
+          ipa group-add --desc=\"OpenStack Admin Users\" grp-openstack-admin;\
+          ipa group-add --desc=\"OpenStack Demo Users\" grp-openstack-demo;\
+          ipa group-add-member --users=svc-ldap grp-openstack;\
+          ipa group-add-member --users=ipauser1 grp-openstack;\
+          ipa group-add-member --users=ipauser1 grp-openstack-admin;\
+          ipa group-add-member --users=ipauser2 grp-openstack;\
+          ipa group-add-member --users=ipauser2 grp-openstack-demo;\
+          ipa group-add-member --users=ipauser3 grp-openstack;"
+          
+    - name: Add REDHAT domain to Keystone
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ openstack_command }} domain create --description \"Test LDAP Domain\" REDHAT

--- a/tests/roles/keystone_adoption/defaults/main.yaml
+++ b/tests/roles/keystone_adoption/defaults/main.yaml
@@ -70,3 +70,52 @@ keystone_patch_federation: |
         secret: osp-secret
 
 keystone_retry_delay: 30
+
+keystone_patch_ldap: |
+  spec:
+    keystone:
+      enabled: true
+      apiOverride:
+        route: {}
+      template:
+        customServiceConfig: |
+          [token]
+          expiration = 360000
+          [identity]
+                    domain_specific_drivers_enabled = true
+        extraMounts:
+          - name: v1
+            region: r1
+            extraVol:
+              - propagation:
+                - Keystone
+                extraVolType: Conf
+                volumes:
+                - name: keystone-domains
+                  secret:
+                    secretName: keystone-domains
+                mounts:
+                - name: keystone-domains
+                  mountPath: "/etc/keystone/domains"
+                  readOnly: true
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  {% if ipv6_enabled | default(false) -%}
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix_ipv6 | default('2620:cf:cf:bbbb') }}::50
+                  {%- else -%}
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
+                  {%- endif %}
+              spec:
+                type: LoadBalancer
+        databaseInstance: openstack
+        secret: osp-secret
+
+# IPA-related variables
+ipa_hostname: "osp-free-ipa-0.ooo.test"
+ipa_admin_password: "nomoresecrets"
+ipa_user_password: "nomoresecrets"

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -16,12 +16,52 @@
     type: Opaque
     EOF
 
+- name: Set IPA BaseDN var
+  ansible.builtin.set_fact:
+    ipa_basedn: "dc={{ ipa_hostname.split('.')[1:] | join(',dc=') }}"
+  when: enable_ldap is defined and enable_ldap
+
+- name: Create Keystone domain config secret for LDAP
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cat <<EOF | oc apply -n openstack -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: keystone-domains
+    type: Opaque
+    stringData:
+      keystone.{{ ipa_domain | default('REDHAT') }}.conf: |
+        [identity]
+        driver = ldap
+        [ldap]
+        url = ldaps://osp-free-ipa-0.ooo.test
+        user = uid=svc-ldap,cn=users,cn=accounts,{{ ipa_basedn }}
+        password = {{ ipa_admin_password | default('nomoresecrets') }}
+        suffix = {{ ipa_basedn }}
+        user_tree_dn = cn=users,cn=accounts,{{ ipa_basedn }}
+        user_objectclass = person
+        user_id_attribute = uid
+        user_name_attribute = uid
+        user_mail_attribute = mail
+        group_tree_dn = cn=groups,cn=accounts,{{ ipa_basedn }}
+        group_objectclass = groupOfNames
+        group_id_attribute = cn
+        group_name_attribute = cn
+        group_member_attribute = member
+        group_desc_attribute = description
+    EOF
+  when: enable_ldap is defined and enable_ldap
+
 - name: deploy podified Keystone
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     if {{ enable_federation | default(false) | lower }} == true; then
       oc patch openstackcontrolplane openstack --type=merge --patch '{{ keystone_patch_federation }}'
+    else if {{ enable_ldap | default(false) | lower }} == true; then
+      oc patch openstackcontrolplane openstack --type=merge --patch '{{ keystone_patch_ldap }}'
     else
       oc patch openstackcontrolplane openstack --type=merge --patch '{{ keystone_patch }}'
     fi


### PR DESCRIPTION
LDAP adoption testing will add a ldap domain to keystone. This ldap connection will be to the freeipa server setup for tlse environments on a multinode adoption job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3614
Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/1203
Jira: https://issues.redhat.com/browse/OSPRH-6861