### PR TITLE
mariadb_copy: wait for connectivity to TripleO Galera before sync check

### DIFF
--- a/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
+++ b/docs_user/modules/proc_migrating-databases-to-mariadb-instances.adoc
@@ -186,6 +186,26 @@ $ oc wait --for condition=Ready pod/mariadb-copy-data --timeout=30s
 
 .Procedure
 
+. Wait for the `mariadb-copy-data` pod to reach the source TripleO Galera databases:
++
+----
+for CELL in $(echo $CELLS); do
+  MEMBERS=SOURCE_GALERA_MEMBERS_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')[@]
+  for i in "${!MEMBERS}"; do
+    echo "Checking connectivity to the database node $i"
+    oc rsh mariadb-copy-data mysql \
+      -h "$i" -uroot -p"${SOURCE_DB_ROOT_PASSWORD[$CELL]}" -e 'select 1;'
+  done
+done
+----
++
+[NOTE]
+====
+For BGP-enabled environments, this command might take a few moments to succeed while the route to the `mariadb-copy-data` pod is advertised and propagated through the network via BGP. If the command fails, wait a few seconds and retry. The connection should succeed once the BGP route advertisement is complete.
+
+For standard deployments, this command should succeed immediately.
+====
+
 . Check that the source Galera database clusters in each cell have its members online and synced:
 +
 ----
@@ -232,7 +252,7 @@ $ oc rsh mariadb-copy-data mysql -rsh "${PODIFIED_MARIADB_IP['super']}" \
 +
 [NOTE]
 ====
-For BGP-enabled environments, this command might take a few moments to succeed while BGP routes are advertised and propagated through the network. The `mariadb-copy-data` pod needs to receive the route to the podified MariaDB IP address through BGP before it can establish a connection. If the command fails, wait a few seconds and retry. The connection should succeed once the BGP route advertisement is complete.
+For BGP-enabled environments, this command might take a few moments to succeed while the route to the `mariadb-copy-data` pod is advertised and propagated through the network via BGP. If the command fails, wait a few seconds and retry. The connection should succeed once the BGP route advertisement is complete.
 
 For IPv6 environments, this command might take a few moments to succeed while the network IPv6 stack completes its setup. If the command fails, wait a few seconds and retry.
 

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -86,6 +86,26 @@
   until: _podified_db_check.rc == 0
   changed_when: false
 
+- name: wait until TripleO Galera DBs are reachable from the mariadb-copy-data pod
+  no_log: "{{ use_no_log }}"
+  ansible.builtin.shell: |
+    {{ oc_header }}
+    {{ mariadb_members_env }}
+    {{ mariadb_copy_shell_vars_src }}
+    for CELL in $(echo $CELLS); do
+      MEMBERS=SOURCE_GALERA_MEMBERS_$(echo ${CELL}|tr '[:lower:]' '[:upper:]')[@]
+      for i in "${!MEMBERS}"; do
+        echo "Checking connectivity to the database node $i"
+        oc rsh mariadb-copy-data mysql \
+          -h "$i" -uroot -p"${SOURCE_DB_ROOT_PASSWORD[$CELL]}" -e 'select 1;'
+      done
+    done
+  register: _galera_db_check
+  retries: 60
+  delay: 3
+  until: _galera_db_check.rc == 0
+  changed_when: false
+
 - name: check that the Galera database cluster(s) members are online and synced, for all cells
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
Commit 824d9edf replaced sleep-based BGP workarounds with a retry loop that checks connectivity to the podified MariaDB, but did not add an equivalent check for the source TripleO Galera nodes. With BGP, the route to the mariadb-copy-data pod may take a few seconds to be advertised, causing the subsequent WSREP sync check to fail with "ERROR 2002 (HY000): Can't connect to MySQL server" (EINPROGRESS).

Add a retry-loop task that verifies TCP connectivity to every TripleO Galera member via 'select 1;' before running the non-retrying WSREP sync check. Also update the documentation procedure to include this new connectivity check step and fix the BGP note wording to correctly describe route advertisement direction.

Assisted-By: Claude (claude-opus-4.6)