### PR TITLE
Use combined swift-conversion service for rolling node conversion

### DIFF
--- a/docs_user/modules/proc_converting-object-storage-nodes.adoc
+++ b/docs_user/modules/proc_converting-object-storage-nodes.adoc
@@ -19,11 +19,9 @@ Pre-provisioned nodes:: Setting `preProvisioned: true` in the
   Existing disk mounts are untouched. The `SwiftRawDisks` parameter from
   {OpenStackPreviousInstaller} is not migrated or converted. Disks on
   converted nodes must be managed manually.
-Rolling conversion with multiple node sets:: In production, do not convert
-  all {object_storage} nodes at once. Instead, create separate
-  `OpenStackDataPlaneNodeSet` custom resources and deploy them sequentially.  Align
-  groups with ring zones or regions so that no more than one replica of any
-  partition is affected during the conversion.
+Rolling conversion:: The `swift-conversion` service uses `serial: 1` by
+  default, which converts one node at a time to keep the {object_storage}
+  available.
 
 .Prerequisites
 
@@ -89,18 +87,41 @@ $ oc patch openstackcontrolplane openstack --type=merge --patch-file=swift-confi
 ----
 
 . Create a `OpenStackDataPlaneService` CR to remove remaining
-  {OpenStackPreviousInstaller} artifacts, such as containers, `systemd` units, and
-  configuration, from the node:
+  {OpenStackPreviousInstaller} artifacts and deploy the {object_storage} services
+  on the node:
 +
 ----
 $ oc apply -f - <<EOF
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: tripleo-cleanup
+  name: swift-conversion
   namespace: openstack
 spec:
-  playbook: osp.edpm.tripleo_cleanup
+  addCertMounts: false
+  caCerts: combined-ca-bundle
+  edpmServiceType: swift
+  dataSources:
+  - secretRef:
+      name: swift-conf
+  - configMapRef:
+      name: swift-storage-config-data
+  - configMapRef:
+      name: swift-ring-files
+  playbookContents: |
+    - name: Cleanup and deploy Swift
+      hosts: "{{ edpm_override_hosts | default('all', true) }}"
+      serial: 1
+      strategy: linear
+      gather_facts: "{{ gather_facts | default(false) }}"
+      any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+      max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+      environment: "{{ edpm_playbook_environment | default({}) }}"
+      tasks:
+        - ansible.builtin.import_role:
+            name: osp.edpm.edpm_tripleo_cleanup
+        - ansible.builtin.import_role:
+            name: osp.edpm.edpm_swift
 EOF
 ----
 
@@ -225,8 +246,7 @@ endif::[]
   - run-os
   - reboot-os
   - install-certs
-  - tripleo-cleanup
-  - swift
+  - swift-conversion
   tlsEnabled: true
 ----
 

--- a/tests/roles/swift_conversion/defaults/main.yaml
+++ b/tests/roles/swift_conversion/defaults/main.yaml
@@ -80,6 +80,5 @@ swift_conversion_nodeset: |
     - run-os
     - reboot-os
     - install-certs
-    - tripleo-cleanup
-    - swift
+    - swift-conversion
     tlsEnabled: {{ enable_tlse }}

--- a/tests/roles/swift_conversion/tasks/main.yaml
+++ b/tests/roles/swift_conversion/tasks/main.yaml
@@ -27,6 +27,42 @@
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch-file=swift-config-patch.yaml
 
+- name: Create OpenStackDataPlaneService for Swift conversion
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    oc apply -f - <<EOF
+    apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneService
+    metadata:
+      name: swift-conversion
+    spec:
+      addCertMounts: false
+      caCerts: combined-ca-bundle
+      edpmServiceType: swift
+      dataSources:
+      - secretRef:
+          name: swift-conf
+      - configMapRef:
+          name: swift-storage-config-data
+      - configMapRef:
+          name: swift-ring-files
+      playbookContents: |
+        - name: Cleanup and deploy Swift
+          hosts: "{{ edpm_override_hosts | default('all', true) }}"
+          serial: 1
+          strategy: linear
+          gather_facts: "{{ gather_facts | default(false) }}"
+          any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+          max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+          environment: "{{ edpm_playbook_environment | default({}) }}"
+          tasks:
+            - ansible.builtin.import_role:
+                name: osp.edpm.edpm_tripleo_cleanup
+            - ansible.builtin.import_role:
+                name: osp.edpm.edpm_swift
+    EOF
+
 - name: Create OpenStackDataPlaneNodeSet for Swift node conversion
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
Combines the tripleo-cleanup and swift services in a single swift-conversion service. By using "serial: 1" Swift storage servers are stopped only on a single node at a time. This way there is no service interruption when using three replicas (default) - two storage nodes will be always available.

JIRA: [OSPRH-28625](https://redhat.atlassian.net/browse/OSPRH-28625)