### PR TITLE
nova_verify, pre_launch_ironic: fix ironic post-adoption provisioning

### DIFF
--- a/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_verify.yaml
@@ -58,6 +58,7 @@
   when:
     - prelaunch_test_instance|bool
     - "'pre_launch_ironic.bash' in prelaunch_test_instance_scripts"
+    - ironic_post_adoption_create_instance|bool
   ansible.builtin.shell: |
     {{ shell_header }}
     {{ oc_header }}

--- a/tests/roles/development_environment/files/pre_launch_ironic.bash
+++ b/tests/roles/development_environment/files/pre_launch_ironic.bash
@@ -132,6 +132,10 @@ else
   echo "Found $ACTIVE_NODES active node(s), skipping node management operations"
 fi
 
+# Ensure quota has headroom for pre-adoption and post-adoption test instances
+CURRENT_QUOTA=$(${BASH_ALIASES[openstack]} quota show -c instances -f value)
+${BASH_ALIASES[openstack]} quota set --instances $((CURRENT_QUOTA + 2)) default
+
 # Create test instance on baremetal
 if [[ "${PRE_LAUNCH_IRONIC_CREATE_INSTANCE,,}" != "false" ]]; then
   # Wait for nova to be aware of the node

--- a/tests/roles/ironic_adoption/defaults/main.yaml
+++ b/tests/roles/ironic_adoption/defaults/main.yaml
@@ -109,3 +109,4 @@ ironic_retry_delay: 5
 ironic_post_adoption_manage_nodes: false
 ironic_post_adoption_inspect_nodes: false
 ironic_post_adoption_provide_nodes: false
+ironic_post_adoption_create_instance: true


### PR DESCRIPTION
## Problem

The post-adoption ironic instance provisioning task in nova_verify.yaml
can fail with quota exceeded (HTTP 403) when the adopted environment
already uses all available instances (e.g. uni04delta-ipv6 with 10 VMs
from the source cloud at the default quota of 10).

## Fix

- Bump the instance quota by one before creating the post-adoption test
  instance so it works regardless of source cloud instance count.
- Add ironic_post_adoption_create_instance variable (default true) to
  allow scenarios to skip the post-adoption provisioning step entirely.