### PR TITLE
[BUGFIX] Remove redundant ExtraConfig virt_type from config_download

### DIFF
--- a/scenarios/dcn_nostorage/central/config_download.yaml
+++ b/scenarios/dcn_nostorage/central/config_download.yaml
@@ -46,11 +46,6 @@ parameter_defaults:
       use_neutron: false
   ControllerExtraConfig:
     nova::availability_zone::default_schedule_zone: az-central
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/dcn_nostorage/dcn1/config_download.yaml
+++ b/scenarios/dcn_nostorage/dcn1/config_download.yaml
@@ -43,12 +43,7 @@ parameter_defaults:
     - ip_address: 192.168.122.111
       use_neutron: false
   ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
     nova::availability_zone::default_schedule_zone: az-central
-  ComputeDcn1ExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/dcn_nostorage/dcn2/config_download.yaml
+++ b/scenarios/dcn_nostorage/dcn2/config_download.yaml
@@ -43,12 +43,7 @@ parameter_defaults:
     - ip_address: 192.168.122.111
       use_neutron: false
   ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
     nova::availability_zone::default_schedule_zone: az-central
-  ComputeDcn2ExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/hci/config_download.yaml
+++ b/scenarios/hci/config_download.yaml
@@ -42,12 +42,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -47,12 +47,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.131
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   NeutronDnsDomain: 'example.com'
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true

--- a/scenarios/uni02beta/config_download.yaml
+++ b/scenarios/uni02beta/config_download.yaml
@@ -39,12 +39,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni04delta-ipv6/config_download.yaml
+++ b/scenarios/uni04delta-ipv6/config_download.yaml
@@ -39,12 +39,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 2620:cf:cf:aaaa::83
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   ExtraConfig:
     neutron::notification_driver: 'noop'
     neutron::config::plugin_ml2_config:

--- a/scenarios/uni04delta/config_download.yaml
+++ b/scenarios/uni04delta/config_download.yaml
@@ -40,12 +40,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   ExtraConfig:
     neutron::notification_driver: 'noop'
   BarbicanSimpleCryptoGlobalDefault: true

--- a/scenarios/uni05epsilon/config_download_cell1.yaml
+++ b/scenarios/uni05epsilon/config_download_cell1.yaml
@@ -60,9 +60,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.121
       use_neutron: false
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni05epsilon/config_download_cell2.yaml
+++ b/scenarios/uni05epsilon/config_download_cell2.yaml
@@ -60,9 +60,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.122
       use_neutron: false
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni05epsilon/config_download_overcloud.yaml
+++ b/scenarios/uni05epsilon/config_download_overcloud.yaml
@@ -42,9 +42,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.120
       use_neutron: false
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni06zeta/config_download.yaml
+++ b/scenarios/uni06zeta/config_download.yaml
@@ -38,12 +38,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.131
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/uni07eta/config_download.yaml
+++ b/scenarios/uni07eta/config_download.yaml
@@ -42,12 +42,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   ExtraConfig:
     neutron::notification_driver: 'noop'
     neutron::plugins::ml2::path_mtu: 1400

--- a/scenarios/uni09iota/config_download.yaml
+++ b/scenarios/uni09iota/config_download.yaml
@@ -39,12 +39,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true


### PR DESCRIPTION
These ExtraConfig entries duplicate what `--libvirt-type qemu` already
sets via stack_args in every scenario ([example: uni01alpha.yaml L42](https://github.com/openstack-k8s-operators/data-plane-adoption/blob/downstream/scenarios/uni01alpha.yaml#L42)).
The duplication is harmless for the default qemu case, but it blocks
overrides due to TripleO's hiera priority chain.

**The mechanism:** TripleO's [hieradata_files hierarchy](https://github.com/openstack/tripleo-heat-templates/blob/16b0e650ca838995894a8552f5070bb3e40f1984/overcloud.j2.yaml#L677-L700)
(from `overcloud.j2.yaml` in tripleo-heat-templates) resolves entries
top-down, first match wins:

```
L684:  - role_extraconfig    ← ComputeExtraConfig (position 7)
       ...
L688:  - service_configs     ← --libvirt-type CLI arg (position 11)
```

Both sources set the same Puppet keys (`nova::compute::libvirt::virt_type`),
so the ExtraConfig at position 7 silently wins over the CLI arg at
position 11. Any `--libvirt-type kvm` override via stack_args gets
ignored.

**What's removed:**
- 8 standard scenarios - entire `ComputeExtraConfig` and `ControllerExtraConfig` blocks
- 3 cell scenarios (uni05epsilon) - `ComputeExtraConfig` blocks
- 3 DCN scenarios - virt_type lines only, `nova::availability_zone` preserved in `ControllerExtraConfig`

No other consumer of these entries exists in
[ci-framework/adoption_osp_deploy](https://github.com/openstack-k8s-operators/ci-framework/tree/main/roles/adoption_osp_deploy)
or DPA adoption roles.

**Tested** - full adoption pipeline (7/7 stages, ~10h):
deploy-infra → deploy-osp → deploy-ocp → install-operators →
install-shiftstack → run-adoption → run-shiftstack-after

Related-Issue: #[OSPRH-27919](https://redhat.atlassian.net/browse/OSPRH-27919)