### PR TITLE
[18.0-fr6] configure zuul CI to run with 18.0-fr6 branch

### DIFF
--- a/zuul.d/jobs-layout.yaml
+++ b/zuul.d/jobs-layout.yaml
@@ -4,6 +4,11 @@
     github-check:
       jobs:
         - noop
-        - adoption-standalone-to-crc-ceph
-        - adoption-standalone-to-crc-no-ceph
-        - adoption-docs-preview
+        - adoption-standalone-to-crc-ceph: &required_projects
+            required-projects:
+              - name: openstack-k8s-operators/data-plane-adoption
+                override-checkout: 18.0-fr6
+              - name: openstack-k8s-operators/install_yamls
+                override-checkout: 18.0-fr6
+        - adoption-standalone-to-crc-no-ceph: *required_projects
+        - adoption-docs-preview: *required_projects


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/OSPRH-32121 