### PR TITLE
Add NetApp and multipath THT environment files to uni05epsilon

### DIFF
--- a/scenarios/uni05epsilon.yaml
+++ b/scenarios/uni05epsilon.yaml
@@ -63,6 +63,8 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/debug.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/external-ceph.yaml"
       - "/home/zuul/external_ceph_params.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/cinder-netapp-config.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/multipathd.yaml"
     network_data_file: "uni05epsilon/network_data.yaml.j2"
     routes: *sroutes
     vips_data_file: "uni05epsilon/vips_data_overcloud.yaml"
@@ -115,6 +117,7 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/external-ceph.yaml"
       - "/home/zuul/external_ceph_params.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/multipathd.yaml"
       - "/home/zuul/cell1-input.yaml"
     network_data_file: "uni05epsilon/network_data.yaml.j2"
     routes: *sroutes
@@ -156,6 +159,7 @@ stacks:
       - "/usr/share/openstack-tripleo-heat-templates/environments/debug.yaml"
       - "/usr/share/openstack-tripleo-heat-templates/environments/external-ceph.yaml"
       - "/home/zuul/external_ceph_params.yaml"
+      - "/usr/share/openstack-tripleo-heat-templates/environments/multipathd.yaml"
       - "/home/zuul/cell2-input.yaml"
     network_data_file: "uni05epsilon/network_data.yaml.j2"
     routes: *sroutes


### PR DESCRIPTION
## Summary
- Add `cinder-netapp-config.yaml` to the overcloud stack to enable NetApp
  backend configuration in cinder-volume
- Add `multipathd.yaml` to all stacks (overcloud, cell1, cell2) so multipath
  is properly installed and configured for iSCSI operations

Without `multipathd.yaml`, the `device-mapper-multipath` package is not
installed and `/etc/multipath.conf` is not created during TripleO 17.1
deployment. This causes container startup failures (`statfs
/etc/multipath.conf: no such file or directory`) when TripleO tries to
bind-mount this file into service containers.

This aligns with the pattern used by `uni07eta` which already includes
both environment files.

Related-Issue: #[OSPRH-32880](https://redhat.atlassian.net/browse/OSPRH-32880)

## Test plan
- [ ] Run `uni05epsilon-rhel9-rhoso18.0-adoption` pipeline via testproject
  with `Depends-On:` referencing both this PR and the corresponding
  ci-framework-jobs MR

Made with [Cursor](https://cursor.com)