### PR TITLE
Fix Ganesha VIP constraint removal for IPv6 deployments

### DIFF
--- a/docs_user/modules/proc_stopping-openstack-services.adoc
+++ b/docs_user/modules/proc_stopping-openstack-services.adoc
@@ -84,9 +84,14 @@ sudo pcs constraint remove order-ceph-nfs-openstack-manila-share-Optional
 # determine the Ganesha VIP from the NFS-Ganesha configuration
 GANESHA_VIP=$(awk -F '[=;]' '/Bind_Addr/ {gsub(/ /, "", $2); print $2}' /etc/ganesha/ganesha.conf)
 
-# remove the co-location and ordering constraints between the VIP and haproxy-bundle
-sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
-sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+# Pacemaker replaces colons with dots in IPv6 resource names
+GANESHA_VIP_PCS=$(echo "${GANESHA_VIP}" | tr ':' '.')
+
+# query and remove constraints between the VIP and haproxy-bundle
+for constraint_id in $(sudo pcs constraint --full | grep -F "ip-${GANESHA_VIP_PCS}" | grep "haproxy-bundle" | grep -o '(id:[^)]*)' | sed 's/(id://;s/)//'); do
+    echo "Removing constraint: ${constraint_id}"
+    sudo pcs constraint remove "${constraint_id}"
+done
 ----
 
 . Disable {OpenStackShort} control plane services:

--- a/tests/roles/stop_openstack_services/tasks/main.yaml
+++ b/tests/roles/stop_openstack_services/tasks/main.yaml
@@ -45,13 +45,22 @@
         exit 1
     fi
 
-    echo "Removing Pacemaker constraints between ceph-nfs VIP (ip-${GANESHA_VIP}) and haproxy-bundle"
+    GANESHA_VIP_PCS=$(echo "${GANESHA_VIP}" | tr ':' '.')
+
+    echo "Removing Pacemaker constraints between ceph-nfs VIP (ip-${GANESHA_VIP_PCS}) and haproxy-bundle"
     for i in {1..3}; do
         SSH_CMD="CONTROLLER${i}_SSH"
         if [ ! -z "${!SSH_CMD}" ]; then
             echo "Using controller $i to run pacemaker commands"
-            ${!SSH_CMD} sudo pcs constraint remove colocation-ip-${GANESHA_VIP}-haproxy-bundle-INFINITY
-            ${!SSH_CMD} sudo pcs constraint remove order-ip-${GANESHA_VIP}-haproxy-bundle-Optional
+            CONSTRAINT_IDS=$(${!SSH_CMD} sudo pcs constraint --full | grep -F "ip-${GANESHA_VIP_PCS}" | grep "haproxy-bundle" | grep -o '(id:[^)]*)' | sed 's/(id://;s/)//')
+            if [ -z "${CONSTRAINT_IDS}" ]; then
+                echo "WARNING: No constraints found between ip-${GANESHA_VIP_PCS} and haproxy-bundle"
+            else
+                for constraint_id in ${CONSTRAINT_IDS}; do
+                    echo "Removing constraint: ${constraint_id}"
+                    ${!SSH_CMD} sudo pcs constraint remove "${constraint_id}"
+                done
+            fi
             break
         fi
     done


### PR DESCRIPTION
Look up Pacemaker constraint IDs dynamically from
`pcs constraint --full` output instead of constructing them from the VIP address.
The previous approach broke on IPv6 because colons in the address produced
constraint IDs that pcs could not find ([OSPRH-31796](https://redhat.atlassian.net/browse/OSPRH-31796)).