### PR TITLE
Remove FIPS workaround

### DIFF
--- a/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-compute-services-to-the-data-plane.adoc
@@ -534,11 +534,6 @@ ifeval::["{build}" != "downstream"]
           curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
           python3 -m venv ./venv
           PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
-          # This is required for FIPS enabled until trunk.rdoproject.org
-          # is not being served from a centos7 host, tracked by
-          # https://issues.redhat.com/browse/RHOSZUUL-1517
-          sudo dnf -y install crypto-policies
-          sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
           sudo ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
           sudo dnf -y upgrade openstack-selinux
           sudo rm -f /run/virtlogd.pid

--- a/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
+++ b/docs_user/modules/proc_adopting-networker-services-to-the-data-plane.adoc
@@ -239,11 +239,6 @@ ifeval::["{build}" != "downstream"]
           curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
           python3 -m venv ./venv
           PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
-          # This is required for FIPS enabled until trunk.rdoproject.org
-          # is not being served from a centos7 host, tracked by
-          # https://issues.redhat.com/browse/RHOSZUUL-1517
-          sudo dnf -y install crypto-policies
-          sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
           sudo ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
           sudo rm -rf repo-setup-main
 endif::[]

--- a/docs_user/modules/proc_converting-object-storage-nodes.adoc
+++ b/docs_user/modules/proc_converting-object-storage-nodes.adoc
@@ -197,11 +197,6 @@ ifeval::["{build}" != "downstream"]
           curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
           python3 -m venv ./venv
           PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
-          # This is required for FIPS enabled until trunk.rdoproject.org
-          # is not being served from a centos7 host, tracked by
-          # https://issues.redhat.com/browse/RHOSZUUL-1517
-          sudo dnf -y install crypto-policies
-          sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
           sudo ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
           sudo dnf -y upgrade openstack-selinux
           sudo rm -f /run/virtlogd.pid

--- a/tests/roles/dataplane_adoption/defaults/main.yaml
+++ b/tests/roles/dataplane_adoption/defaults/main.yaml
@@ -108,11 +108,6 @@ edpm_bootstrap_command: |
   curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
   python3 -m venv ./venv
   PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
-  # This is required for FIPS enabled until trunk.rdoproject.org
-  # is not being served from a centos7 host, tracked by
-  # https://issues.redhat.com/browse/RHOSZUUL-1517
-  dnf -y install crypto-policies
-  update-crypto-policies --set FIPS:NO-ENFORCE-EMS
   ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
   {%+ if compute_adoption|bool +%}
   # Exclude ceph-common-18.2.7|8|9 as it's pulling newer openssl not compatible

--- a/tests/roles/swift_conversion/defaults/main.yaml
+++ b/tests/roles/swift_conversion/defaults/main.yaml
@@ -16,11 +16,6 @@ edpm_bootstrap_command: |
   curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
   python3 -m venv ./venv
   PBR_VERSION=0.0.0 ./venv/bin/pip install ./repo-setup-main
-  # This is required for FIPS enabled until trunk.rdoproject.org
-  # is not being served from a centos7 host, tracked by
-  # https://issues.redhat.com/browse/RHOSZUUL-1517
-  dnf -y install crypto-policies
-  update-crypto-policies --set FIPS:NO-ENFORCE-EMS
   ./venv/bin/repo-setup current-podified -b antelope -d centos9 --stream
   rm -rf repo-setup-main
 


### PR DESCRIPTION
The workaround should no longer be necessary as trunk.rdoproject.org should support TLS 1.3 now.

Reference: https://github.com/openstack-k8s-operators/install_yamls/pull/1010
Reference: https://redhat.atlassian.net/browse/RHOSZUUL-1517
Assisted-by: goose+gemini