### PR TITLE
[18.0-fr5] neutron: use YAML literal for ironic_ml2_baremetal patch

### DIFF
--- a/tests/roles/neutron_adoption/defaults/main.yaml
+++ b/tests/roles/neutron_adoption/defaults/main.yaml
@@ -30,3 +30,11 @@ neutron_config_patch: |
         networkAttachments:
         - internalapi
 neutron_retry_delay: 5
+
+ironic_ml2_baremetal_patch: |
+  spec:
+    neutron:
+      template:
+        ml2MechanismDrivers:
+          - ovn
+          - baremetal


### PR DESCRIPTION
The | block is required so the value is a string passed to oc patch --patch. A nested mapping serializes to invalid JSON and the API rejects the merge patch.


(cherry picked from commit 3d5a0289ae359680940ea9c3dc1991071c255433)