### PR TITLE
Add test role for converting external Swift storage nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ test-swift-migration:
 	mkdir -p tests/logs
 	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_SECRETS) -e @$(TEST_VARS)  $(TEST_ARGS) tests/playbooks/test_swift_migration.yaml 2>&1 | tee $(TEST_OUTFILE)
 
+test-swift-conversion: TEST_OUTFILE ?= tests/logs/test_swift_conversion_out_$(shell date +%FT%T%Z).log
+test-swift-conversion:
+	mkdir -p tests/logs
+	ANSIBLE_CONFIG=$(TEST_CONFIG) ansible-playbook -v -i $(TEST_INVENTORY) -e @$(TEST_SECRETS) -e @$(TEST_VARS)  $(TEST_ARGS) tests/playbooks/test_swift_conversion.yaml 2>&1 | tee $(TEST_OUTFILE)
+
 test-ocp-as-gw: TEST_OUTFILE ?= tests/logs/test_ocp_as_gw_out_$(shell date +%FT%T%Z).log
 test-ocp-as-gw:  ## Launch test suite related to the ocp gateways
 	mkdir -p tests/logs

--- a/tests/playbooks/test_swift_conversion.yaml
+++ b/tests/playbooks/test_swift_conversion.yaml
@@ -1,0 +1,11 @@
+- name: Swift conversion
+  hosts: local
+  gather_facts: false
+  force_handlers: true
+  module_defaults:
+    ansible.builtin.shell:
+      executable: /bin/bash
+  roles:
+    - role: swift_conversion
+      tags:
+        - swift_conversion

--- a/tests/roles/swift_conversion/defaults/main.yaml
+++ b/tests/roles/swift_conversion/defaults/main.yaml
@@ -1,0 +1,85 @@
+---
+ansible_ssh_private_key_secret: dataplane-adoption-secret
+
+default_timesync_ntp_servers:
+  - hostname: pool.ntp.org
+
+swift_conversion_nodeset_name: openstack-edpm-ipam
+swift_conversion_deployment_name: openstack-edpm-ipam
+
+edpm_node_hostname: edpm-swift-0
+edpm_user: root
+
+edpm_bootstrap_command: |
+  # This is a hack to deploy RDO Delorean repos to RHEL as if it were Centos 9 Stream
+  set -euxo pipefail
+  curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
+  python3 -m venv ./venv
+  PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
+  # This is required for FIPS enabled until trunk.rdoproject.org
+  # is not being served from a centos7 host, tracked by
+  # https://issues.redhat.com/browse/RHOSZUUL-1517
+  dnf -y install crypto-policies
+  update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+  ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
+  rm -rf repo-setup-main
+
+swift_conversion_nodeset: |
+  apiVersion: dataplane.openstack.org/v1beta1
+  kind: OpenStackDataPlaneNodeSet
+  metadata:
+    name: {{ swift_conversion_nodeset_name }}
+  spec:
+    preProvisioned: true
+    networkAttachments:
+    - ctlplane
+    - storage
+    nodeTemplate:
+      ansible:
+        ansibleUser: {{ edpm_user }}
+        ansibleVars:
+          edpm_swift_disks: []
+          edpm_bootstrap_release_version_package: []
+          edpm_bootstrap_command: |
+            {{ edpm_bootstrap_command| indent(10) }}
+          edpm_nodes_validation_validate_controllers_icmp: false
+          edpm_nodes_validation_validate_gateway_icmp: false
+          edpm_service_removal_skip_list:
+          - tripleo-container-shutdown.service
+          edpm_sshd_allowed_ranges:
+          - 192.168.122.0/24
+          enable_debug: false
+          gather_facts: false
+          timesync_ntp_servers: {{ timesync_ntp_servers | default(default_timesync_ntp_servers) }}
+      ansibleSSHPrivateKeySecret: {{ ansible_ssh_private_key_secret }}
+      managementNetwork: ctlplane
+    nodes:
+      standalone:
+        ansible:
+          ansibleHost: "{{ standalone_ip | default(edpm_node_ip) }}"
+          ansibleVars:
+            edpm_swift_disks: []
+        hostName: "{{ edpm_node_hostname }}"
+        networks:
+        - defaultRoute: true
+          fixedIP: "{{ standalone_ip | default(edpm_node_ip) }}"
+          name: ctlplane
+          subnetName: subnet1
+        - name: internalapi
+          subnetName: subnet2
+        - name: storage
+          subnetName: subnet3
+        - name: tenant
+          subnetName: subnet4
+    services:
+    - bootstrap
+    - download-cache
+    - install-os
+    - configure-os
+    - ssh-known-hosts
+    - run-os
+    - reboot-os
+    - install-certs
+    - tripleo-cleanup
+    - swift
+    tlsEnabled: {{ enable_tlse }}

