### PR TITLE
Use server-side apply for swift-ring-files ConfigMap

### DIFF
--- a/docs_user/modules/proc_adopting-the-object-storage-service.adoc
+++ b/docs_user/modules/proc_adopting-the-object-storage-service.adoc
@@ -30,7 +30,7 @@ EOF
 . Create the `swift-ring-files` `ConfigMap` that includes the {object_storage} ring files:
 +
 ----
-$ oc apply -f - <<EOF
+$ oc apply --server-side -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,6 +42,13 @@ binaryData:
   object.ring.gz: $($CONTROLLER1_SSH "base64 -w0 /var/lib/config-data/puppet-generated/swift/etc/swift/object.ring.gz")
 EOF
 ----
++
+[NOTE]
+====
+The `--server-side` flag is required if the {object_storage} ring files
+are large enough to exceed the annotation size limit imposed by the
+client-side `oc apply`.
+====
 
 . Patch the `OpenStackControlPlane` custom resource to deploy the {object_storage}:
 +

--- a/tests/roles/swift_adoption/tasks/main.yaml
+++ b/tests/roles/swift_adoption/tasks/main.yaml
@@ -18,7 +18,7 @@
     {{ shell_header }}
     {{ oc_header }}
     CONTROLLER1_SSH="{{ controller1_ssh }}"
-    oc apply -f - <<EOF
+    oc apply --server-side -f - <<EOF
     apiVersion: v1
     kind: ConfigMap
     metadata:


### PR DESCRIPTION
Client-side `oc apply` writes the entire manifest into the last-applied-configuration annotation, which can exceed the limit when Swift ring files are large. Using `oc apply --server-side` avoids this annotation entirely while remaining idempotent, unlike `oc create` which would fail on retries if the resource already exists.

Closes: [OSPRH-25258](https://redhat.atlassian.net/browse/OSPRH-25258)