### PR TITLE
Remove custom OVN ConfigMap/DataPlaneService workaround for DCN

### DIFF
--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -393,9 +393,6 @@ dataplane_cr: |
           ovn_monitor_all: true
           edpm_ovn_remote_probe_interval: 60000
           edpm_ovn_ofctrl_wait_before_clear: 8000
-          {% if edpm_ovn_dbs_nodeset is defined -%}
-          edpm_ovn_dbs: {{ edpm_ovn_dbs_nodeset }}
-          {%+ endif +%}
     nodes:
 
 dpa_dir: "../.."

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -411,100 +411,11 @@
     {% endif %}
     {% endfor %}
 
-- name: Get OVN SB internalapi IPs for DCN nodesets
-  when: edpm_nodes_dcn1 is defined or edpm_nodes_dcn2 is defined
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-
-    # Get internalapi IPs from OVN SB pods
-    OVN_SB_IPS=""
-    for pod in ovsdbserver-sb-0 ovsdbserver-sb-1 ovsdbserver-sb-2; do
-      IP=$(oc get pod -n openstack $pod -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}' | \
-           python3 -c "import sys, json; data=json.load(sys.stdin); print([n for n in data if 'internalapi' in n.get('name','')][0]['ips'][0])")
-      if [ -z "$OVN_SB_IPS" ]; then
-        OVN_SB_IPS="\"$IP\""
-      else
-        OVN_SB_IPS="$OVN_SB_IPS, \"$IP\""
-      fi
-    done
-
-    echo "[$OVN_SB_IPS]"
-  register: ovn_sb_ips_result
-
-- name: Set OVN SB IPs fact for DCN nodesets
-  when: edpm_nodes_dcn1 is defined or edpm_nodes_dcn2 is defined
-  ansible.builtin.set_fact:
-    edpm_ovn_dbs_dcn: "{{ ovn_sb_ips_result.stdout | trim | from_json }}"
-
-- name: Create DCN OVN controller ConfigMap with direct IPs
-  when: edpm_nodes_dcn1 is defined or edpm_nodes_dcn2 is defined
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-
-    # Build ovn-remote connection string from internalapi IPs
-    OVN_REMOTE="{% for ip in edpm_ovn_dbs_dcn %}tcp:{{ ip }}:6642{% if not loop.last %},{% endif %}{% endfor %}"
-
-    # Create ConfigMap for DCN nodes with direct IPs
-    oc apply -f - <<EOF
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: ovncontroller-config-dcn
-      namespace: openstack
-    data:
-      ovsdb-config: |
-        ovn-remote: $OVN_REMOTE
-    EOF
-
-- name: Create DCN-specific OVN DataPlaneService
-  when: edpm_nodes_dcn1 is defined or edpm_nodes_dcn2 is defined
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-
-    # Create OpenStackDataPlaneService for DCN that uses the DCN ConfigMap
-    oc apply -f - <<EOF
-    apiVersion: dataplane.openstack.org/v1beta1
-    kind: OpenStackDataPlaneService
-    metadata:
-      name: ovn-dcn
-      namespace: openstack
-    spec:
-      addCertMounts: false
-      caCerts: combined-ca-bundle
-      containerImageFields:
-      - OvnControllerImage
-      dataSources:
-      - configMapRef:
-          name: ovncontroller-config-dcn
-      edpmServiceType: ovn
-      playbook: osp.edpm.ovn
-      tlsCerts:
-        default:
-          contents:
-          - dnsnames
-          - ips
-          issuer: osp-rootca-issuer-ovn
-          keyUsages:
-          - digital signature
-          - key encipherment
-          - server auth
-          - client auth
-          networks:
-          - ctlplane
-    EOF
-
 - name: Create OpenStackDataPlaneNodeSet_dcn1
   when: edpm_nodes_dcn1 is defined
   no_log: "{{ use_no_log }}"
   vars:
     edpm_ovn_bridge_mappings_nodeset: "{{ edpm_ovn_bridge_mappings_dcn1|default(omit) }}"
-    edpm_ovn_dbs_nodeset: "{{ edpm_ovn_dbs_dcn }}"
   ansible.builtin.shell: |
     {{ shell_header }}
     CELL=cell1
@@ -521,7 +432,6 @@
   no_log: "{{ use_no_log }}"
   vars:
     edpm_ovn_bridge_mappings_nodeset: "{{ edpm_ovn_bridge_mappings_dcn2|default(omit) }}"
-    edpm_ovn_dbs_nodeset: "{{ edpm_ovn_dbs_dcn }}"
   ansible.builtin.shell: |
     {{ shell_header }}
     CELL=cell1
@@ -578,45 +488,6 @@
     {%+ if edpm_nodes_dcn2 is defined +%}
     cat nodeset-cell1-dcn2.yaml | oc apply -f -
     {%+ endif +%}
-
-- name: Patch DCN nodesets to use ovn-dcn service instead of ovn
-  when: edpm_nodes_dcn1 is defined or edpm_nodes_dcn2 is defined
-  no_log: "{{ use_no_log }}"
-  ansible.builtin.shell: |
-    {{ shell_header }}
-    {{ oc_header }}
-
-    # Patch dcn1 nodeset if it exists
-    {% if edpm_nodes_dcn1 is defined %}
-    if oc get openstackdataplanenodeset dcn1 -n openstack &>/dev/null; then
-      # Get current services list and replace 'ovn' with 'ovn-dcn'
-      SERVICES=$(oc get openstackdataplanenodeset dcn1 -n openstack -o jsonpath='{.spec.services}' | \
-        sed 's/"ovn"/"ovn-dcn"/g')
-
-      # Apply the patch
-      oc patch openstackdataplanenodeset dcn1 -n openstack --type=merge --patch "
-      spec:
-        services: $SERVICES
-      "
-      echo "Patched dcn1 nodeset to use ovn-dcn service"
-    fi
-    {% endif %}
-
-    # Patch dcn2 nodeset if it exists
-    {% if edpm_nodes_dcn2 is defined %}
-    if oc get openstackdataplanenodeset dcn2 -n openstack &>/dev/null; then
-      # Get current services list and replace 'ovn' with 'ovn-dcn'
-      SERVICES=$(oc get openstackdataplanenodeset dcn2 -n openstack -o jsonpath='{.spec.services}' | \
-        sed 's/"ovn"/"ovn-dcn"/g')
-
-      # Apply the patch
-      oc patch openstackdataplanenodeset dcn2 -n openstack --type=merge --patch "
-      spec:
-        services: $SERVICES
-      "
-      echo "Patched dcn2 nodeset to use ovn-dcn service"
-    fi
-    {% endif %}
 
 # TODO(bogdando): Apply the ceph backend config for Cinder in the original openstack CR, via kustomize perhaps?
 - name: prepare the adopted data plane workloads to use Ceph backend for Cinder, if configured so


### PR DESCRIPTION
Remove the custom ovncontroller-config-dcn ConfigMap, ovn-dcn DataPlaneService, and DCN nodeset patching that was working around OVN SB connectivity for DCN compute nodes. The standard OVN service uses DNS (ovsdbserver-sb.openstack.svc) which resolves to internalapi IPs via DNSData CRs. With proper routes in the internalapi NAD, the standard mechanism should work without hardcoding tcp:<IP> entries, which also broke TLS scenarios.

The NAD route patching is retained as it is still required for macvlan pods to reach DCN subnets.

Tracker: [OSPRH-30146](https://redhat.atlassian.net/browse/OSPRH-30146)