### PR TITLE
Preserve Ganesha VIP when stopping OpenStack services

### DIFF
--- a/docs_user/modules/proc_stopping-openstack-services.adoc
+++ b/docs_user/modules/proc_stopping-openstack-services.adoc
@@ -77,6 +77,18 @@ sudo pcs constraint remove colocation-openstack-manila-share-ceph-nfs-INFINITY
 sudo pcs constraint remove order-ceph-nfs-openstack-manila-share-Optional
 ----
 
+. If your deployment enables CephFS through NFS as a back end for {rhos_component_storage_file_first_ref}, remove the Pacemaker co-location and ordering constraints between the `ceph-nfs` Virtual IP address and `haproxy-bundle`. This ensures that the NFS-Ganesha Virtual IP remains available when HAProxy is stopped later in the adoption process, preventing NFS mount disruptions for any active NFS clients:
++
+[source,yaml]
+----
+# determine the Ganesha VIP from the NFS-Ganesha configuration
+GANESHA_VIP=$(awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' /etc/ganesha/ganesha.conf)
+
+# remove the co-location and ordering constraints between the VIP and haproxy-bundle
+sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
+sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+----
+
 . Disable {OpenStackShort} control plane services:
 +
 [source,yaml]

--- a/docs_user/modules/proc_stopping-openstack-services.adoc
+++ b/docs_user/modules/proc_stopping-openstack-services.adoc
@@ -84,9 +84,14 @@ sudo pcs constraint remove order-ceph-nfs-openstack-manila-share-Optional
 # determine the Ganesha VIP from the NFS-Ganesha configuration
 GANESHA_VIP=$(awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' /etc/ganesha/ganesha.conf)
 
-# remove the co-location and ordering constraints between the VIP and haproxy-bundle
-sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
-sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+# Pacemaker replaces colons with dots in IPv6 resource names
+GANESHA_VIP_PCS=$(echo "${GANESHA_VIP}" | tr ':' '.')
+
+# query and remove constraints between the VIP and haproxy-bundle
+for constraint_id in $(sudo pcs constraint --full | grep -F "ip-${GANESHA_VIP_PCS}" | grep "haproxy-bundle" | grep -o '(id:[^)]*)' | sed 's/(id://;s/)//'); do
+    echo "Removing constraint: ${constraint_id}"
+    sudo pcs constraint remove "${constraint_id}"
+done
 ----
 
 . Disable {OpenStackShort} control plane services:

--- a/tests/roles/stop_openstack_services/defaults/main.yaml
+++ b/tests/roles/stop_openstack_services/defaults/main.yaml
@@ -1,3 +1,5 @@
+ganesha_default_path: "/etc/ganesha/ganesha.conf"
+
 # DCN storage nodes - list of nodes with ssh connection strings
 # Used to stop Glance/Cinder/etcd services on DCN compute nodes
 dcn_storage_nodes: []

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -24,6 +24,38 @@
         fi
     done
 
+- name: Remove colocation constraints between ceph-nfs VIP and haproxy-bundle
+  when: manila_backend | default("")  == "cephnfs"
+  ansible.builtin.shell: |
+    {{ shell_header }}
+    {{ oc_header }}
+    {{ stop_openstack_services_shell_vars }}
+
+    GANESHA_VIP=""
+    for i in {1..3}; do
+        SSH_CMD="CONTROLLER${i}_SSH"
+        if [ ! -z "${!SSH_CMD}" ]; then
+            GANESHA_VIP=$(${!SSH_CMD} "awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, \"\", \$2); print \$2}' {{ ganesha_default_path }}")
+            break
+        fi
+    done
+
+    if [ -z "${GANESHA_VIP}" ]; then
+        echo "ERROR: Could not determine Ganesha VIP from {{ ganesha_default_path }}"
+        exit 1
+    fi
+
+    echo "Removing Pacemaker constraints between ceph-nfs VIP (ip-${GANESHA_VIP}) and haproxy-bundle"
+    for i in {1..3}; do
+        SSH_CMD="CONTROLLER${i}_SSH"
+        if [ ! -z "${!SSH_CMD}" ]; then
+            echo "Using controller $i to run pacemaker commands"
+            ${!SSH_CMD} sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
+            ${!SSH_CMD} sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+            break
+        fi
+    done
+
 - name: stop control plane services
   no_log: "{{ use_no_log }}"
   ansible.builtin.shell: |

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -45,13 +45,22 @@
         exit 1
     fi
 
-    echo "Removing Pacemaker constraints between ceph-nfs VIP (ip-${GANESHA_VIP}) and haproxy-bundle"
+    GANESHA_VIP_PCS=$(echo "${GANESHA_VIP}" | tr ':' '.')
+
+    echo "Removing Pacemaker constraints between ceph-nfs VIP (ip-${GANESHA_VIP_PCS}) and haproxy-bundle"
     for i in {1..3}; do
         SSH_CMD="CONTROLLER${i}_SSH"
         if [ ! -z "${!SSH_CMD}" ]; then
             echo "Using controller $i to run pacemaker commands"
-            ${!SSH_CMD} sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
-            ${!SSH_CMD} sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+            CONSTRAINT_IDS=$(${!SSH_CMD} sudo pcs constraint --full | grep -F "ip-${GANESHA_VIP_PCS}" | grep "haproxy-bundle" | grep -o '(id:[^)]*)' | sed 's/(id://;s/)//')
+            if [ -z "${CONSTRAINT_IDS}" ]; then
+                echo "WARNING: No constraints found between ip-${GANESHA_VIP_PCS} and haproxy-bundle"
+            else
+                for constraint_id in ${CONSTRAINT_IDS}; do
+                    echo "Removing constraint: ${constraint_id}"
+                    ${!SSH_CMD} sudo pcs constraint remove "${constraint_id}"
+                done
+            fi
             break
         fi
     done


### PR DESCRIPTION
Cherry-pick of #1466 to 18-stable.

Remove ceph-nfs VIP colocation/ordering constraints with haproxy-bundle in `stop_openstack_services`, before haproxy is later disabled by `stop_remaining_services`. Without this fix, Pacemaker kills the Ganesha VIP when haproxy-bundle is disabled, causing NFS hard mount D-state cascade and tripleo-cleanup timeout on networker nodes.

Closes: [OSPRH-31796](https://redhat.atlassian.net/browse/OSPRH-31796)