### PR TITLE
Fix neutron-adoption with ironic

### DIFF
--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -4,12 +4,12 @@
     {{ oc_header }}
     oc patch openstackcontrolplane openstack --type=merge --patch '{{ neutron_config_patch }}'
 
-- name: Patch neutron ml2MechanismDrivers to inlcude ml2 baremetal
+- name: Patch neutron ml2MechanismDrivers to include ml2 baremetal
   when: ironic_adoption|bool
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_ml2_baremetal_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_ml2_baremetal_patch | to_json }}'
 
 - name: wait for Neutron to start up
   ansible.builtin.shell: |


### PR DESCRIPTION
Fix a conversion issue in neutron-adoption, the task triggers a bug:

[..]
oc patch openstackcontrolplane openstack --type=merge --patch '{'spec': {'neutron': {'template': {'ml2MechanismDrivers': ['ovn', 'baremetal']}}}}' Error from server (BadRequest): error decoding patch: invalid character 's' looking for beginning of object key string [..]

ironic_ml2_baremetal_patch is an ansible object, it needs to be converted to a json string before it's used in an oc patch command