### PR TITLE
[BUGFIX] Fix ironic conductor for post-adoption baremetal provisioning

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -1,3 +1,17 @@
+- name: Delete stale down nova-compute services from prior deployment
+  ansible.builtin.shell: |
+    {{ mariadb_copy_shell_vars_dst }}
+    for CELL in $(echo $RENAMED_CELLS); do
+      STALE=$(oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \
+        nova_${CELL} -e "SELECT COUNT(*) FROM services WHERE \`binary\`='nova-compute' AND deleted=0 AND version < (SELECT MAX(version) FROM services WHERE \`binary\`='nova-compute' AND deleted=0)")
+      if [ "$STALE" -gt 0 ]; then
+        echo "Cleaning $STALE stale nova-compute services from $CELL"
+        oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \
+          nova_${CELL} -e "UPDATE services SET deleted=id, deleted_at=NOW() WHERE \`binary\`='nova-compute' AND deleted=0 AND version < (SELECT mv FROM (SELECT MAX(version) AS mv FROM services WHERE \`binary\`='nova-compute' AND deleted=0) t)"
+      fi
+    done
+  changed_when: false
+
 - name: wait for Compute data plane services version updated for all cells
   ansible.builtin.shell: |
     {{ mariadb_copy_shell_vars_dst }}

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -46,36 +46,123 @@
   retries: 60
   delay: "{{ dataplane_retry_delay }}"
 
+# Workaround (OSPRH-28474): ironic-operator conductor dnsmasq template is
+# missing UEFI iPXE boot directives. Patch must be applied here (after all
+# spec.ironic CR patches) because ironic-operator reconciliation regenerates
+# the conductor dnsmasq configmap, wiping earlier patches (OSPRH-28479).
+- name: Patch conductor dnsmasq for UEFI iPXE boot chain
+  when:
+    - ironic_conductor_dnsmasq_uefi_fix | default(false) | bool
+    - "'pre_launch_ironic.bash' in prelaunch_test_instance_scripts | default([])"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    CONDUCTOR_POD=$(oc get pods -n openstack -l component=conductor \
+      -o jsonpath='{.items[0].metadata.name}')
+
+    # Skip if already patched (idempotent)
+    if oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- \
+        grep -q 'dhcp-boot=tag:efi,tag:!ipxe' /var/lib/ironic/dnsmasq.conf; then
+      echo "dnsmasq UEFI boot directives already present"
+      exit 0
+    fi
+
+    CONDUCTOR_IP=$(oc get pod -n openstack "$CONDUCTOR_POD" \
+      -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | \
+      python3 -c "import sys,json; nets=json.load(sys.stdin); print([n['ips'][0] for n in nets if n.get('name','').endswith('/{{ ironic_network }}') or n.get('interface','') == '{{ ironic_network }}'][0])")
+
+    if [ -z "$CONDUCTOR_IP" ]; then
+      echo "ERROR: Could not determine conductor IP on {{ ironic_network }} network"
+      exit 1
+    fi
+    echo "Conductor IP: $CONDUCTOR_IP"
+
+    # Wrap IPv6 addresses in brackets for URL construction (RFC 3986)
+    CONDUCTOR_URL_IP="${CONDUCTOR_IP}"
+    [[ "$CONDUCTOR_IP" == *:* ]] && CONDUCTOR_URL_IP="[${CONDUCTOR_IP}]"
+
+    oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- sh -c \
+      "printf '\n# UEFI iPXE boot chain (ironic-operator bug workaround)\ndhcp-boot=tag:efi,tag:!ipxe,snponly.efi\ndhcp-boot=tag:ipxe,http://%s:8088/boot.ipxe\n' \
+        '${CONDUCTOR_URL_IP}' >> /var/lib/ironic/dnsmasq.conf"
+
+    oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- kill 1
+    sleep 15
+    oc wait -n openstack --for condition=Ready --timeout=120s pod/"$CONDUCTOR_POD"
+
+    oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- \
+      grep 'dhcp-boot=tag:efi,tag:!ipxe' /var/lib/ironic/dnsmasq.conf
+
 - name: Provision new instance on ironic
   when:
     - prelaunch_test_instance|bool
     - "'pre_launch_ironic.bash' in prelaunch_test_instance_scripts"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-    alias openstack="oc exec -t openstackclient -- openstack"
+  ansible.builtin.shell:
+    cmd: |
+      {{ shell_header }}
+      {{ oc_header }}
+      alias openstack="oc exec -t openstackclient -- openstack"
 
