### PR TITLE
Enable IGMP snooping for uni06-zeta pre-adoption deployment

### DIFF
--- a/scenarios/uni06zeta/config_download.yaml
+++ b/scenarios/uni06zeta/config_download.yaml
@@ -51,6 +51,7 @@ parameter_defaults:
   ControllerCount: 3
   ComputeCount: 2
   NeutronGlobalPhysnetMtu: 1350
+  NeutronEnableIgmpSnooping: true
   CinderLVMLoopDeviceSize: 20480
   CloudName: overcloud.example.com
   CloudNameInternal: overcloud.internalapi.example.com


### PR DESCRIPTION
Add NeutronEnableIgmpSnooping to align with post-adoption configuration and tempest configuration.