### PR TITLE
[BUGFIX] Remove ExtraConfig virt_type

### DIFF
--- a/scenarios/dcn_nostorage/central/config_download.yaml
+++ b/scenarios/dcn_nostorage/central/config_download.yaml
@@ -46,11 +46,6 @@ parameter_defaults:
       use_neutron: false
   ControllerExtraConfig:
     nova::availability_zone::default_schedule_zone: az-central
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/dcn_nostorage/dcn1/config_download.yaml
+++ b/scenarios/dcn_nostorage/dcn1/config_download.yaml
@@ -43,12 +43,7 @@ parameter_defaults:
     - ip_address: 192.168.122.111
       use_neutron: false
   ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
     nova::availability_zone::default_schedule_zone: az-central
-  ComputeDcn1ExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/dcn_nostorage/dcn2/config_download.yaml
+++ b/scenarios/dcn_nostorage/dcn2/config_download.yaml
@@ -43,12 +43,7 @@ parameter_defaults:
     - ip_address: 192.168.122.111
       use_neutron: false
   ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
     nova::availability_zone::default_schedule_zone: az-central
-  ComputeDcn2ExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/hci/config_download.yaml
+++ b/scenarios/hci/config_download.yaml
@@ -42,12 +42,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/uni01alpha/config_download.yaml
+++ b/scenarios/uni01alpha/config_download.yaml
@@ -47,12 +47,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.131
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   NeutronDnsDomain: 'example.com'
   BarbicanSimpleCryptoGlobalDefault: true
   SwiftEncryptionEnabled: true

--- a/scenarios/uni02beta/config_download.yaml
+++ b/scenarios/uni02beta/config_download.yaml
@@ -39,12 +39,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni04delta-ipv6/config_download.yaml
+++ b/scenarios/uni04delta-ipv6/config_download.yaml
@@ -39,12 +39,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 2620:cf:cf:aaaa::83
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   ExtraConfig:
     neutron::notification_driver: 'noop'
     neutron::config::plugin_ml2_config:

--- a/scenarios/uni04delta/config_download.yaml
+++ b/scenarios/uni04delta/config_download.yaml
@@ -40,12 +40,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   ExtraConfig:
     neutron::notification_driver: 'noop'
   BarbicanSimpleCryptoGlobalDefault: true

--- a/scenarios/uni05epsilon/config_download_cell1.yaml
+++ b/scenarios/uni05epsilon/config_download_cell1.yaml
@@ -60,9 +60,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.121
       use_neutron: false
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni05epsilon/config_download_cell2.yaml
+++ b/scenarios/uni05epsilon/config_download_cell2.yaml
@@ -60,9 +60,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.122
       use_neutron: false
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni05epsilon/config_download_overcloud.yaml
+++ b/scenarios/uni05epsilon/config_download_overcloud.yaml
@@ -42,9 +42,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.120
       use_neutron: false
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman

--- a/scenarios/uni06zeta/config_download.yaml
+++ b/scenarios/uni06zeta/config_download.yaml
@@ -38,12 +38,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.131
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true

--- a/scenarios/uni07eta/config_download.yaml
+++ b/scenarios/uni07eta/config_download.yaml
@@ -42,12 +42,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   ExtraConfig:
     neutron::notification_driver: 'noop'
     neutron::plugins::ml2::path_mtu: 1400

--- a/scenarios/uni09iota/config_download.yaml
+++ b/scenarios/uni09iota/config_download.yaml
@@ -39,12 +39,6 @@ parameter_defaults:
   OVNDBsVirtualFixedIPs:
     - ip_address: 192.168.122.111
       use_neutron: false
-  ControllerExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::virt_type: qemu
   BarbicanSimpleCryptoGlobalDefault: true
   Debug: true
   DockerPuppetDebug: true


### PR DESCRIPTION
## Summary

Removes redundant `virt_type` entries from `ExtraConfig` blocks across 14 scenario `config_download.yaml` files. These entries override the Hiera priority chain unnecessarily and cause adoption failures when the target RHOSO environment uses a different libvirt type.

Preserves all non-virt_type entries (e.g. `nova::availability_zone` in DCN scenarios).

This is a resubmission of #1292 which was mistakenly merged to `downstream` instead of `main`. Identical change, correct target branch this time.

CI-verified in shiftstack adoption pipeline (buildset ed0ebfeb, 6/6 stages SUCCESS).

Related: [OSPRH-27919](https://redhat.atlassian.net/browse/OSPRH-27919)