### PR TITLE
[BGP] Apply overcloud temporary default routes at pre_oc_run

### DIFF
--- a/scenarios/bgp-l3-xl.yaml
+++ b/scenarios/bgp-l3-xl.yaml
@@ -168,6 +168,10 @@ stacks:
       - osp-r0-controllers
       - osp-r1-controllers
       - osp-r2-controllers
+    pre_oc_run:
+      - name: "01 Add default route to OC nodes before OC deploy"
+        type: playbook
+        source: "adoption_bgp_pre_overcloud.yaml"
 pre_uc_run:
   - name: "01 Deploy BGP fabric"
     type: playbook

--- a/tests/roles/dataplane_adoption/tasks/main.yaml
+++ b/tests/roles/dataplane_adoption/tasks/main.yaml
@@ -847,7 +847,7 @@
   when: bgp
   ansible.builtin.shell: |
     {{ shell_header }}
-    ssh -o StrictHostKeyChecking=accept-new -i {{ edpm_privatekey_path }} root@{{ item.key }} 'bash -s' << 'EOF'
+    ssh -o StrictHostKeyChecking=accept-new -i {{ edpm_privatekey_path }} root@{{ item.key }}.utility 'bash -s' << 'EOF'
     cp /etc/os-net-config/tripleo_config.yaml /etc/os-net-config/tripleo_config.yaml.bak
     awk 'BEGIN { first_done=0; skip=0 }
     /^network_config:/ { print; next }


### PR DESCRIPTION
Apply temporary default routes to overcloud nodes right before overcloud
deployment runs.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4105