### PR TITLE
Restrict test log outputs

### DIFF
--- a/tests/roles/backend_services/tasks/main.yaml
+++ b/tests/roles/backend_services/tasks/main.yaml
@@ -1,6 +1,8 @@
 - name: create osp-secret
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     cd {{ install_yamls_path }}
     make input
@@ -15,6 +17,7 @@
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {% if aodh_password %}
         oc set data secret/osp-secret "AodhPassword={{ aodh_password }}"

--- a/tests/roles/backend_services/tasks/ospdo_backend_services.yaml
+++ b/tests/roles/backend_services/tasks/ospdo_backend_services.yaml
@@ -1,5 +1,7 @@
 - name: get service passwords
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+     {{ shell_header_no_xtrace }}
      oc get secret tripleo-passwords -o jsonpath='{.data.*}' | base64 -d>~/tripleo-standalone-passwords.yaml
      cp ~/tripleo-standalone-passwords.yaml {{ tripleo_passwords['default'] | replace("~", "$HOME") }}
   when: get_svc_pass| default(false) | bool

--- a/tests/roles/barbican_adoption/tasks/main.yaml
+++ b/tests/roles/barbican_adoption/tasks/main.yaml
@@ -1,6 +1,8 @@
 - name: patch osp-secret with kek
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     CONTROLLER1_SSH="{{ controller1_ssh }}"
     oc set data secret/osp-secret "BarbicanSimpleCryptoKEK=$($CONTROLLER1_SSH \
@@ -10,8 +12,10 @@
 
 - name: Create HSM login secret for Barbican
   when: barbican_hsm_enabled|default(false)
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     cat <<EOF | oc apply -f -
     apiVersion: v1

--- a/tests/roles/common_defaults/defaults/main.yaml
+++ b/tests/roles/common_defaults/defaults/main.yaml
@@ -1,6 +1,6 @@
 # Whether to use no_log on tasks which may output potentially
 # sensitive data.
-use_no_log: false
+use_no_log: true
 
 # Network configuration for IPv4/IPv6 support
 ipv6_enabled: false
@@ -28,6 +28,10 @@ renamed_cells: "{{ [default_cell_name] + cells | difference(['default']) }}"
 # expected.
 shell_header: |
   set -euxo pipefail
+
+# Header to disable command tracing in tasks that handle sensitive data.
+shell_header_no_xtrace: |
+  set +x
 
 # Snippet to get the desired 'oc' command onto $PATH.
 oc_header: |
@@ -133,6 +137,7 @@ mariadb_client_network_annotation: >-
   }}
 mariadb_copy_shell_vars_src: |-
   {{ shell_header }}
+  {{ shell_header_no_xtrace }}
 
   PASSWORD_FILE="{{ tripleo_passwords['default'] | replace("~", "$HOME") }}"
 
@@ -170,6 +175,7 @@ mariadb_copy_shell_vars_src: |-
 # for any tables that are created in the future as part of db sync
 mariadb_copy_shell_vars_dst: |
   {{ shell_header }}
+  {{ shell_header_no_xtrace }}
   {{ oc_header }}
   {{ mariadb_image_env }}
   {{ cells_env }}

--- a/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
+++ b/tests/roles/dataplane_adoption/tasks/nova_ffu.yaml
@@ -1,5 +1,7 @@
 - name: wait for Compute data plane services version updated for all cells
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ mariadb_copy_shell_vars_dst }}
     for CELL in $(echo $RENAMED_CELLS); do
       oc exec openstack-$CELL-galera-0 -c galera -- mysql -rs -uroot -p"${PODIFIED_DB_ROOT_PASSWORD[$CELL]}" \

--- a/tests/roles/dataplane_adoption/tasks/ospdo_dataplane.yaml
+++ b/tests/roles/dataplane_adoption/tasks/ospdo_dataplane.yaml
@@ -1,7 +1,9 @@
 # Take the private ssh key (id_ra) from the /home/cloud-admin/.ssh/ directory of the openstackclient pod and create a secret in the osp18 namespace
 - name: Create secret from openstackclient pod
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
       {{ shell_header }}
+      {{ shell_header_no_xtrace }}
       {{ oc_header }}
       oc apply -f - <<EOF
       apiVersion: v1
@@ -16,7 +18,12 @@
 
 # needed for : https://github.com/openstack-k8s-operators/openstack-operator/blob/37f12745cc6971241f6d24fa9b0a28d39a428be7/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml#L8
 - name: Create secret for OpenStackDataPlaneService
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ shell_header_no_xtrace }}
+    {{ oc_header }}
+
     LIBVIRT_PASSWORD=$(grep <"${PASSWORD_FILE}" ' LibvirtTLSPassword:' | awk -F ': ' '{ print $2; }')
 
     oc apply -f - <<EOF

