### PR TITLE
Enabled LUKS encryption for Ceph OSD in HCI scenarios

### DIFF
--- a/scenarios/hci/osd_spec.yaml
+++ b/scenarios/hci/osd_spec.yaml
@@ -1,3 +1,4 @@
 ---
 data_devices:
   all: true
+encrypted: true


### PR DESCRIPTION
This pull request introduces at-rest data encryption for Ceph OSDs within Hyperconverged Infrastructure (HCI) environments. By modifying the OSD specification, the HCI nodes will automatically have their underlying storage drives encrypted.