### PR TITLE
cinder:  backend_host and volume_backend_name from 17.1

### DIFF
--- a/tests/roles/cinder_adoption/templates/cinder_volume_netapp_iscsi.yaml.j2
+++ b/tests/roles/cinder_adoption/templates/cinder_volume_netapp_iscsi.yaml.j2
@@ -7,7 +7,8 @@ spec:
             - storage
           customServiceConfig: |
             [{{ cinder_netapp_backend }}]
-            volume_backend_name=ontap-iscsi
+            backend_host=hostgroup
+            volume_backend_name={{ cinder_netapp_backend }}
             volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
             netapp_storage_protocol=iscsi
             netapp_storage_family=ontap_cluster

--- a/tests/roles/cinder_adoption/templates/cinder_volume_netapp_nfs.yaml.j2
+++ b/tests/roles/cinder_adoption/templates/cinder_volume_netapp_nfs.yaml.j2
@@ -7,7 +7,8 @@ spec:
             - storage
           customServiceConfig: |
             [{{ cinder_netapp_backend }}]
-            volume_backend_name=ontap-nfs
+            backend_host=hostgroup
+            volume_backend_name={{ cinder_netapp_backend }}
             volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
             netapp_storage_protocol=nfs
             netapp_storage_family=ontap_cluster

--- a/tests/roles/cinder_adoption/templates/cinder_volume_pure_fc.yaml.j2
+++ b/tests/roles/cinder_adoption/templates/cinder_volume_pure_fc.yaml.j2
@@ -7,7 +7,8 @@ spec:
             - storage
           customServiceConfig: |
             [{{ cinder_pure_backend }}]
-            volume_backend_name=pure-fc
+            backend_host=hostgroup
+            volume_backend_name={{ cinder_pure_backend }}
             volume_driver=cinder.volume.drivers.pure.PureFCDriver
             consistencygroup_support=True
           customServiceConfigSecrets:


### PR DESCRIPTION
This change makes sure that
- makes sure that volume_backend_name has the same value as the overall section, matching the value from 17.1;
- adds backend_host=hostgroup to the templates for the cinder volume configuration which were missing it.

If these keys are not assigned the same value as in 17.1, cinder won't be able to manage the volumes created before the adoption, because they will be assigned a new value for os-vol-host-attr:host, and the value for volume_backend_name set so far did not match the old value.