### PR TITLE
Fix adoption order: adopt Cinder before Glance in test_with_ceph

### DIFF
--- a/tests/playbooks/test_with_ceph.yaml
+++ b/tests/playbooks/test_with_ceph.yaml
@@ -49,6 +49,9 @@
     - role: neutron_adoption
       tags:
         - neutron_adoption
+    - role: cinder_adoption
+      tags:
+        - cinder_adoption
     - role: glance_adoption
       tags:
         - glance_adoption
@@ -58,9 +61,6 @@
     - role: nova_adoption
       tags:
         - nova_adoption
-    - role: cinder_adoption
-      tags:
-        - cinder_adoption
     - role: octavia_adoption
       tags:
         - octavia_adoption


### PR DESCRIPTION
## Summary

Move `cinder_adoption` before `glance_adoption` in `test_with_ceph.yaml` to
prevent a deadlock when `glance_backend` is set to `cinder`.

## Problem

When `glance_backend` is overridden from its default `ceph` to `cinder`
(e.g. in the uni05epsilon-adoption scenario), the Glance operator detects
that Cinder is required and waits for Cinder resources to become ready
before starting Glance pods. However, in the current role ordering,
`glance_adoption` runs *before* `cinder_adoption`, causing a deadlock:
Glance waits for Cinder, but Cinder hasn't been adopted yet.

This manifests as Glance pods never starting, with the
OpenStackControlPlane CR showing:
```
GlanceAPIReady: Waiting for Cinder resources
```

## Fix

Move `cinder_adoption` before `glance_adoption`. This matches the ordering
already used in `test_minimal.yaml` and is safe because:

- Cinder depends only on Keystone and MariaDB (both already adopted)
- Cinder does **not** depend on Glance
- Glance may depend on Cinder (when `glance_backend: cinder`)

Made with [Cursor](https://cursor.com)