### PR TITLE
Add ML2 baremetal mechanism driver support for Ironic adoption

### DIFF
--- a/docs_user/modules/proc_adopting-the-networking-service.adoc
+++ b/docs_user/modules/proc_adopting-the-networking-service.adoc
@@ -74,8 +74,8 @@ $ oc patch openstackcontrolplane openstack --type=merge --patch '
         dhcp_agent_notification = True
 '
 ----
-====
 +
+====
 [NOTE]
 ====
 If you are adopting the {bare_metal_first_ref}, you must configure the ML2 mechanism drivers to include both `ovn` and `baremetal`:

--- a/docs_user/modules/proc_adopting-the-networking-service.adoc
+++ b/docs_user/modules/proc_adopting-the-networking-service.adoc
@@ -75,6 +75,23 @@ $ oc patch openstackcontrolplane openstack --type=merge --patch '
 '
 ----
 ====
++
+[NOTE]
+====
+If you are adopting the {bare_metal_first_ref}, you must configure the ML2 mechanism drivers to include both `ovn` and `baremetal`:
+
+[source,shell]
+----
+$ oc patch openstackcontrolplane openstack --type=merge --patch '
+spec:
+  neutron:
+    template:
+      ml2MechanismDrivers:
+        - ovn
+        - baremetal
+'
+----
+====
 
 .Verification
 

--- a/docs_user/modules/proc_deploying-the-bare-metal-provisioning-service.adoc
+++ b/docs_user/modules/proc_deploying-the-bare-metal-provisioning-service.adoc
@@ -20,6 +20,7 @@ $ oc get openstackcontrolplanes.core.openstack.org <name> -o jsonpath='{.spec.ir
 +
 ** Replace `<name>` with the name of your existing `OpenStackControlPlane` CR, for example, `openstack-control-plane`.
 * The {identity_service_first_ref}, {networking_first_ref}, and {image_service_first_ref} are operational.
+* The {networking_service} is configured with the ML2 baremetal mechanism driver. For more information, see xref:adopting-the-networking-service_adopt-control-plane[Adopting the {networking_service}].
 +
 [NOTE]
 If you use the {bare_metal} in a Bare Metal as a Service configuration, do not adopt the {compute_service_first_ref} before you adopt the {bare_metal}.

--- a/tests/roles/neutron_adoption/defaults/main.yaml
+++ b/tests/roles/neutron_adoption/defaults/main.yaml
@@ -30,3 +30,11 @@ neutron_config_patch: |
         networkAttachments:
         - internalapi
 neutron_retry_delay: 5
+
+ironic_ml2_baremetal_patch:
+  spec:
+    neutron:
+      template:
+        ml2MechanismDrivers:
+          - ovn
+          - baremetal

--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -4,6 +4,13 @@
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch '{{ neutron_config_patch }}'
 
+- name: Patch neutron ml2MechanismDrivers to inlcude ml2 baremetal
+  when: ironic_adoption|bool
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_ml2_baremetal_patch }}'
+
 - name: wait for Neutron to start up
   ansible.builtin.shell: |
     {{ shell_header }}


### PR DESCRIPTION
Configure Neutron to include the baremetal mechanism driver when Ironic adoption is enabled. This adds a new patch configuration that extends ml2MechanismDrivers to include both ovn and baremetal, and applies it conditionally during the neutron_adoption role when ironic_adoption is true.

Closes: [OSPRH-28478](https://redhat.atlassian.net/browse/OSPRH-28478)