### PR TITLE
ovn_adoption: fix scp with IPv6 addresses in cluster-to-standalone

### DIFF
--- a/docs_user/modules/proc_migrating-ovn-data.adoc
+++ b/docs_user/modules/proc_migrating-ovn-data.adoc
@@ -57,10 +57,14 @@ $CONTROLLER1_SSH sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conve
 $CONTROLLER1_SSH sudo chmod 644 /tmp/ovn_standalone_conversion/ovn*.db
 
 # Create local directory and copy converted databases
+# Note: brackets around the address are required so that IPv6 colons
+# are not confused with the scp host:path separator.
 mkdir -p /tmp/ovn_adoption_dbs
-CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed 's/^ssh/scp/')
-${CONTROLLER1_SCP}:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/
-${CONTROLLER1_SCP}:/tmp/ovn_standalone_conversion/ovnsb_db.db /tmp/ovn_adoption_dbs/
+CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed -e 's/^ssh/scp/' -e 's/ [^ ]*$//')
+CONTROLLER1_USERHOST=$(echo "$CONTROLLER1_SSH" | awk '{print $NF}')
+CONTROLLER1_SCP_DEST=$(echo "$CONTROLLER1_USERHOST" | sed 's/@\(.*\)/@[\1]/')
+${CONTROLLER1_SCP} ${CONTROLLER1_SCP_DEST}:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/
+${CONTROLLER1_SCP} ${CONTROLLER1_SCP_DEST}:/tmp/ovn_standalone_conversion/ovnsb_db.db /tmp/ovn_adoption_dbs/
 
 # Cleanup on controller
 $CONTROLLER1_SSH sudo rm -rf /tmp/ovn_standalone_conversion

--- a/tests/roles/ovn_adoption/tasks/cluster_to_standalone.yaml
+++ b/tests/roles/ovn_adoption/tasks/cluster_to_standalone.yaml
@@ -23,14 +23,18 @@
     # Create local temp directory
     mkdir -p /tmp/ovn_adoption_dbs
 
-    # Use scp like other parts of the codebase
-    CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed 's/^ssh/scp/')
+    # Build scp command from ssh command, wrapping the address in brackets
+    # so that IPv6 colons are not confused with the scp host:path separator.
+    # The last token is user@host; insert brackets around the host part only.
+    CONTROLLER1_SCP=$(echo "$CONTROLLER1_SSH" | sed -e 's/^ssh/scp/' -e 's/ [^ ]*$//')
+    CONTROLLER1_USERHOST=$(echo "$CONTROLLER1_SSH" | awk '{print $NF}')
+    CONTROLLER1_SCP_DEST=$(echo "$CONTROLLER1_USERHOST" | sed 's/@\(.*\)/@[\1]/')
 
     echo "Copying NB database to ansible controller..."
-    ${CONTROLLER1_SCP}:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/
+    ${CONTROLLER1_SCP} ${CONTROLLER1_SCP_DEST}:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/
 
     echo "Copying SB database to ansible controller..."
-    ${CONTROLLER1_SCP}:/tmp/ovn_standalone_conversion/ovnsb_db.db /tmp/ovn_adoption_dbs/
+    ${CONTROLLER1_SCP} ${CONTROLLER1_SCP_DEST}:/tmp/ovn_standalone_conversion/ovnsb_db.db /tmp/ovn_adoption_dbs/
 
     # Cleanup on controller
     $CONTROLLER1_SSH sudo rm -rf /tmp/ovn_standalone_conversion


### PR DESCRIPTION
The scp command constructed from the SSH command by replacing "ssh" with "scp" does not account for IPv6 addresses. When the controller host is an IPv6 address (e.g. 2620:cf:cf:aaaa::70), scp interprets the colons as the host:path separator, causing it to connect to a bogus IPv4 address derived from the first octet.

Fix by splitting the SSH command into the scp options and the host, then wrapping the host in square brackets for the scp remote path. This is compatible with both IPv4 and IPv6 addresses since brackets around an IPv4 address are valid in scp.

Update both the test role and the user-facing documentation.

