### PR TITLE
Fix quota set to target admin project instead of default

### DIFF
--- a/tests/roles/development_environment/files/pre_launch_ironic.bash
+++ b/tests/roles/development_environment/files/pre_launch_ironic.bash
@@ -134,7 +134,7 @@ fi
 
 # Ensure quota has headroom for pre-adoption and post-adoption test instances
 CURRENT_QUOTA=$(${BASH_ALIASES[openstack]} quota show -c instances -f value)
-${BASH_ALIASES[openstack]} quota set --instances $((CURRENT_QUOTA + 2)) default
+${BASH_ALIASES[openstack]} quota set --instances $((CURRENT_QUOTA + 2)) admin
 
 # Create test instance on baremetal
 if [[ "${PRE_LAUNCH_IRONIC_CREATE_INSTANCE,,}" != "false" ]]; then


### PR DESCRIPTION
PR #1412 added a quota increase for pre-adoption Ironic test
  instances, but targeted project 'default' instead of 'admin'.
  The OS_CLOUD=overcloud authenticates as project admin
  (clouds.yaml: project_name: admin), so quota set should
  target admin to match the project instances are created under.

  Since adoption migrates the TripleO DB, this quota carries
  over to the adopted cloud, providing headroom for
  post-adoption instance creation as well.