### PR TITLE
Remove unused undercloud ctlplane_vip from scenario files

### DIFF
--- a/scenarios/bgp-l3-xl.yaml
+++ b/scenarios/bgp-l3-xl.yaml
@@ -114,7 +114,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "bgp-l3-xl/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "bgp-l3-xl/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.98
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/dcn_nostorage.yaml
+++ b/scenarios/dcn_nostorage.yaml
@@ -67,7 +67,6 @@ undercloud:
       value: 192.168.144.200,192.168.144.220
   undercloud_parameters_override: "dcn_nostorage/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "dcn_nostorage/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.98
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/dcn_storage.yaml
+++ b/scenarios/dcn_storage.yaml
@@ -71,7 +71,6 @@ undercloud:
       value: 192.168.144.200,192.168.144.220
   undercloud_parameters_override: "dcn_storage/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "dcn_storage/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.98
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/hci.yaml
+++ b/scenarios/hci.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "hci/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "hci/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.98
 cloud_domain: "ooo.test"
 tlse: true
 enable_keystone_ldap: true

--- a/scenarios/uni01alpha.yaml
+++ b/scenarios/uni01alpha.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni01alpha/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni01alpha/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.101
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/uni02beta.yaml
+++ b/scenarios/uni02beta.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni02beta/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni02beta/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.101
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/uni04delta-ipv6.yaml
+++ b/scenarios/uni04delta-ipv6.yaml
@@ -28,7 +28,6 @@ undercloud:
 
   undercloud_parameters_override: "uni04delta-ipv6/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni04delta-ipv6/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 2620:cf:cf:aaaa::98
 
 cloud_domain: "example.com"
 hostname_groups_map:

--- a/scenarios/uni04delta.yaml
+++ b/scenarios/uni04delta.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni04delta/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni04delta/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.98
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/uni05epsilon.yaml
+++ b/scenarios/uni05epsilon.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni05epsilon/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni05epsilon/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.101
   routes: &sroutes
     - ip_netmask: 0.0.0.0/0
       next_hop: 192.168.122.1

--- a/scenarios/uni06zeta.yaml
+++ b/scenarios/uni06zeta.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni06zeta/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni06zeta/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.101
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/uni07eta.yaml
+++ b/scenarios/uni07eta.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni07eta/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni07eta/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.101
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for

--- a/scenarios/uni09iota.yaml
+++ b/scenarios/uni09iota.yaml
@@ -21,7 +21,6 @@ undercloud:
       value: false
   undercloud_parameters_override: "uni09iota/hieradata_overrides_undercloud.yaml"
   undercloud_parameters_defaults: "uni09iota/undercloud_parameter_defaults.yaml"
-  ctlplane_vip: 192.168.122.101
 cloud_domain: "example.com"
 hostname_groups_map:
   # map ansible groups in the inventory to role hostname format for


### PR DESCRIPTION
## Summary

- Remove the `ctlplane_vip` key from the `undercloud:` section in all 12 scenario files
- The undercloud `ctlplane_vip` was never consumed by any service endpoint — all endpoints use `ctlplane_ip` instead
- The consumer code in `ci-framework`'s `adoption_osp_deploy` role is being removed in the companion PR

The overcloud VIPs defined in `vips_data.yaml` files are a separate concept and are **not** affected by this change.

### Files changed

`scenarios/hci.yaml`, `scenarios/uni01alpha.yaml`, `scenarios/uni02beta.yaml`, `scenarios/uni04delta.yaml`, `scenarios/uni04delta-ipv6.yaml`, `scenarios/uni05epsilon.yaml`, `scenarios/uni06zeta.yaml`, `scenarios/uni07eta.yaml`, `scenarios/uni09iota.yaml`, `scenarios/dcn_nostorage.yaml`, `scenarios/dcn_storage.yaml`, `scenarios/bgp-l3-xl.yaml`

## Test plan

- [x] Zuul `check` pipeline passes with `Depends-On` pulling in the ci-framework companion PR
- [x] Adoption jobs that exercise these scenarios complete successfully

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4019
Related-Issue: #[OSPRH-17418](https://redhat.atlassian.net/browse/OSPRH-17418)

Made with [Cursor](https://cursor.com)