### PR TITLE
Enable Ceph for uni05epsilon adoption scenario

### DIFF
--- a/scenarios/uni05epsilon.yaml
+++ b/scenarios/uni05epsilon.yaml
@@ -61,6 +61,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/podman.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/debug.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/external-ceph.yaml"
+      - "/home/zuul/external_ceph_params.yaml"
     network_data_file: "uni05epsilon/network_data.yaml.j2"
     routes: *sroutes
     vips_data_file: "uni05epsilon/vips_data_overcloud.yaml"
@@ -68,6 +70,24 @@ stacks:
     config_download_file: "uni05epsilon/config_download_overcloud.yaml"
     stack_nodes:
       - osp-controllers
+    pre_oc_run:
+      - name: 01 Prepare Ceph nodes
+        type: playbook
+        source: "setup_cephnodes.yaml"
+        inventory: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/data-plane-adoption'].
+                    src_dir }}/scenarios/uni05epsilon/ceph_inventory.yaml"
+      - name: 02 Deploy external ceph
+        type: playbook
+        source: "ceph.yml"
+        gathering: implicit
+        inventory: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/data-plane-adoption'].
+                    src_dir }}/scenarios/uni05epsilon/ceph_inventory.yaml"
+      - name: 03 Create external Ceph parameters file
+        type: playbook
+        source: "create_external_ceph_params.yml"
+        extra_vars:
+          ceph_node: "cell1-osp-compute-uni05epsilon-0"
+          ceph_mon_host: "172.18.0.94,172.18.0.95"
     post_oc_run:
       - name: Multi-cell post overcloud deploy
         type: playbook
@@ -93,6 +113,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/debug.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/external-ceph.yaml"
+      - "/home/zuul/external_ceph_params.yaml"
       - "/home/zuul/cell1-input.yaml"
     network_data_file: "uni05epsilon/network_data.yaml.j2"
     routes: *sroutes
@@ -132,6 +154,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/podman.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/debug.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/external-ceph.yaml"
+      - "/home/zuul/external_ceph_params.yaml"
       - "/home/zuul/cell2-input.yaml"
     network_data_file: "uni05epsilon/network_data.yaml.j2"
     routes: *sroutes

--- a/scenarios/uni05epsilon/ceph_inventory.yaml
+++ b/scenarios/uni05epsilon/ceph_inventory.yaml
@@ -1,0 +1,20 @@
+computes:
+  hosts:
+    cell1-osp-compute-uni05epsilon-0:
+      ansible_user: zuul
+      ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
+      bridge_ip: 192.168.122.94/24
+      external_ip: 172.21.0.94/24
+      internalapi_ip: 172.17.0.94/24
+      storage_ip: 172.18.0.94/24
+      storagemgmt_ip: 172.20.0.94/24
+      tenant_ip: 172.19.0.94/24
+    cell2-osp-compute-uni05epsilon-0:
+      ansible_user: zuul
+      ansible_ssh_private_key_file: /home/zuul/.ssh/cifmw_reproducer_key
+      bridge_ip: 192.168.122.95/24
+      external_ip: 172.21.0.95/24
+      internalapi_ip: 172.17.0.95/24
+      storage_ip: 172.18.0.95/24
+      storagemgmt_ip: 172.20.0.95/24
+      tenant_ip: 172.19.0.95/24

--- a/scenarios/uni05epsilon/config_download_cell1.yaml
+++ b/scenarios/uni05epsilon/config_download_cell1.yaml
@@ -43,6 +43,12 @@ resource_registry:
 
 parameter_defaults:
   SshFirewallAllowAll: true
+  ExtraFirewallRules:
+    '110 ceph_mon':
+      dport:
+        - 3300
+        - 6789
+      proto: tcp
 
   # Specify that this is an additional cell
   NovaAdditionalCell: true

--- a/scenarios/uni05epsilon/config_download_cell2.yaml
+++ b/scenarios/uni05epsilon/config_download_cell2.yaml
@@ -43,6 +43,12 @@ resource_registry:
 
 parameter_defaults:
   SshFirewallAllowAll: true
+  ExtraFirewallRules:
+    '110 ceph_mon':
+      dport:
+        - 3300
+        - 6789
+      proto: tcp
 
   # Specify that this is an additional cell
   NovaAdditionalCell: true

--- a/scenarios/uni05epsilon/osd_spec.yaml
+++ b/scenarios/uni05epsilon/osd_spec.yaml
@@ -1,0 +1,3 @@
+---
+data_devices:
+  all: true

--- a/scenarios/uni05epsilon/roles.yaml
+++ b/scenarios/uni05epsilon/roles.yaml
@@ -46,6 +46,8 @@
     - OS::TripleO::Services::AuditD
     - OS::TripleO::Services::BootParams
     - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephClient
+    - OS::TripleO::Services::CephExternal
     - OS::TripleO::Services::CinderApi
     - OS::TripleO::Services::CinderBackendDellSc
     - OS::TripleO::Services::CinderBackendDellEMCPowerFlex
@@ -165,6 +167,8 @@
     - OS::TripleO::Services::AuditD
     - OS::TripleO::Services::BootParams
     - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephClient
+    - OS::TripleO::Services::CephExternal
     - OS::TripleO::Services::Clustercheck
     - OS::TripleO::Services::Collectd
     - OS::TripleO::Services::ContainerImagePrepare
@@ -217,6 +221,8 @@
       subnet: tenant_subnet
     Storage:
       subnet: storage_subnet
+    StorageMgmt:
+      subnet: storage_mgmt_subnet
   default_route_networks: ['ControlPlane']
   HostnameFormatDefault: '%stackname%-novacompute-%index%'
   RoleParametersDefault:
@@ -240,6 +246,8 @@
     - OS::TripleO::Services::AuditD
     - OS::TripleO::Services::BootParams
     - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephClient
+    - OS::TripleO::Services::CephExternal
     - OS::TripleO::Services::ComputeNeutronCorePlugin
     - OS::TripleO::Services::ComputeNeutronL3Agent
     - OS::TripleO::Services::ComputeNeutronMetadataAgent


### PR DESCRIPTION
## Summary

Add external Ceph deployment to the uni05epsilon multi-cell adoption scenario, following the uni04delta pattern.

The Ceph cluster is deployed on the cell1 and cell2 compute nodes (which have OSD disks) as an external cluster before the TripleO overcloud deploy. All three stacks (overcloud, cell1, cell2) reference the external-ceph environment and generated credentials.

### Changes
- Add `ceph_inventory.yaml` targeting cell1/cell2 compute nodes
- Add `osd_spec.yaml` for OSD device configuration
- Add `pre_oc_run` hooks to overcloud stack: setup ceph nodes, deploy ceph cluster, create external ceph parameters
- Add `external-ceph.yaml` TripleO environment to all three stacks (overcloud, cell1, cell2)

### Related
- Jira: [OSPNW-1658](https://redhat.atlassian.net/browse/OSPNW-1658)

Made with [Cursor](https://cursor.com)