--- a/tests/roles/designate_adoption/tasks/designate_cr_config.yaml
+++ b/tests/roles/designate_adoption/tasks/designate_cr_config.yaml
@@ -1,6 +1,8 @@
 - name: Retrieve the known ns_record values from the designate database
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     DB_ROOT_PASSWORD=$(oc get -o json secret/osp-secret | jq -r .data.DbRootPassword | base64 -d)
     oc exec openstack-galera-0 -c galera -- mysql -rs -uroot -p"$DB_ROOT_PASSWORD" \

--- a/tests/roles/get_services_configuration/tasks/main.yaml
+++ b/tests/roles/get_services_configuration/tasks/main.yaml
@@ -21,6 +21,7 @@
 - name: create mariadb-client container
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     # delete existing mariadb-client pods
@@ -31,6 +32,7 @@
 - name: wait until SOURCE_MARIADB_IP is reachable
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     oc rsh mariadb-client mysql -rsh ${SOURCE_MARIADB_IP[default]} -uroot -p${SOURCE_DB_ROOT_PASSWORD[default]} -e 'select 1;'
@@ -45,6 +47,7 @@
 - name: test connection to the original DB
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     unset PULL_OPENSTACK_CONFIGURATION_DATABASES
@@ -57,6 +60,7 @@
 - name: run mysqlcheck on the original DB to look for things that are not OK
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     unset PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK
@@ -86,6 +90,7 @@
   block:
     - name: get Nova cells mappings from database
       ansible.builtin.shell: |
+        {{ shell_header_no_xtrace }}
         {{ oc_header }}
         {{ mariadb_copy_shell_vars_src }}
         export PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS=$(oc rsh mariadb-client \
@@ -94,6 +99,7 @@
 
     - name: get the host names of the registered Nova compute services
       ansible.builtin.shell: |
+        {{ shell_header_no_xtrace }}
         {{ oc_header }}
         {{ mariadb_copy_shell_vars_src }}
         unset PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES
@@ -113,6 +119,7 @@
 - name: store exported variables for future use
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_src }}
     for CELL in $(echo $CELLS); do

--- a/tests/roles/heat_adoption/tasks/main.yaml
+++ b/tests/roles/heat_adoption/tasks/main.yaml
@@ -1,12 +1,16 @@
 - name: Encode the heat_auth_encryption_key to base64 format
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     echo {{ heat_auth_encryption_key }} | base64
   register: heat_encoded_auth_key
 
 - name: Patch osp-secret for HeatAuthEncryptionKey
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     oc patch secret osp-secret --type='json' -p='[{"op" : "replace" ,"path" : "/data/HeatAuthEncryptionKey" ,"value" : "{{ heat_encoded_auth_key.stdout }}"}]'
 

--- a/tests/roles/keystone_adoption/tasks/main.yaml
+++ b/tests/roles/keystone_adoption/tasks/main.yaml
@@ -199,8 +199,10 @@
     - enable_federation | default(false) | bool
   block:
     - name: Generate OIDC token after adoption
+      no_log: "{{ use_no_log }}"
       ansible.builtin.shell: |
         {{ shell_header }}
+        {{ shell_header_no_xtrace }}
         {{ oc_header }}
 
         oc exec openstackclient -- bash -c "cat > /tmp/oidc_cloudrc" <<'EOF'
@@ -243,8 +245,10 @@
   failed_when: after_adoption_credential.stdout != 'test'
 
 - name: get ldap user token
+  no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
     {{ shell_header }}
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
 
     alias openstack="oc exec -t openstackclient -- openstack"

--- a/tests/roles/mariadb_copy/tasks/main.yaml
+++ b/tests/roles/mariadb_copy/tasks/main.yaml
@@ -76,6 +76,7 @@
 - name: wait until podified MariaDB is reachable
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_copy_shell_vars_dst }}
     oc rsh mariadb-copy-data mysql -rsh "${PODIFIED_MARIADB_IP['super']}" \
@@ -109,6 +110,7 @@
 - name: check that the Galera database cluster(s) members are online and synced, for all cells
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |
+    {{ shell_header_no_xtrace }}
     {{ oc_header }}
     {{ mariadb_members_env }}
     {{ mariadb_copy_shell_vars_src }}


### PR DESCRIPTION
This to avoid printing secrets into logs, as another layer of security, even though the CI environments are isolated and short-lived.

The change does the following:

* Default `use_no_log: true`.

* Add `use_no_log` onto more tasks.

* Disable xtrace (`set -x`) on such tasks as another precaution. This is done via a new `shell_header_no_xtrace` variable so that the behavior is not hardcoded.

If debugging of the relevant tasks is necessary, it can be done by tweaking these variables for a testproject.

Assisted by: goose+gemini