### PR TITLE
octavia-adoption: perform failover only on amphora LBs

### DIFF
--- a/docs_user/modules/proc_performing-post-adoption-cleanup-of-load-balancers.adoc
+++ b/docs_user/modules/proc_performing-post-adoption-cleanup-of-load-balancers.adoc
@@ -21,12 +21,15 @@ $ alias openstack="oc exec -t openstackclient -- openstack"
 $ openstack loadbalancer create --vip-subnet-id public-subnet --name lb-post-adoption --wait
 ----
 
-. Trigger a failover for all existing load balancers to upgrade the amphorae virtual machines to use the new image and to establish connectivity with the new control plane:
+. Trigger a failover for all existing amphora load balancers to upgrade the amphorae virtual machines to use the new image and to establish connectivity with the new control plane:
 +
 ----
-$ openstack loadbalancer list -f value -c id | \
+$ openstack loadbalancer list -f value -c id --provider amphora | \
       xargs -r -n1 -P4 ${BASH_ALIASES[openstack]} loadbalancer failover --wait
 ----
++
+[NOTE]
+OVN load balancers don't support failover as they don't need to be updated during upgrades.
 
 . Delete old flavors that were migrated to the new control plane:
 +

--- a/docs_user/modules/proc_performing-post-adoption-cleanup-of-load-balancers.adoc
+++ b/docs_user/modules/proc_performing-post-adoption-cleanup-of-load-balancers.adoc
@@ -29,7 +29,7 @@ $ openstack loadbalancer list -f value -c id --provider amphora | \
 ----
 +
 [NOTE]
-Failover is not applicable to OVN load balancers. As native components of the OVN infrastructure, they do not require actions during upgrades and updates.
+Failover does not apply to OVN load balancers. As native components of the OVN infrastructure, they do not require actions during upgrades and updates.
 
 . Delete old flavors that were migrated to the new control plane:
 +

--- a/docs_user/modules/proc_performing-post-adoption-cleanup-of-load-balancers.adoc
+++ b/docs_user/modules/proc_performing-post-adoption-cleanup-of-load-balancers.adoc
@@ -29,7 +29,7 @@ $ openstack loadbalancer list -f value -c id --provider amphora | \
 ----
 +
 [NOTE]
-OVN load balancers don't support failover as they don't need to be updated during upgrades.
+Failover is not applicable to OVN load balancers. As native components of the OVN infrastructure, they do not require actions during upgrades and updates.
 
 . Delete old flavors that were migrated to the new control plane:
 +

--- a/tests/roles/dataplane_adoption/tasks/octavia_post.yaml
+++ b/tests/roles/dataplane_adoption/tasks/octavia_post.yaml
@@ -43,7 +43,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ octavia_header }}
-    ${BASH_ALIASES[openstack]} loadbalancer list -f value -c id --not-tag new | \
+    ${BASH_ALIASES[openstack]} loadbalancer list -f value -c id --not-tag new --provider amphora | \
       xargs -r -n1 -P4 ${BASH_ALIASES[openstack]} loadbalancer failover --wait
 
 - name: check for existing load balancer


### PR DESCRIPTION
During our tests, tobiko creates an ovn load balancer in the source cloud.
ovn load balancers don't support failovers so they need to be skipped in the "perform failover of existing load balancers" task. Update the docs accordingly.