### PR TITLE
Add missing spec section to designate DNS service overrides

### DIFF
--- a/docs_user/modules/proc_adopting-the-dns-service.adoc
+++ b/docs_user/modules/proc_adopting-the-dns-service.adoc
@@ -245,16 +245,22 @@ spec:
                   metallb.universe.tf/address-pool: designateext
                   metallb.universe.tf/allow-shared-ip: designateext
                   metallb.universe.tf/loadBalancerIPs: 172.50.0.80
+              spec:
+                type: LoadBalancer
             - metadata:
                 annotations:
                   metallb.universe.tf/address-pool: designateext
                   metallb.universe.tf/allow-shared-ip: designateext
                   metallb.universe.tf/loadBalancerIPs: 172.50.0.81
+              spec:
+                type: LoadBalancer
             - metadata:
                 annotations:
                   metallb.universe.tf/address-pool: designateext
                   metallb.universe.tf/allow-shared-ip: designateext
                   metallb.universe.tf/loadBalancerIPs: 172.50.0.82
+              spec:
+                type: LoadBalancer
         replicas: 3
         storageClass: <storage_class>
         storageRequest: 10G
@@ -273,11 +279,15 @@ spec:
                   metallb.universe.tf/address-pool: designateext
                   metallb.universe.tf/allow-shared-ip: designateext
                   metallb.universe.tf/loadBalancerIPs: 172.50.0.85
+              spec:
+                type: LoadBalancer
             - metadata:
                 annotations:
                   metallb.universe.tf/address-pool: designateext
                   metallb.universe.tf/allow-shared-ip: designateext
                   metallb.universe.tf/loadBalancerIPs: 172.50.0.86
+              spec:
+                type: LoadBalancer
 MAINCR
 ----
 +

--- a/tests/roles/designate_adoption/tasks/designate_cr_config.yaml
+++ b/tests/roles/designate_adoption/tasks/designate_cr_config.yaml
@@ -78,16 +78,22 @@
                       metallb.universe.tf/address-pool: designateext
                       metallb.universe.tf/allow-shared-ip: designateext
                       metallb.universe.tf/loadBalancerIPs: 172.50.0.80
+                  spec:
+                    type: LoadBalancer
                 - metadata:
                     annotations:
                       metallb.universe.tf/address-pool: designateext
                       metallb.universe.tf/allow-shared-ip: designateext
                       metallb.universe.tf/loadBalancerIPs: 172.50.0.81
+                  spec:
+                    type: LoadBalancer
                 - metadata:
                     annotations:
                       metallb.universe.tf/address-pool: designateext
                       metallb.universe.tf/allow-shared-ip: designateext
                       metallb.universe.tf/loadBalancerIPs: 172.50.0.82
+                  spec:
+                    type: LoadBalancer
             replicas: 3
             storageClass: $STORAGE_CLASS_NAME
             storageRequest: 10G
@@ -106,11 +112,15 @@
                       metallb.universe.tf/address-pool: designateext
                       metallb.universe.tf/allow-shared-ip: designateext
                       metallb.universe.tf/loadBalancerIPs: 172.50.0.85
+                  spec:
+                    type: LoadBalancer
                 - metadata:
                     annotations:
                       metallb.universe.tf/address-pool: designateext
                       metallb.universe.tf/allow-shared-ip: designateext
                       metallb.universe.tf/loadBalancerIPs: 172.50.0.86
+                  spec:
+                    type: LoadBalancer
     MAINCR
   environment:
     STORAGE_CLASS_NAME: "{{ storage_class_name }}"


### PR DESCRIPTION
The service definitions were not being created because of the missing spec section.