### PR TITLE
Fix oidc remote cloudrc path

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -36,7 +36,7 @@ enable_federation: false
 get_oidc_token_command: >-
   ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no {{ source_osp_ssh_user }}@{{ standalone_ip | default(edpm_node_ip) }} "source {{ federation_oidc_cloudrc_remote_path }} && openstack token issue -f value -c id"
 # Path on the source node where the rendered cloudrc file should be stored.
-federation_oidc_cloudrc_remote_path: /home/{{ source_osp_ssh_user }}/ci-framework-data/tmp/{{ federation_oidc_cloudrc_filename }}
+federation_oidc_cloudrc_remote_path: /root/{{ federation_oidc_cloudrc_filename }}
 # Name of the cloudrc file rendered for OIDC authentication.
 federation_oidc_cloudrc_filename: kctestuser1
 federation_oidc_cloudrc_template: kctestuser1.j2


### PR DESCRIPTION
OIDC tests can run into issues due to the
federation_oidc_cloudrc_remote_path var, it can try to access the /home/root folder, which doesn't exist.
This patch will set federation_oidc_cloudrc_remote_path to /root/ci-framework-data/tmp/{{ federation_oidc_cloudrc_filename }}