### PR TITLE
Update the IP brigde for ceph to avoid conflict with test IP range

### DIFF
--- a/scenarios/uni04delta/ceph_inventory.yaml
+++ b/scenarios/uni04delta/ceph_inventory.yaml
@@ -3,7 +3,7 @@ ceph:
     osp-ext-ceph-uni04delta-0:
       ansible_user: zuul
       ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
-      bridge_ip: 192.168.122.210/24
+      bridge_ip: 192.168.122.106/24
       external_ip: 10.0.0.210/24
       internalapi_ip: 172.17.0.210/24
       storage_ip: 172.18.0.210/24
@@ -12,7 +12,7 @@ ceph:
     osp-ext-ceph-uni04delta-1:
       ansible_user: zuul
       ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
-      bridge_ip: 192.168.122.211/24
+      bridge_ip: 192.168.122.107/24
       external_ip: 10.0.0.211/24
       internalapi_ip: 172.17.0.211/24
       storage_ip: 172.18.0.211/24
@@ -21,7 +21,7 @@ ceph:
     osp-ext-ceph-uni04delta-2:
       ansible_user: zuul
       ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
-      bridge_ip: 192.168.122.212/24
+      bridge_ip: 192.168.122.108/24
       external_ip: 10.0.0.212/24
       internalapi_ip: 172.17.0.212/24
       storage_ip: 172.18.0.212/24


### PR DESCRIPTION
For test IP range uses:
start=192.168.122.171,end=192.168.122.250
so to avoid IP conflict, it needs to change the current IP bridge of ceph.
In ci-framework-job files, IPs from .106 are assigned for ceph but it seems that it is not used.