### PR TITLE
replaced link with ibm link

### DIFF
--- a/docs_user/adoption-attributes.adoc
+++ b/docs_user/adoption-attributes.adoc
@@ -99,6 +99,11 @@ ifeval::["{build}" == "downstream"]
 :CephCluster: Red Hat Ceph Storage
 :CephVernum: 7
 
+
+// Ceph 9 IBM PDF paths - update these when Ceph 9 minor version changes
+:ceph9_pdf_path: SSEG27_9.9.1/out/91
+:ceph9_version: 9.9.1
+
 //Components and services
 
 //Identity service (keystone)

--- a/docs_user/modules/proc_creating-a-ceph-nfs-cluster.adoc
+++ b/docs_user/modules/proc_creating-a-ceph-nfs-cluster.adoc
@@ -135,7 +135,7 @@ For more information about deploying the clustered Ceph NFS service, see 'Manage
 
 * link:https://docs.redhat.com/documentation/en-us/red_hat_ceph_storage/7/html/operations_guide/index#management-of-nfs-ganesha-gateway-using-the-ceph-orchestrator[Red Hat Ceph Storage 7 _Operations Guide_]
 * link:https://docs.redhat.com/documentation/en-us/red_hat_ceph_storage/8/html/operations_guide/index#management-of-nfs-ganesha-gateway-using-the-ceph-orchestrator[Red Hat Ceph Storage 8 _Operations Guide_]
-* link:https://docs.redhat.com/documentation/en-us/red_hat_ceph_storage/9/html/operations_guide/index#management-of-nfs-ganesha-gateway-using-the-ceph-orchestrator[Red Hat Ceph Storage 9 _Operations Guide_]
+* link:https://www.ibm.com/docs/en/{ceph9_pdf_path}/Red_Hat_Ceph_Storage_NFS_cluster_and_share_management_(OpenStack_Manila_users_only).pdf[Red Hat Ceph Storage 9 NFS cluster and share management (OpenStack Manila users only)] > Creating an NFS cluster
 ====
 endif::[]
 


### PR DESCRIPTION
Replaced docs-redhat.com link with a link to IBM docs, according to this MR: https://gitlab.cee.redhat.com/rhci-documentation/docs-Red_Hat_Enterprise_Linux_OpenStack_Platform/-/merge_requests/14988/diffs