### PR TITLE
neutron: use YAML literal for ironic_ml2_baremetal patch

### DIFF
--- a/tests/roles/neutron_adoption/defaults/main.yaml
+++ b/tests/roles/neutron_adoption/defaults/main.yaml
@@ -31,7 +31,7 @@ neutron_config_patch: |
         - internalapi
 neutron_retry_delay: 5
 
-ironic_ml2_baremetal_patch:
+ironic_ml2_baremetal_patch: |
   spec:
     neutron:
       template:


### PR DESCRIPTION
The | block is required so the value is a string passed to oc patch --patch. A nested mapping serializes to invalid JSON and the API rejects the merge patch.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3917/

Co-authored-by: Cursor <cursoragent@cursor.com>