### PR TITLE
neutron_verify, nova_verify: skip pre_launch.bash checks when it did not run

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/neutron_verify.yaml
@@ -49,9 +49,11 @@
     success_msg: "neutron-dhcp-agent is ALIVE after adoption"
 
 - name: verify connectivity to the existing test VM instance using Floating IP
-  when: prelaunch_test_instance|bool
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
   ansible.builtin.shell: |
-      ping -c4 {{ lookup('env', 'FIP') | default(public_subnet_fip_1, True) }}
+      {{ ping_command }} -c4 {{ lookup('env', 'FIP') | default(public_subnet_fip_1, True) }}
 
 - name: validate pings, new workloads after adoption and cleanup
   when: neutron_qe_test | default('false') | bool

--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -5,14 +5,18 @@
       alias openstack="oc exec -t openstackclient -- openstack"
 
 - name: verify if the image save works
-  when: prelaunch_test_instance|bool
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
   ansible.builtin.shell: |
     {{ nova_header }}
     ${BASH_ALIASES[openstack]} image save cirros --file /tmp/cirrossave.img
 
 # NOTE(bogdando): do not use 'set -o pipefail' for these verifications
 - name: verify if the existing test VM instance is running
-  when: prelaunch_test_instance|bool
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
   ansible.builtin.shell: |
     {{ nova_header }}
     ${BASH_ALIASES[openstack]} server --os-compute-api-version 2.48 show --diagnostics test 2>&1 || echo FAIL
@@ -21,7 +25,9 @@
     - ("FAIL" in nova_verify_running_result.stdout_lines)
 
 - name: verify if the Compute services can stop the existing test VM instance
-  when: prelaunch_test_instance|bool
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
   ansible.builtin.shell: |
     {{ nova_header }}
     ${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test ACTIVE" && ${BASH_ALIASES[openstack]} server stop test || echo PASS
@@ -35,7 +41,9 @@
   delay: "{{ dataplane_retry_delay }}"
 
 - name: verify if the Compute services can start the existing test VM instance
-  when: prelaunch_test_instance|bool
+  when:
+    - prelaunch_test_instance|bool
+    - "'pre_launch.bash' in prelaunch_test_instance_scripts"
   ansible.builtin.shell: |
     {{ nova_header }}
     ${BASH_ALIASES[openstack]} server list -c Name -c Status -f value | grep -qF "test SHUTOFF" && ${BASH_ALIASES[openstack]} server start test || echo PASS


### PR DESCRIPTION
## Problem

Several post-adoption verification tasks in neutron_verify.yaml and
nova_verify.yaml are guarded only by `prelaunch_test_instance|bool`.
These tasks assume pre_launch.bash ran and created the cirros image,
test VM, and floating IP. When only pre_launch_ironic.bash runs (e.g.
test_with_ceph_and_ironic), none of those resources exist and the
verifications fail.

This is particularly visible in IPv6 scenarios like uni04delta-ipv6
where the public_subnet_fip_1 default (192.168.122.20) is an IPv4
address unreachable on a pure-IPv6 network.

## Fix

Add the `pre_launch.bash` guard to all affected tasks, matching the
pattern already used in `octavia_post.yaml` and `nova_verify.yaml`
(ironic task). Also replace the hardcoded `ping` in neutron_verify
with the `ping_command` variable for consistency with
`pre_launch.bash.j2` and BGP scenario support.

Affected tasks:
- **neutron_verify**: FIP connectivity ping
- **nova_verify**: cirros image save, test VM diagnostics, stop, start