--- a/tests/roles/swift_conversion/meta/main.yaml
+++ b/tests/roles/swift_conversion/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: common_defaults

--- a/tests/roles/swift_conversion/tasks/main.yaml
+++ b/tests/roles/swift_conversion/tasks/main.yaml
@@ -1,0 +1,70 @@
+- name: Patch the OpenStackControlPlane CR to change the Swift default storage ports
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ cells_env }}
+
+    cat > swift-config-patch.yaml << EOF
+    spec:
+      swift:
+        template:
+          swiftStorage:
+            defaultConfigOverwrite:
+              01-account-server.conf: |
+                [DEFAULT]
+                bind_port = 6002
+              01-container-server.conf: |
+                [DEFAULT]
+                bind_port = 6001
+              01-object-server.conf: |
+                [DEFAULT]
+                bind_port = 6000
+    EOF
+
+- name: Apply the patch file
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc patch openstackcontrolplane openstack --type=merge --patch-file=swift-config-patch.yaml
+
+- name: Create OpenStackDataPlaneNodeSet for Swift node conversion
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    {{ swift_conversion_nodeset }}
+    EOF
+
+- name: Create OpenStackDataPlaneDeployment to trigger conversion
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneDeployment
+    metadata:
+      name: {{ swift_conversion_deployment_name }}
+      namespace: openstack
+    spec:
+      nodeSets:
+      - {{ swift_conversion_nodeset_name }}
+    EOF
+
+- name: Wait for the Swift node conversion deployment to finish
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc wait --for condition=Ready openstackdataplanedeployment/{{ swift_conversion_deployment_name }} --timeout=30m
+
+- name: Verify Swift services are running on converted node
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    ssh -o StrictHostKeyChecking=accept-new -i {{ edpm_privatekey_path }} {{ edpm_user }}@{{ standalone_ip | default(edpm_node_ip) }} "sudo systemctl status edpm_swift_*"
+
+- name: Verify Swift is still functional after conversion
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc rsh openstackclient /bin/sh -c "touch obj && openstack container create cont && openstack object create cont obj"


### PR DESCRIPTION
Swift adoption is a two-stage process:

- Stage 1 (role swift_adoption) adopts the control plane and ring configuration. The Swift proxy service will run on OpenShift afterwards, Swift storage services will remain on the former nodes (either control plane or external storage nodes).

- Stage 2 differs based on the goal:
  - either migrate data (eg. from control planes to PVs or dataplane nodes) using the existing role (swift_migration)
  - or convert existing nodes in place (eg. external ObjectStorage nodes) using the new role (swift_conversion).

This commit adds the test role for the conversion. This is basically a Swift storage dataplane deployment using pre-provisioned nodes, disabling the former TripleO services.

After running the initial control plane adoption, delete the existing OpenStackDataPlaneNodeSet before starting the conversion test. For example:

make test-minimal
oc delete --ignore-not-found=true OpenStackDataPlaneNodeSet --all make test-swift-conversion

JIRA: [OSPRH-28625](https://redhat.atlassian.net/browse/OSPRH-28625)