### PR TITLE
[neutron_adoption] Fix JSON serialization for ml2 baremetal patch

### DIFF
--- a/tests/roles/neutron_adoption/tasks/main.yaml
+++ b/tests/roles/neutron_adoption/tasks/main.yaml
@@ -9,7 +9,7 @@
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
-    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_ml2_baremetal_patch }}'
+    oc patch openstackcontrolplane openstack --type=merge --patch '{{ ironic_ml2_baremetal_patch | to_json }}'
 
 - name: wait for Neutron to start up
   ansible.builtin.shell: |


### PR DESCRIPTION
The `ironic_ml2_baremetal_patch` variable is a YAML dict, not a string. Without the `to_json `filter, Ansible renders it as a Python repr with single quotes, which oc patch rejects as invalid JSON. This breaks adoption jobs that include ironic (e.g. uni04delta-ipv6).

e.g.

```
TASK [neutron_adoption : Patch neutron ml2MechanismDrivers to inlcude ml2 baremetal] ***
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "set -euxo pipefail\n\n\noc patch openstackcontrolplane openstack --type=merge --patch '{'spec': {'neutron': {'template': {'ml2MechanismDrivers': ['ovn', 'baremetal']}}}}'\n", "delta": "0:00:00.165346", "end": "2026-05-12 03:16:53.552724", "msg": "non-zero return code", "rc": 1, "start": "2026-05-12 03:16:53.387378", "stderr": "+ oc patch openstackcontrolplane openstack --type=merge --patch '{spec: {neutron: {template: {ml2MechanismDrivers: [ovn, baremetal]}}}}'\nError from server (BadRequest): error decoding patch: invalid character 's' looking for beginning of object key string", "stderr_lines": ["+ oc patch openstackcontrolplane openstack --type=merge --patch '{spec: {neutron: {template: {ml2MechanismDrivers: [ovn, baremetal]}}}}'", "Error from server (BadRequest): error decoding patch: invalid character 's' looking for beginning of object key string"], "stdout": "", "stdout_lines": []}
```

Co-Authored-By: Cursor (claude-sonnet-4-20250514)