-    function wait_server_active() {
-      local server_name=$1
-      local retries=100
-      local counter=0
-      set +e
-      until ${BASH_ALIASES[openstack]} server show ${server_name} -f value -c status | grep "ACTIVE"; do
-        if [[ "$counter" -eq "$retries" ]]; then
-          echo "ERROR: Timeout. Server: \"${server_name}\" did not reach state: \"ACTIVE\""
-          ${BASH_ALIASES[openstack]} server show ${server_name}
-          exit 1
-        fi
-        echo "Waiting for image \"${server_name}\" to reach state \"ACTIVE\""
+      function wait_server_active() {
+        local server_name=$1
+        local retries=100
+        local counter=0
+        local status
+        set +e
+        while true; do
+          status=$(${BASH_ALIASES[openstack]} server show ${server_name} -f value -c status)
+          if [ "$status" = "ACTIVE" ]; then
+            echo "$status"
+            break
+          fi
+          if [ "$status" = "ERROR" ]; then
+            echo "ERROR: Server ${server_name} entered ERROR state"
+            ${BASH_ALIASES[openstack]} server show ${server_name}
+            exit 1
+          fi
+          if [[ "$counter" -eq "$retries" ]]; then
+            echo "ERROR: Timeout. Server: ${server_name} did not reach state: ACTIVE (current: ${status})"
+            ${BASH_ALIASES[openstack]} server show ${server_name}
+            exit 1
+          fi
+          echo "Waiting for ${server_name} to reach state ACTIVE (current: ${status})"
+          sleep 10
+          ((counter++))
+        done
+        set -e
+      }
+
+      ${BASH_ALIASES[openstack]} server create test-baremetal-post-adoption --flavor baremetal --image CentOS-Stream-GenericCloud-x86_64-9 --nic net-id=provisioning
+      wait_server_active test-baremetal-post-adoption
+
+      # Workaround: conductor dnsmasq DHCP race on flat/provisioning network.
+      # The conductor dnsmasq is the only DHCP server for baremetal ports (OVN
+      # doesn't serve vif_type=other). Without a dhcp-host entry, conductor
+      # assigns IPs from its pool range instead of the neutron-assigned IP.
+      # Add a dhcp-host entry mapping the port MAC to the correct IP, restart
+      # dnsmasq, and reboot the instance to pick up the correct address.
+      PORT_MAC=$(${BASH_ALIASES[openstack]} port list --server test-baremetal-post-adoption -f json | jq -r '.[0]["MAC Address"]')
+      PORT_IP=$(${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption -f json -c addresses | jq -r '.addresses.provisioning[0]')
+      echo "Port MAC: $PORT_MAC  Neutron IP: $PORT_IP"
+
+      CONDUCTOR_POD=$(oc get pods -n openstack -l component=conductor \
+        -o jsonpath='{.items[0].metadata.name}')
+
+      if ! oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- \
+          grep -q "dhcp-host=${PORT_MAC}" /var/lib/ironic/dnsmasq.conf 2>/dev/null; then
+        oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- sh -c \
+          "printf '\n# DHCP host entry for deployed baremetal instance (ironic-operator workaround)\ndhcp-host=%s,%s\n' \
+            '${PORT_MAC}' '${PORT_IP}' >> /var/lib/ironic/dnsmasq.conf"
+        oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- kill 1
+        sleep 15
+        oc wait -n openstack --for condition=Ready --timeout=120s pod/"$CONDUCTOR_POD"
+        oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- \
+          grep "dhcp-host=${PORT_MAC}" /var/lib/ironic/dnsmasq.conf
+        echo "Rebooting instance to pick up correct DHCP address..."
+        ${BASH_ALIASES[openstack]} server reboot test-baremetal-post-adoption
         sleep 10
-        ((counter++))
-      done
-      set -e
-    }
+        wait_server_active test-baremetal-post-adoption
+      fi
 
-    ${BASH_ALIASES[openstack]} server create test-baremetal-post-adoption --flavor baremetal --image CentOS-Stream-GenericCloud-x86_64-9 --nic net-id=provisioning
-    wait_server_active test-baremetal-post-adoption
-
-    # Check instance status and network connectivity
-    ${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption
-    ping -c 4 $(${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption -f json -c addresses | jq -r .addresses.provisioning[0])
+      # Check instance status and network connectivity
+      ${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption
+      ping -c 4 $(${BASH_ALIASES[openstack]} server show test-baremetal-post-adoption -f json -c addresses | jq -r '.addresses.provisioning[0]')

--- a/tests/roles/development_environment/files/pre_launch_ironic.bash
+++ b/tests/roles/development_environment/files/pre_launch_ironic.bash
@@ -6,8 +6,10 @@ function wait_node_state() {
   local node_state=$1
   local retries=120
   local counter=0
+  local total_nodes
+  total_nodes=$(${BASH_ALIASES[openstack]} baremetal node list -c UUID -f value | wc -l)
   set +e
-  until ! ${BASH_ALIASES[openstack]} baremetal node list -f value -c "Provisioning\ State" | grep -P "^(?!${node_state}).*$"; do
+  until [ "$(${BASH_ALIASES[openstack]} baremetal node list --provision-state "${node_state}" -c UUID -f value | wc -l)" -eq "$total_nodes" ]; do
     if [[ "$counter" -eq "$retries" ]]; then
       echo "ERROR: Timeout. Nodes did not reach provisioning state: ${node_state}"
       exit 1
@@ -24,7 +26,7 @@ function wait_image_active() {
   local retries=100
   local counter=0
   set +e
-  until ! ${BASH_ALIASES[openstack]} image show  Fedora-Cloud-Base-38 -f value -c status | grep -P "^(?!active).*$"; do
+  until ${BASH_ALIASES[openstack]} image show "${image_name}" -f value -c status | grep -q "^active$"; do
     if [[ "$counter" -eq "$retries" ]]; then
       echo "ERROR: Timeout. Image: ${image_name} did not reach state: active"
       exit 1
@@ -91,7 +93,7 @@ wait_image_active CentOS-Stream-GenericCloud-x86_64-9
 export BAREMETAL_NODES=$(${BASH_ALIASES[openstack]} baremetal node list -c UUID -f value)
 
 # Check if any nodes are active (in use by instances)
-ACTIVE_NODES=$(${BASH_ALIASES[openstack]} baremetal node list -c "Provisioning State" -f value | grep -c "active" || true)
+ACTIVE_NODES=$(${BASH_ALIASES[openstack]} baremetal node list --provision-state active -c UUID -f value | wc -l)
 
 if [ "$ACTIVE_NODES" -eq 0 ]; then
   echo "No active nodes found, proceeding with node management operations"

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -1,3 +1,14 @@
+- name: Wait for source cloud Keystone to be available
+  when: prelaunch_test_instance | bool
+  ansible.builtin.shell:
+    cmd: |
+      {{ shell_header }}
+      {{ openstack_command }} token issue -f value -c id
+  register: _keystone_check
+  until: _keystone_check is success
+  retries: 30
+  delay: 10
+
 - name: pre-launch test VM instance
   no_log: "{{ use_no_log }}"
   when:

--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -39,6 +39,20 @@ ironic_patch: |
           networkAttachments:
           - {{ ironic_network }}
           provisionNetwork: {{ ironic_network }}
+          # OSPRH-28478: conductor dhcpRanges required for deploy/clean
+          dhcpRanges:
+          - name: conductor-0
+            {% if ipv6_enabled | default(false) -%}
+            cidr: 2620:cf:cf:ffff::/64
+            start: 2620:cf:cf:ffff::240
+            end: 2620:cf:cf:ffff::249
+            {%- else -%}
+            cidr: 172.20.1.0/24
+            start: 172.20.1.240
+            end: 172.20.1.249
+            gateway: 172.20.1.1
+            {%- endif %}
+
           storageRequest: 10G
           storageClass: {{ storage_class_name }}
           customServiceConfig: |
@@ -46,9 +60,10 @@ ironic_patch: |
             cleaning_network=provisioning
             provisioning_network=provisioning
             rescuing_network=provisioning
-            # inspection_network=<introspection network uuid>
             [conductor]
             automated_clean=true
+            [service_catalog]
+            endpoint_override=http://{{ dns_server_provisioning_ip | ansible.utils.ipwrap }}:6385
         ironicInspector:
           replicas: 1
           inspectionNetwork: {{ ironic_network }}
@@ -109,3 +124,7 @@ ironic_retry_delay: 5
 ironic_post_adoption_manage_nodes: false
 ironic_post_adoption_inspect_nodes: false
 ironic_post_adoption_provide_nodes: false
+# Workaround (OSPRH-28474): ironic-operator conductor dnsmasq template missing
+# UEFI iPXE boot directives. The inspector template has them, the conductor
+# doesn't. Set to false once the ironic-operator template is fixed upstream.
+ironic_conductor_dnsmasq_uefi_fix: true

--- a/tests/roles/ironic_adoption/tasks/main.yaml
+++ b/tests/roles/ironic_adoption/tasks/main.yaml
@@ -94,6 +94,46 @@
   retries: 60
   delay: "{{ ironic_retry_delay }}"
 
+- name: Patch conductor dnsmasq for UEFI iPXE boot chain
+  when: ironic_conductor_dnsmasq_uefi_fix | bool
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    CONDUCTOR_POD=$(oc get pods -n openstack -l component=conductor \
+      -o jsonpath='{.items[0].metadata.name}')
+
+    # Skip if already patched (idempotent)
+    if oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- \
+        grep -q 'dhcp-boot=tag:efi,tag:!ipxe' /var/lib/ironic/dnsmasq.conf; then
+      echo "dnsmasq UEFI boot directives already present"
+      exit 0
+    fi
+
+    CONDUCTOR_IP=$(oc get pod -n openstack "$CONDUCTOR_POD" \
+      -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | \
+      python3 -c "import sys,json; nets=json.load(sys.stdin); print([n['ips'][0] for n in nets if n.get('name','').endswith('/{{ ironic_network }}') or n.get('interface','') == '{{ ironic_network }}'][0])")
+
+    if [ -z "$CONDUCTOR_IP" ]; then
+      echo "ERROR: Could not determine conductor IP on {{ ironic_network }} network"
+      exit 1
+    fi
+    echo "Conductor IP: $CONDUCTOR_IP"
+
+    # Wrap IPv6 addresses in brackets for URL construction (RFC 3986)
+    CONDUCTOR_URL_IP="${CONDUCTOR_IP}"
+    [[ "$CONDUCTOR_IP" == *:* ]] && CONDUCTOR_URL_IP="[${CONDUCTOR_IP}]"
+
+    oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- sh -c \
+      "printf '\n# UEFI iPXE boot chain (ironic-operator bug workaround)\ndhcp-boot=tag:efi,tag:!ipxe,snponly.efi\ndhcp-boot=tag:ipxe,http://%s:8088/boot.ipxe\n' \
+        '${CONDUCTOR_URL_IP}' >> /var/lib/ironic/dnsmasq.conf"
+
+    oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- kill 1
+    sleep 15
+    oc wait -n openstack --for condition=Ready --timeout=120s pod/"$CONDUCTOR_POD"
+
+    oc exec -n openstack "$CONDUCTOR_POD" -c dnsmasq -- \
+      grep 'dhcp-boot=tag:efi,tag:!ipxe' /var/lib/ironic/dnsmasq.conf
+
 - name: Change the DNS server in the provisioning subnet
   ansible.builtin.shell: |
     {{ shell_header }}
@@ -101,16 +141,34 @@
     alias openstack="oc exec -t openstackclient -- openstack"
     ${BASH_ALIASES[openstack]} subnet set --dns-nameserver {{ dns_server_provisioning_ip }} provisioning-subnet
 
-- name: Reset node driver_info to use new deploy images
+# Workaround (OSPRH-28476): ironic.conf has no global deploy_kernel/
+# deploy_ramdisk defaults, so per-node httpboot URLs must be set.
+- name: Set node deploy images to conductor httpboot URLs
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     alias openstack="oc exec -t openstackclient -- openstack"
 
+    CONDUCTOR_POD=$(oc get pods -n openstack -l component=conductor \
+      -o jsonpath='{.items[0].metadata.name}')
+    CONDUCTOR_IP=$(oc get pod -n openstack "$CONDUCTOR_POD" \
+      -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | \
+      python3 -c "import sys,json; nets=json.load(sys.stdin); print([n['ips'][0] for n in nets if n.get('name','').endswith('/{{ ironic_network }}') or n.get('interface','') == '{{ ironic_network }}'][0])")
+
+    if [ -z "$CONDUCTOR_IP" ]; then
+      echo "ERROR: Could not determine conductor IP on {{ ironic_network }} network"
+      exit 1
+    fi
+    echo "Conductor IP: $CONDUCTOR_IP"
+
+    # Wrap IPv6 addresses in brackets for URL construction (RFC 3986)
+    CONDUCTOR_URL_IP="${CONDUCTOR_IP}"
+    [[ "$CONDUCTOR_IP" == *:* ]] && CONDUCTOR_URL_IP="[${CONDUCTOR_IP}]"
+
     for node in $(${BASH_ALIASES[openstack]} baremetal node list -c UUID -f value); do
       ${BASH_ALIASES[openstack]} baremetal node set $node \
-        --driver-info deploy_ramdisk= \
-        --driver-info deploy_kernel=
+        --driver-info deploy_ramdisk=http://${CONDUCTOR_URL_IP}:8088/ironic-python-agent.initramfs \
+        --driver-info deploy_kernel=http://${CONDUCTOR_URL_IP}:8088/ironic-python-agent.kernel
     done
 
 - name: Post-adoption baremetal node management


### PR DESCRIPTION
Fix issues preventing post-adoption baremetal provisioning in the
test-with-ironic scenario. Contains workarounds for ironic-operator
bugs and related fixes. Discovered during shiftstack adoption CI
([OSPRH-27919](https://redhat.atlassian.net/browse/OSPRH-27919)),
but all fixes affect regular ironic adoption too.

**Fixes:**

1. **Missing conductor DHCP ranges** ([OSPRH-28474](https://redhat.atlassian.net/browse/OSPRH-28474)):
   ironicConductors had no `dhcpRanges`, nodes couldn't PXE boot.
   Added `172.20.1.240-249` (non-overlapping with inspector `190-199`).

2. **IPA heartbeat using unreachable K8s hostname** ([OSPRH-28474](https://redhat.atlassian.net/browse/OSPRH-28474)):
   Set `endpoint_override` to MetalLB VIP in conductor `[service_catalog]`.
   Uses [`ansible.utils.ipwrap`](https://docs.ansible.com/ansible/latest/collections/ansible/utils/ipwrap_filter.html)
   for IPv6 bracket wrapping (RFC 3986).

3. **Conductor dnsmasq missing UEFI boot directives** ([OSPRH-28474](https://redhat.atlassian.net/browse/OSPRH-28474)):
   ironic-operator conductor template lacks `dhcp-boot` lines (inspector
   template has them). Workaround patches `dnsmasq.conf` at runtime,
   gated by `ironic_conductor_dnsmasq_uefi_fix` toggle (default: `true`).
   Applied in both `ironic_adoption` and `nova_verify` because operator
   reconciliation can wipe the first patch ([OSPRH-28479](https://redhat.atlassian.net/browse/OSPRH-28479)).

4. **Conductor dnsmasq DHCP race** ([OSPRH-28474](https://redhat.atlassian.net/browse/OSPRH-28474)):
   Deployed instances get wrong IP from conductor pool (OVN doesn't serve
   `vif_type=other` ports). Workaround adds `dhcp-host` entry and reboots
   instance. Idempotent (skips if MAC already in config).

5. **Deploy images cleared with no fallback** ([OSPRH-28476](https://redhat.atlassian.net/browse/OSPRH-28476)):
   Sets httpboot IPA deploy images on nodes using conductor pod IP.
   Old code blanked `deploy_ramdisk`/`deploy_kernel` with no replacement.

**Additional fixes:**
- Clean stale nova-compute services blocking FFU version convergence
  (soft-delete via `UPDATE services SET deleted=id` where version < MAX)
- Wait for source Keystone availability before pre-launch tests
- Fix `wait_node_state` to use `--provision-state` server-side filter
  (replaces fragile `grep -P` with escaped column names)
- Fix `wait_image_active` to use `${image_name}` param (was hardcoded
  to `Fedora-Cloud-Base-38`)
- Add ERROR state detection in `wait_server_active` (early exit vs timeout)
- IPv6 URL bracket wrapping and CONDUCTOR_IP guards

**Tested** - full adoption pipeline (7/7 stages, ~10h):
deploy-infra → deploy-osp → deploy-ocp → install-operators →
install-shiftstack → run-adoption → run-shiftstack-after
([buildset 9821f411](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/buildset/9821f411e5284656bd82c9ba00a9135d))

**Bugs filed:**
- [OSPRH-28474](https://redhat.atlassian.net/browse/OSPRH-28474) - ironic-operator conductor dnsmasq template gaps (Critical)
- [OSPRH-28476](https://redhat.atlassian.net/browse/OSPRH-28476) - ironic_adoption clears deploy images with no fallback
- [OSPRH-28478](https://redhat.atlassian.net/browse/OSPRH-28478) - Ironic adoption doc missing ML2 and conductor dhcpRanges
- [OSPRH-28479](https://redhat.atlassian.net/browse/OSPRH-28479) - RFE: CR field for custom conductor dnsmasq directives

Related-Issue: [OSPRH-27919](https://redhat.atlassian.net/browse/OSPRH-27919)