### PR TITLE
Fix oidc remote cloudrc path

### DIFF
--- a/tests/roles/development_environment/defaults/main.yaml
+++ b/tests/roles/development_environment/defaults/main.yaml
@@ -36,15 +36,17 @@ enable_federation: false
 get_oidc_token_command: >-
   ssh -i {{ edpm_privatekey_path }} -o StrictHostKeyChecking=no {{ source_osp_ssh_user }}@{{ standalone_ip | default(edpm_node_ip) }} "source {{ federation_oidc_cloudrc_remote_path }} && openstack token issue -f value -c id"
 # Path on the source node where the rendered cloudrc file should be stored.
-federation_oidc_cloudrc_remote_path: /home/{{ source_osp_ssh_user }}/ci-framework-data/tmp/{{ federation_oidc_cloudrc_filename }}
+federation_oidc_cloudrc_remote_path: /root/{{ federation_oidc_cloudrc_filename }}
 # Name of the cloudrc file rendered for OIDC authentication.
 federation_oidc_cloudrc_filename: kctestuser1
 federation_oidc_cloudrc_template: kctestuser1.j2
 # Location of the ingress operator CA used to seed the Keycloak trust bundle.
 federation_ingress_ca_path: ~/ci-framework-data/tmp/ingress-operator-ca.crt
+# Location on the standalone node where the ingress operator CA is copied to.
+federation_oidc_ca_remote_path: /root/ingress-operator-ca.crt
 
 # Federation defaults aligned with ci-framework
-cifmw_federation_keycloak_url: https://keycloak-openstack.apps-crc.testing
+cifmw_federation_keycloak_url: https://keycloak-{{ cifmw_federation_keycloak_namespace | default('cert-manager') }}.apps-crc.testing
 cifmw_federation_keystone_url: https://keystone-public-openstack.apps-crc.testing
 cifmw_federation_horizon_url: https://horizon-openstack.apps-crc.testing
 cifmw_federation_keycloak_realm: openstack

--- a/tests/roles/development_environment/tasks/main.yaml
+++ b/tests/roles/development_environment/tasks/main.yaml
@@ -75,6 +75,13 @@
       {{ openstack_command }} token issue -f value -c id
   register: before_adoption_token
 
+- name: Upload TLS CA certificate bundle to standalone
+  when: enable_federation | default(false) | bool
+  ansible.builtin.shell:
+    cmd: |
+      {{ shell_header }}
+      scp -o StrictHostKeyChecking=no -i {{ edpm_privatekey_path }} {{ federation_ingress_ca_path }} {{ source_osp_ssh_user }}@{{ standalone_ip | default(edpm_node_ip) }}:{{ federation_oidc_ca_remote_path }}
+
 - name: Render OIDC cloudrc
   when: enable_federation | default(false) | bool
   ansible.builtin.template:
@@ -98,6 +105,9 @@
       {{ shell_header }}
       {{ get_oidc_token_command }}
   register: before_adoption_oidc_token
+  retries: 5
+  delay: 15
+  until before_adoption_oidc_token.rc == 0
 
 - name: Create credential for sanity checking its value after adoption
   no_log: "{{ use_no_log }}"

--- a/tests/roles/development_environment/templates/kctestuser1.j2
+++ b/tests/roles/development_environment/templates/kctestuser1.j2
@@ -1,5 +1,5 @@
 unset OS_CLOUD
-export OS_CACERT=/home/cloud-admin/full-ca-list.crt
+export OS_CACERT={{ federation_oidc_ca_remote_path }}
 export OS_PROJECT_NAME="{{ cifmw_federation_project_name }}"
 export OS_PROJECT_DOMAIN_NAME="{{ cifmw_federation_domain }}"
 export OS_AUTH_URL="{{ cifmw_federation_keystone_url }}/v3"


### PR DESCRIPTION
OIDC tests can run into issues due to the
federation_oidc_cloudrc_remote_path var, it can try to access the /home/root folder, which doesn't exist.
This patch will set federation_oidc_cloudrc_remote_path to /root/ci-framework-data/tmp/{{ federation_oidc_cloudrc_filename }}