### PR TITLE
keystone ldap adoption testing

### DIFF
--- a/scenarios/hci.yaml
+++ b/scenarios/hci.yaml
@@ -24,6 +24,7 @@ undercloud:
   ctlplane_vip: 192.168.122.98
 cloud_domain: "ooo.test"
 tlse: true
+enable_keystone_ldap: true
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for
   # 17.1 deployment

--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -1,3 +1,14 @@
+# IPA-related variables
+ipa_hostname: "osp-free-ipa-0.ooo.test"
+# Short hostname for SSH to the FreeIPA server
+ipa_ssh_host: "{{ ipa_hostname.split('.')[0] }}"
+# ci-framework test-operator default is ~/.ssh/id_cifw (e.g. /home/zuul/.ssh/id_cifw in Zuul)
+controller_ssh_identity_file: "{{ cifmw_test_operator_controller_priv_key_file_path | default(edpm_privatekey_path) }}"
+# OpenShift cluster DNS forwarding for the IPA/LDAP domain (TLS-E)
+openshift_dns_forward_zone: "{{ ipa_hostname.split('.')[1:] | join('.') }}"
+openshift_dns_forward_upstream: "192.168.111.30"
+ipa_admin_password: "nomoresecrets"
+ipa_user_password: "nomoresecrets"
 prelaunch_test_instance: true
 prelaunch_test_instance_scripts:
   - pre_launch.bash

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -233,3 +233,52 @@
     cmd: |
       {{ shell_header }}
       curl {{ octavia_vip_address.stdout }}
+
+- name: Add IPA domain to Keystone and create IPA users
+  when: enable_keystone_ldap | default(false) | bool
+  block:
+    - name: Configure OpenShift cluster DNS forwarding for IPA domain
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ oc_header }}
+        oc apply -f - <<EOF
+        apiVersion: operator.openshift.io/v1
+        kind: DNS
+        metadata:
+          name: default
+        spec:
+          servers:
+          - name: internal-forwarder
+            zones:
+            - {{ openshift_dns_forward_zone }}
+            forwardPlugin:
+              upstreams:
+              - {{ openshift_dns_forward_upstream }}
+        EOF
+
+    - name: SSH into IPA host and execute IPA commands
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        ssh -o StrictHostKeyChecking=accept-new -i {{ controller_ssh_identity_file }} root@{{ ipa_ssh_host }} "echo {{ ipa_admin_password }} | kinit admin;\
+          ipa user-add svc-ldap --first=Openstack --last=LDAP;\
+          echo {{ ipa_admin_password }} | ipa passwd svc-ldap;\
+          ipa user-add ipauser1 --first=ipa1 --last=user1;\
+          echo {{ ipa_user_password }} | ipa passwd ipauser1;\
+          ipa user-add ipauser2 --first=ipa2 --last=user2;\
+          echo {{ ipa_user_password }} | ipa passwd ipauser2;\
+          ipa user-add ipauser3 --first=ipa3 --last=user3;\
+          echo {{ ipa_user_password }} | ipa passwd ipauser3;\
+          ipa group-add --desc=\"OpenStack Users\" grp-openstack;\
+          ipa group-add --desc=\"OpenStack Admin Users\" grp-openstack-admin;\
+          ipa group-add --desc=\"OpenStack Demo Users\" grp-openstack-demo;\
+          ipa group-add-member --users=svc-ldap grp-openstack;\
+          ipa group-add-member --users=ipauser1 grp-openstack;\
+          ipa group-add-member --users=ipauser1 grp-openstack-admin;\
+          ipa group-add-member --users=ipauser2 grp-openstack;\
+          ipa group-add-member --users=ipauser2 grp-openstack-demo;\
+          ipa group-add-member --users=ipauser3 grp-openstack;"
+
+    - name: Add REDHAT domain to Keystone
+      ansible.builtin.shell: |
+        {{ shell_header }}
+        {{ openstack_command }} domain create --description \"Test LDAP Domain\" REDHAT

--- a/tests/roles/keystone_adoption/defaults/main.yaml
+++ b/tests/roles/keystone_adoption/defaults/main.yaml
@@ -70,3 +70,54 @@ keystone_patch_federation: |
         secret: osp-secret
 
 keystone_retry_delay: 30