Example of actual behavior:
```
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "set -euxo pipefail\n\nCONTROLLER1_SSH=\"ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70\"\n\necho \"Using CONTROLLER1 for database conversion\"\n\n# Create working directory on controller\n$CONTROLLER1_SSH sudo mkdir -p /tmp/ovn_standalone_conversion\n\n# Convert cluster databases to standalone on the controller\n$CONTROLLER1_SSH sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conversion/ovnnb_db.db /var/lib/openvswitch/ovn/ovnnb_db.db\n$CONTROLLER1_SSH sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conversion/ovnsb_db.db /var/lib/openvswitch/ovn/ovnsb_db.db\n\n# Set permissions for copying\n$CONTROLLER1_SSH sudo chmod 644 /tmp/ovn_standalone_conversion/ovn*.db\n\n# Create local temp directory\nmkdir -p /tmp/ovn_adoption_dbs\n\n# Use scp like other parts of the codebase\nCONTROLLER1_SCP=$(echo \"$CONTROLLER1_SSH\" | sed 's/^ssh/scp/')\n\necho \"Copying NB database to ansible controller...\"\n${CONTROLLER1_SCP}:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/\n\necho \"Copying SB database to ansible controller...\"\n${CONTROLLER1_SCP}:/tmp/ovn_standalone_conversion/ovnsb_db.db /tmp/ovn_adoption_dbs/\n\n# Cleanup on controller\n$CONTROLLER1_SSH sudo rm -rf /tmp/ovn_standalone_conversion\n\necho \"Successfully converted and copied databases to ansible controller\"\n", "delta": "0:00:02.052464", "end": "2026-05-27 18:59:20.832418", "msg": "non-zero return code", "rc": 255, "start": "2026-05-27 18:59:18.779954", "stderr": "+ CONTROLLER1_SSH='ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70'\n+ echo 'Using CONTROLLER1 for database conversion'\n+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo mkdir -p /tmp/ovn_standalone_conversion\n+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conversion/ovnnb_db.db /var/lib/openvswitch/ovn/ovnnb_db.db\n+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conversion/ovnsb_db.db /var/lib/openvswitch/ovn/ovnsb_db.db\n+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo chmod 644 '/tmp/ovn_standalone_conversion/ovn*.db'\n+ mkdir -p /tmp/ovn_adoption_dbs\n++ echo 'ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70'\n++ sed 's/^ssh/scp/'\n+ CONTROLLER1_SCP='scp -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70'\n+ echo 'Copying NB database to ansible controller...'\n+ scp -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/\nssh: connect to host 0.0.10.60 port 22: Network is unreachable\r\nConnection closed", "stderr_lines": ["+ CONTROLLER1_SSH='ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70'", "+ echo 'Using CONTROLLER1 for database conversion'", "+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo mkdir -p /tmp/ovn_standalone_conversion", "+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conversion/ovnnb_db.db /var/lib/openvswitch/ovn/ovnnb_db.db", "+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo ovsdb-tool cluster-to-standalone /tmp/ovn_standalone_conversion/ovnsb_db.db /var/lib/openvswitch/ovn/ovnsb_db.db", "+ ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70 sudo chmod 644 '/tmp/ovn_standalone_conversion/ovn*.db'", "+ mkdir -p /tmp/ovn_adoption_dbs", "++ echo 'ssh -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70'", "++ sed 's/^ssh/scp/'", "+ CONTROLLER1_SCP='scp -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70'", "+ echo 'Copying NB database to ansible controller...'", "+ scp -i /home/zuul/.ssh/id_cifw -o StrictHostKeyChecking=accept-new root@2620:cf:cf:aaaa::70:/tmp/ovn_standalone_conversion/ovnnb_db.db /tmp/ovn_adoption_dbs/", "ssh: connect to host 0.0.10.60 port 22: Network is unreachable", "Connection closed"], "stdout": "Using CONTROLLER1 for database conversion\nCopying NB database to ansible controller...", "stdout_lines": ["Using CONTROLLER1 for database conversion", "Copying NB database to ansible controller..."]}
```