### PR TITLE
Preserve Ganesha VIP when stopping OpenStack services

### DIFF
--- a/docs_user/modules/proc_stopping-openstack-services.adoc
+++ b/docs_user/modules/proc_stopping-openstack-services.adoc
@@ -77,6 +77,18 @@ sudo pcs constraint remove colocation-openstack-manila-share-ceph-nfs-INFINITY
 sudo pcs constraint remove order-ceph-nfs-openstack-manila-share-Optional
 ----
 
+. If your deployment enables CephFS through NFS as a back end for {rhos_component_storage_file_first_ref}, remove the Pacemaker co-location and ordering constraints between the `ceph-nfs` Virtual IP address and `haproxy-bundle`. This ensures that the NFS-Ganesha Virtual IP remains available when HAProxy is stopped later in the adoption process, preventing NFS mount disruptions for any active NFS clients:
++
+[source,yaml]
+----
+# determine the Ganesha VIP from the NFS-Ganesha configuration
+GANESHA_VIP=$(awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' /etc/ganesha/ganesha.conf)
+
+# remove the co-location and ordering constraints between the VIP and haproxy-bundle
+sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
+sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+----
+
 . Disable {OpenStackShort} control plane services:
 +
 [source,yaml]

--- a/tests/roles/stop_openstack_services/defaults/main.yaml
+++ b/tests/roles/stop_openstack_services/defaults/main.yaml
@@ -1,3 +1,5 @@
+ganesha_default_path: "/etc/ganesha/ganesha.conf"
+
 # DCN storage nodes - list of nodes with ssh connection strings
 # Used to stop Glance/Cinder/etcd services on DCN compute nodes
 dcn_storage_nodes: []

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -24,6 +24,38 @@
         fi
     done
 
+- name: Remove colocation constraints between ceph-nfs VIP and haproxy-bundle
+  when: manila_backend | default("")  == "cephnfs"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ stop_openstack_services_shell_vars }}
+
+    GANESHA_VIP=""
+    for i in {1..3}; do
+        SSH_CMD="CONTROLLER${i}_SSH"
+        if [ ! -z "${!SSH_CMD}" ]; then
+            GANESHA_VIP=$(${!SSH_CMD} "awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, \"\", \$2); print \$2}' {{ ganesha_default_path }}")
+            break
+        fi
+    done
+
+    if [ -z "${GANESHA_VIP}" ]; then
+        echo "ERROR: Could not determine Ganesha VIP from {{ ganesha_default_path }}"
+        exit 1
+    fi
+
+    echo "Removing Pacemaker constraints between ceph-nfs VIP (ip-${GANESHA_VIP}) and haproxy-bundle"
+    for i in {1..3}; do
+        SSH_CMD="CONTROLLER${i}_SSH"
+        if [ ! -z "${!SSH_CMD}" ]; then
+            echo "Using controller $i to run pacemaker commands"
+            ${!SSH_CMD} sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
+            ${!SSH_CMD} sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+            break
+        fi
+    done
+
 - name: stop control plane services
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |


### PR DESCRIPTION
## Summary

- Remove ceph-nfs VIP colocation/ordering constraints with haproxy-bundle in `stop_openstack_services`, before haproxy is later disabled by `stop_remaining_services`
- Without this fix, Pacemaker kills the Ganesha VIP when haproxy-bundle is disabled, causing NFS hard mount D-state cascade and tripleo-cleanup timeout on networker nodes (~94 min hang vs 30 min limit)
- Updates both test role and docs procedure to maintain parity

Closes: [OSPRH-31796](https://redhat.atlassian.net/browse/OSPRH-31796)

## Root cause

The Ganesha VIP (e.g. `ip-10.0.0.155`) has dual INFINITY colocation constraints: one with `ceph-nfs` and one with `haproxy-bundle`. NFS-Ganesha binds directly to this VIP (`Bind_Addr` in `ganesha.conf`) — haproxy is not in the NFS data path. When `stop_remaining_services` disables `haproxy-bundle`, Pacemaker can no longer satisfy the colocation and stops the VIP. The `ceph-nfs` resource stays running, but with no VIP, existing NFS hard mounts enter D-state (uninterruptible sleep). The subsequent `tripleo-cleanup` on the networker node hangs for ~94 minutes waiting on these D-state processes, exceeding the 30-minute timeout.

## Fix

Remove the `colocation-ip-<VIP>-haproxy-bundle-INFINITY` and `order-ip-<VIP>-haproxy-bundle-Optional` constraints during `stop_openstack_services` (alongside the existing `manila-share ↔ ceph-nfs` constraint removal). The VIP then stays alive anchored to `ceph-nfs` alone.