+
+keystone_patch_ldap: |
+  spec:
+    keystone:
+      enabled: true
+      apiOverride:
+        route: {}
+      template:
+        customServiceConfig: |
+          [token]
+          expiration = 360000
+          [identity]
+          domain_specific_drivers_enabled = true
+        extraMounts:
+          - name: v1
+            region: r1
+            extraVol:
+              - propagation:
+                - Keystone
+                extraVolType: Conf
+                volumes:
+                - name: keystone-domains
+                  secret:
+                    secretName: keystone-domains
+                mounts:
+                - name: keystone-domains
+                  mountPath: "/etc/keystone/domains"
+                  readOnly: true
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  {% if ipv6_enabled | default(false) -%}
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix_ipv6 | default('2620:cf:cf:bbbb') }}::50
+                  {%- else -%}
+                  metallb.universe.tf/loadBalancerIPs: {{ internalapi_prefix | default('172.17.0') }}.80
+                  {%- endif %}
+
+              spec:
+                type: LoadBalancer
+        databaseInstance: openstack
+        secret: osp-secret
+
+# IPA-related variables
+ipa_hostname: "osp-free-ipa-0.ooo.test"
+ipa_ssh_host: "{{ ipa_hostname.split('.')[0] }}"
+ipa_admin_password: "nomoresecrets"
+ipa_user_password: "nomoresecrets"

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -16,12 +16,52 @@
     type: Opaque
     EOF
 
+- name: Set IPA BaseDN var
+  ansible.builtin.set_fact:
+    ipa_basedn: "dc={{ ipa_hostname.split('.')[1:] | join(',dc=') }}"
+  when: enable_keystone_ldap | default(false) | bool
+
+- name: Create Keystone domain config secret for LDAP
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    cat <<EOF | oc apply -n openstack -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: keystone-domains
+    type: Opaque
+    stringData:
+      keystone.{{ ipa_domain | default('REDHAT') }}.conf: |
+        [identity]
+        driver = ldap
+        [ldap]
+        url = ldaps://osp-free-ipa-0.ooo.test
+        user = uid=svc-ldap,cn=users,cn=accounts,{{ ipa_basedn }}
+        password = {{ ipa_admin_password | default('nomoresecrets') }}
+        suffix = {{ ipa_basedn }}
+        user_tree_dn = cn=users,cn=accounts,{{ ipa_basedn }}
+        user_objectclass = person
+        user_id_attribute = uid
+        user_name_attribute = uid
+        user_mail_attribute = mail
+        group_tree_dn = cn=groups,cn=accounts,{{ ipa_basedn }}
+        group_objectclass = groupOfNames
+        group_id_attribute = cn
+        group_name_attribute = cn
+        group_member_attribute = member
+        group_desc_attribute = description
+    EOF
+  when: enable_keystone_ldap | default(false) | bool
+
 - name: deploy podified Keystone
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}
     if {{ enable_federation | default(false) | lower }} == true; then
       oc patch openstackcontrolplane openstack --type=merge --patch '{{ keystone_patch_federation }}'
+    elif {{ enable_keystone_ldap | default(false) | lower }}; then
+      oc patch openstackcontrolplane openstack --type=merge --patch '{{ keystone_patch_ldap }}'
     else
       oc patch openstackcontrolplane openstack --type=merge --patch '{{ keystone_patch }}'
     fi
@@ -183,3 +223,23 @@
     ${BASH_ALIASES[openstack]} credential show {{ before_adoption_credential.stdout }} -f value -c blob
   register: after_adoption_credential
   failed_when: after_adoption_credential.stdout != 'test'
+
+- name: get ldap user token
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+
+    alias openstack="oc exec -t openstackclient -- openstack"
+
+    auth_url=$(${BASH_ALIASES[openstack]} endpoint list --service keystone --interface public -f value -c URL)
+
+    alias openstack="oc exec -t openstackclient -- env -u OS_CLOUD - OS_AUTH_URL=${auth_url} OS_USERNAME=ipauser1 OS_PASSWORD={{ ipa_user_password }} OS_PROJECT_DOMAIN_NAME=REDHAT OS_USER_DOMAIN_NAME=REDHAT openstack"
+
+    ${BASH_ALIASES[openstack]} token issue -f json
+  register: keystone_ldap_responding_result
+  when: enable_keystone_ldap | default(false) | bool
+
+- name: Print ldap user token
+  ansible.builtin.debug:
+    var: keystone_ldap_responding_result
+  when: enable_keystone_ldap | default(false) | bool


### PR DESCRIPTION
LDAP adoption testing will add a ldap domain to keystone. This ldap connection will be to the freeipa server setup for tlse environments on a multinode adoption job.

Jira: https://issues.redhat.com/browse/OSPRH-6861